### PR TITLE
Reduced circled readings to single zin

### DIFF
--- a/ekho-data/zh_list
+++ b/ekho-data/zh_list
@@ -63,6 +63,7 @@ $textmode
 峨	e2
 鹿	lu4
 上	shang4
+㊤	shang4
 枯	ku1
 鬧	nao4
 克	ke4
@@ -166,6 +167,7 @@ $textmode
 賓	bin1
 坚	jian1
 五	wu3
+㊄	wu3
 單	dan1
 属	shu3
 惡	e4
@@ -173,6 +175,7 @@ $textmode
 檻	kan3
 嗅	xiu4
 日	ri4
+㊐	ri4
 详	xiang2
 職	zhi2
 廉	lian2
@@ -282,6 +285,7 @@ $textmode
 许	xu3
 虑	lv4
 正	zheng4
+㊣	zheng4
 偵	zhen1
 随	sui2
 珍	zhen1
@@ -363,6 +367,7 @@ $textmode
 痕	hen2
 工	gong1
 七	qi1
+㊆	qi1
 碌	lu4
 章	zhang1
 较	jiao4
@@ -387,6 +392,7 @@ $textmode
 转	zhuan3
 衙	ya2
 適	shi4
+㊜	shi4
 白	bai2
 享	xiang3
 燕	yan4
@@ -414,6 +420,7 @@ $textmode
 雄	xiong2
 幟	zhi4
 注	zhu4
+㊟	zhu4
 问	wen4
 质	zhi4
 个	ge4
@@ -675,6 +682,7 @@ $textmode
 糟	zao1
 輩	bei4
 十	shi2
+㊉	shi2
 狀	zhuang4
 嗚	wu1
 捡	jian3
@@ -826,6 +834,7 @@ $textmode
 辜	gu1
 蝗	huang2
 九	jiu3
+㊈	jiu3
 脚	jiao3
 洲	zhou1
 烏	wu1
@@ -1165,6 +1174,7 @@ $textmode
 乓	pang1
 跪	gui4
 六	liu4
+㊅	liu4
 犁	li2
 锄	chu2
 隙	xi4
@@ -1263,6 +1273,7 @@ $textmode
 吆	yao1
 炉	lu2
 財	cai2
+㊖	cai2
 仍	reng2
 婚	hun1
 均	jun1
@@ -1303,6 +1314,7 @@ $textmode
 🈞	zai4
 碧	bi4
 水	shui3
+㊌	shui3
 傷	shang1
 饒	rao2
 莖	jing1
@@ -1391,6 +1403,7 @@ $textmode
 締	di4
 記	ji4
 優	you1
+㊝	you1
 濁	zhuo2
 捞	lao1
 豬	zhu1
@@ -1423,6 +1436,7 @@ $textmode
 沾	zhan1
 返	fan3
 南	nan2
+🀁	nan2
 胶	jiao1
 鎖	suo3
 漩	xuan2
@@ -1596,6 +1610,7 @@ $textmode
 招	zhao1
 器	qi4
 有	you3
+㊒	you3
 🈶	you3
 冒	mao4
 另	ling4
@@ -1649,9 +1664,11 @@ $textmode
 郁	yu4
 歼	jian1
 北	bei3
+🀃	bei3
 屉	ti4
 槐	huai2
 八	ba1
+㊇	ba1
 各	ge4
 箱	xiang1
 蘸	zhan4
@@ -1660,12 +1677,14 @@ $textmode
 催	cui1
 取	qu3
 祝	zhu4
+㊗	zhu4
 匀	yun2
 适	shi4
 試	shi4
 读	du2
 擺	bai3
 写	xie3
+㊢	xie3
 副	fu4
 腹	fu4
 铁	tie3
@@ -1784,6 +1803,7 @@ $textmode
 據	ju4
 哺	bu3
 东	dong1
+🀀	dong1
 违	wei2
 殊	shu1
 氛	fen1
@@ -1812,6 +1832,7 @@ $textmode
 陶	tao2
 狹	xia2
 名	ming2
+㊔	ming2
 度	du4
 踱	duo2
 惚	hu1
@@ -1976,6 +1997,7 @@ $textmode
 挾	xie2
 滋	zi1
 四	si4
+㊃	si4
 樣	yang4
 蔽	bi4
 撼	han4
@@ -2162,6 +2184,7 @@ $textmode
 闭	bi4
 勘	kan1
 株	zhu1
+㊑	zhu1
 唬	hu1
 敌	di2
 则	ze2
@@ -2180,6 +2203,7 @@ $textmode
 执	zhi2
 共	gong4
 宗	zong1
+㊪	zong1
 糙	cao1
 桶	tong3
 漏	lou4
@@ -2202,6 +2226,7 @@ $textmode
 咛	ning2
 脾	pi2
 二	er4
+㊁	er4
 🈔	er4
 🉂	er4
 朽	xiu3
@@ -2227,6 +2252,7 @@ $textmode
 镜	jing4
 满	man3
 右	you4
+㊨	you4
 🈮	you4
 找	zhao3
 往	wang3
@@ -2328,6 +2354,7 @@ $textmode
 瞧	qiao2
 德	de2
 協	xie2
+㊯	xie2
 韧	ren4
 簡	jian3
 钦	qin1
@@ -2453,13 +2480,16 @@ $textmode
 牵	qian1
 厉	li4
 劳	lao2
+㊘	lao2
 陰	yin1
 下	xia4
+㊦	xia4
 悔	hui3
 飄	piao1
 拨	bo1
 熟	shu2
 項	xiang4
+㊠	xiang4
 唇	chun2
 析	xi1
 耕	geng1
@@ -2521,6 +2551,7 @@ $textmode
 末	mo4
 见	jian4
 金	jin1
+㊎	jin1
 检	jian3
 粹	cui4
 恆	heng2
@@ -2560,6 +2591,7 @@ $textmode
 森	sen1
 葱	cong1
 一	yi1
+㊀	yi1
 🈩	yi1
 谬	miu4
 夺	duo2
@@ -2739,6 +2771,7 @@ $textmode
 裝	zhuang1
 泵	beng4
 三	san1
+㊂	san1
 🈪	san1
 🉁	san1
 鼓	gu3
@@ -2809,6 +2842,7 @@ $textmode
 炒	chao3
 膜	mo2
 医	yi1
+㊩	yi1
 黎	li2
 龍	long2
 渗	shen4
@@ -2840,6 +2874,7 @@ $textmode
 貨	huo4
 碰	peng4
 火	huo3
+㊋	huo3
 邁	mai4
 宇	yu3
 演	yan3
@@ -2860,6 +2895,7 @@ $textmode
 繳	jiao3
 鳴	ming2
 夜	ye4
+㊰	ye4
 抡	lun1
 渾	hun2
 笛	di2
@@ -2920,6 +2956,7 @@ $textmode
 乎	hu1
 染	ran3
 印	yin4
+㊞	yin4
 豺	chai2
 蜓	ting2
 猛	meng3
@@ -2982,6 +3019,7 @@ $textmode
 舀	yao3
 灌	guan4
 学	xue2
+㊫	xue2
 诱	you4
 标	biao1
 隸	li4
@@ -3018,6 +3056,7 @@ $textmode
 姨	yi2
 產	chan3
 資	zi1
+㊮	zi1
 篩	shai1
 蠟	la4
 詳	xiang2
@@ -3149,6 +3188,7 @@ $textmode
 綜	zong1
 雖	sui1
 西	xi1
+🀂	xi1
 缚	fu4
 未	wei4
 嘴	zui3
@@ -3264,6 +3304,7 @@ $textmode
 浇	jiao1
 零	ling2
 特	te4
+㊕	te4
 会	hui4
 犧	xi1
 敞	chang3
@@ -3304,6 +3345,8 @@ $textmode
 谁	shui2
 室	shi4
 中	zhong1
+🀄	zhong1
+㊥	zhong1
 🈭	zhong1
 悟	wu4
 揉	rou2
@@ -3424,6 +3467,7 @@ $textmode
 席	xi2
 哆	duo1
 秘	mi4
+㊙	mi4
 攒	zan3
 餅	bing3
 闲	xian2
@@ -3447,6 +3491,7 @@ $textmode
 重	zhong4
 廓	kuo4
 監	jian1
+㊬	jian1
 鵪	an1
 持	chi2
 笑	xiao4
@@ -3471,6 +3516,7 @@ $textmode
 徒	tu2
 輝	hui1
 左	zuo3
+㊧	zuo3
 🈬	zuo3
 串	chuan4
 時	shi2
@@ -3491,6 +3537,7 @@ $textmode
 敬	jing4
 龐	pang2
 男	nan2
+㊚	nan2
 穩	wen3
 彻	che4
 唾	tuo4
@@ -3590,6 +3637,7 @@ $textmode
 療	liao2
 矗	chu4
 女	nv3
+㊛	nv3
 勃	bo2
 藍	lan2
 拣	jian3
@@ -3612,6 +3660,7 @@ $textmode
 舒	shu1
 扒	ba1
 土	tu3
+㊏	tu3
 悦	yue4
 躺	tang3
 廚	chu2
@@ -3627,6 +3676,7 @@ $textmode
 残	can2
 缘	yuan2
 木	mu4
+㊍	mu4
 兜	dou1
 音	yin1
 于	yu2
@@ -3696,6 +3746,7 @@ $textmode
 亞	ya4
 判	pan4
 社	she4
+㊓	she4
 考	kao3
 頓	dun4
 攀	pan1
@@ -3747,6 +3798,7 @@ $textmode
 浅	qian3
 修	xiu1
 月	yue4
+㊊	yue4
 🈷	yue4
 优	you1
 在	zai4
@@ -3773,6 +3825,7 @@ $textmode
 藝	yi4
 饺	jiao3
 企	qi3
+㊭	qi3
 颤	chan4
 丫	ya1
 嘻	xi1
@@ -3827,6 +3880,7 @@ $textmode
 匯	hui4
 蘋	ping2
 休	xiu1
+㊡	xiu1
 縛	fu4
 肤	fu1
 主	zhu3

--- a/ekho-data/zh_listx
+++ b/ekho-data/zh_listx
@@ -21784,862 +21784,430 @@ $textmode
 鶴	he4
 (+ 橫)	yi1heng2
 (一 万)	yi2wan4
-(㊀ 万)	yi2wan4
 (一 下)	yi2xia4
-(一 ㊦)	yi2xia4
-(㊀ 下)	yi2xia4
 (一 世)	yi2shi4
-(㊀ 世)	yi2shi4
 (一 两)	yi4liang3
-(㊀ 两)	yi4liang3
 (一 个)	yi2ge5
-(㊀ 个)	yi2ge5
 (一 串)	yi2chuan4
-(㊀ 串)	yi2chuan4
 (一 串)	yi2chuan4
-(㊀ 串)	yi2chuan4
 (一 举)	yi4ju3
-(㊀ 举)	yi4ju3
 (一 义)	yi2yi4
-(㊀ 义)	yi2yi4
 (一 了)	yi4liao3
-(㊀ 了)	yi4liao3
 (一 了)	yi4liao3
-(㊀ 了)	yi4liao3
 (一 亇)	yi2ge4
-(㊀ 亇)	yi2ge4
 (一 事)	yi2shi4
-(㊀ 事)	yi2shi4
 (一 些)	yi4xie1
-(㊀ 些)	yi4xie1
 (一 亩)	yi4mu3
-(㊀ 亩)	yi4mu3
 (一 人)	yi4ren2
-(㊀ 人)	yi4ren2
 (一 亿)	yi2yi4
-(㊀ 亿)	yi2yi4
 (一 仍)	yi4reng2
-(㊀ 仍)	yi4reng2
 (一 从)	yi4cong2
-(㊀ 从)	yi4cong2
 (一 代)	yi2dai4
-(㊀ 代)	yi2dai4
 (一 件)	yi2jian4
-(㊀ 件)	yi2jian4
 (一 任)	yi2ren4
-(㊀ 任)	yi2ren4
 (一 份)	yi2fen4
-(㊀ 份)	yi2fen4
 (一 伙)	yi4huo3
-(㊀ 伙)	yi4huo3
 (一 会)	yi2hui4
-(㊀ 会)	yi2hui4
 (一 似)	yi2si4
-(㊀ 似)	yi2si4
 (一 位)	yi2wei4
-(㊀ 位)	yi2wei4
 (一 体)	yi4ti3
-(㊀ 体)	yi4ti3
 (一 何)	yi4he2
-(㊀ 何)	yi4he2
 (一 併)	yi2bing4
-(㊀ 併)	yi2bing4
 (一 來)	yi4lai2
-(㊀ 來)	yi4lai2
 (一 來)	yi4lai2
-(㊀ 來)	yi4lai2
 (一 例)	yi2li4
-(㊀ 例)	yi2li4
 (一 例)	yi2li4
-(㊀ 例)	yi2li4
 (一 個)	yi2ge5
-(㊀ 個)	yi2ge5
 (一 偏)	yi4pian1
-(㊀ 偏)	yi4pian1
 (一 億)	yi2yi4
-(㊀ 億)	yi2yi4
 (一 元)	yi4yuan2
-(㊀ 元)	yi4yuan2
 (一 党)	yi4dang3
-(㊀ 党)	yi4dang3
 (一 兩)	yi4liang3
-(㊀ 兩)	yi4liang3
 (一 兩)	yi4liang3
-(㊀ 兩)	yi4liang3
 (一 共)	yi2gong4
-(㊀ 共)	yi2gong4
 (一 具)	yi2ju4
-(㊀ 具)	yi2ju4
 (一 冊)	yi2ce4
-(㊀ 冊)	yi2ce4
 (一 册)	yi2ce4
-(㊀ 册)	yi2ce4
 (一 再)	yi2zai4
-(㊀ 再)	yi2zai4
 (一 冬)	yi4dong1
-(㊀ 冬)	yi4dong1
 (一 准)	yi4zhun3
-(㊀ 准)	yi4zhun3
 (一 出)	yi4chu1
-(㊀ 出)	yi4chu1
 (一 击)	yi4ji1
-(㊀ 击)	yi4ji1
 (一 切)	yi2qie4
-(㊀ 切)	yi2qie4
 (一 切)	yi2qie4
-(㊀ 切)	yi2qie4
 (一 则)	yi4ze2
-(㊀ 则)	yi4ze2
 (一 刬)	yi2chan4
-(㊀ 刬)	yi2chan4
 (一 刹)	yi2cha4
-(㊀ 刹)	yi2cha4
 (一 刻)	yi2ke4
-(㊀ 刻)	yi2ke4
 (一 則)	yi4ze2
-(㊀ 則)	yi4ze2
 (一 剎)	yi2cha4
-(㊀ 剎)	yi2cha4
 (一 剗)	yi2chan4
-(㊀ 剗)	yi2chan4
 (一 副)	yi2fu4
-(㊀ 副)	yi2fu4
 (一 力)	yi2li4
-(㊀ 力)	yi2li4
 (一 力)	yi2li4
-(㊀ 力)	yi2li4
 (一 动)	yi2dong4
-(㊀ 动)	yi2dong4
 (一 動)	yi2dong4
-(㊀ 動)	yi2dong4
 (一 包)	yi4bao1
-(㊀ 包)	yi4bao1
 (一 匙)	yi4chi2
-(㊀ 匙)	yi4chi2
 (一 匹)	yi4pi3
-(㊀ 匹)	yi4pi3
 (一 十)	yi4shi2
-(一 ㊉)	yi4shi2
-(㊀ 十)	yi4shi2
 (一 千)	yi4qian1
-(㊀ 千)	yi4qian1
 (一 半)	yi2ban4
-(㊀ 半)	yi2ban4
 (一 双)	yi4shuang1
-(㊀ 双)	yi4shuang1
 (一 反)	yi4fan3
-(㊀ 反)	yi4fan3
 (一 发)	yi4fa1
-(㊀ 发)	yi4fa1
 (一 口)	yi4kou3
-(㊀ 口)	yi4kou3
 (一 句)	yi2ju4
-(㊀ 句)	yi2ju4
 (一 句)	yi2ju4
-(㊀ 句)	yi2ju4
 (一 只)	yi4zhi1
-(㊀ 只)	yi4zhi1
 (一 台)	yi4tai2
-(㊀ 台)	yi4tai2
 (一 号)	yi2hao4
-(㊀ 号)	yi2hao4
 (一 同)	yi4tong2
-(㊀ 同)	yi4tong2
 (一 名)	yi4ming2
-(㊀ 名)	yi4ming2
-(一 ㊔)	yi4ming2
 (一 向)	yi2xiang4
-(㊀ 向)	yi2xiang4
 (一 听)	yi4ting1
-(㊀ 听)	yi4ting1
 (一 吹)	yi4chui1
-(㊀ 吹)	yi4chui1
 (一 吾)	yi4wu2
-(㊀ 吾)	yi4wu2
 (一 员)	yi4yuan2
-(㊀ 员)	yi4yuan2
 (一 周)	yi4zhou1
-(㊀ 周)	yi4zhou1
 (一 味)	yi2wei4
-(㊀ 味)	yi2wei4
 (一 命)	yi2ming4
-(㊀ 命)	yi2ming4
 (一 品)	yi4pin3
-(㊀ 品)	yi4pin3
 (一 响)	yi4xiang3
-(㊀ 响)	yi4xiang3
 (一 員)	yi4yuan2
-(㊀ 員)	yi4yuan2
 (一 哪)	yi4nei3
-(㊀ 哪)	yi4nei3
 (一 嘴)	yi4zui3
-(㊀ 嘴)	yi4zui3
 (一 回)	yi4hui2
-(㊀ 回)	yi4hui2
 (一 团)	yi4tuan2
-(㊀ 团)	yi4tuan2
 (一 圈)	yi4quan1
-(㊀ 圈)	yi4quan1
 (一 團)	yi4tuan2
-(㊀ 團)	yi4tuan2
 (一 场)	yi4chang2
-(㊀ 场)	yi4chang2
 (一 块)	yi2kuai4
-(㊀ 块)	yi2kuai4
 (一 垒)	yi4lei3
-(㊀ 垒)	yi4lei3
 (一 堂)	yi4tang2
-(㊀ 堂)	yi4tang2
 (一 堆)	yi4dui1
-(㊀ 堆)	yi4dui1
 (一 場)	yi4chang2
-(㊀ 場)	yi4chang2
 (一 堵)	yi4du3
-(㊀ 堵)	yi4du3
 (一 塊)	yi2kuai4
-(㊀ 塊)	yi2kuai4
 (一 壁)	yi2bi4
-(㊀ 壁)	yi2bi4
 (一 壘)	yi4lei3
-(㊀ 壘)	yi4lei3
 (一 壘)	yi4lei3
-(㊀ 壘)	yi4lei3
 (一 声)	yi4sheng1
-(㊀ 声)	yi4sheng1
 (一 壶)	yi4hu2
-(㊀ 壶)	yi4hu2
 (一 壺)	yi4hu2
-(㊀ 壺)	yi4hu2
 (一 处)	yi2chu4
-(㊀ 处)	yi2chu4
 (一 夏)	yi2xia4
-(㊀ 夏)	yi2xia4
 (一 天)	yi4tian1
-(㊀ 天)	yi4tian1
 (一 夫)	yi4fu1
-(㊀ 夫)	yi4fu1
 (一 头)	yi4tou2
-(㊀ 头)	yi4tou2
 (一 套)	yi2tao4
-(㊀ 套)	yi2tao4
 (一 如)	yi4ru2
-(㊀ 如)	yi4ru2
 (一 字)	yi2zi4
-(㊀ 字)	yi2zi4
 (一 宗)	yi4zong1
-(一 ㊪)	yi4zong1
-(㊀ 宗)	yi4zong1
 (一 定)	yi2ding4
-(㊀ 定)	yi2ding4
 (一 审)	yi4shen3
-(㊀ 审)	yi4shen3
 (一 家)	yi4jia1
-(㊀ 家)	yi4jia1
 (一 宿)	yi4xiu3
-(㊀ 宿)	yi4xiu3
 (一 審)	yi4shen3
-(㊀ 審)	yi4shen3
 (一 对)	yi2dui4
-(㊀ 对)	yi2dui4
 (一 封)	yi4feng1
-(㊀ 封)	yi4feng1
 (一 尊)	yi4zun1
-(㊀ 尊)	yi4zun1
 (一 對)	yi2dui4
-(㊀ 對)	yi2dui4
 (一 小)	yi4xiao3
-(㊀ 小)	yi4xiao3
 (一 局)	yi4ju2
-(㊀ 局)	yi4ju2
 (一 层)	yi4ceng2
-(㊀ 层)	yi4ceng2
 (一 屆)	yi2jie4
-(㊀ 屆)	yi2jie4
 (一 届)	yi2jie4
-(㊀ 届)	yi2jie4
 (一 層)	yi4ceng2
-(㊀ 層)	yi4ceng2
 (一 層)	yi4ceng2
-(㊀ 層)	yi4ceng2
 (一 岁)	yi2sui4
-(㊀ 岁)	yi2sui4
 (一 工)	yi4gong1
-(㊀ 工)	yi4gong1
 (一 己)	yi4ji3
-(㊀ 己)	yi4ji3
 (一 带)	yi2dai4
-(㊀ 带)	yi2dai4
 (一 帶)	yi2dai4
-(㊀ 帶)	yi2dai4
 (一 幅)	yi4fu2
-(㊀ 幅)	yi4fu2
 (一 幢)	yi4chuang2
-(㊀ 幢)	yi4chuang2
 (一 干)	yi4gan1
-(㊀ 干)	yi4gan1
 (一 年)	yi4nian2
-(㊀ 年)	yi4nian2
 (一 年)	yi4nian2
-(㊀ 年)	yi4nian2
 (一 并)	yi2bing4
-(㊀ 并)	yi2bing4
 (一 床)	yi4chuang2
-(㊀ 床)	yi4chuang2
 (一 应)	yi4ying1
-(㊀ 应)	yi4ying1
 (一 度)	yi2du4
-(㊀ 度)	yi2du4
 (一 度)	yi2du4
-(㊀ 度)	yi2du4
 (一 座)	yi2zuo4
-(㊀ 座)	yi2zuo4
 (一 式)	yi2shi4
-(㊀ 式)	yi2shi4
 (一 张)	yi4zhang1
-(㊀ 张)	yi4zhang1
 (一 張)	yi4zhang1
-(㊀ 張)	yi4zhang1
 (一 径)	yi2jing4
-(㊀ 径)	yi2jing4
 (一 律)	yi2lv4
-(㊀ 律)	yi2lv4
 (一 律)	yi2lv4
-(㊀ 律)	yi2lv4
 (一 徑)	yi2jing4
-(㊀ 徑)	yi2jing4
 (一 得)	yi4de2
-(㊀ 得)	yi4de2
 (一 從)	yi4cong2
-(㊀ 從)	yi4cong2
 (一 心)	yi4xin1
-(㊀ 心)	yi4xin1
 (一 总)	yi4zong3
-(㊀ 总)	yi4zong3
 (一 息)	yi4xi1
-(㊀ 息)	yi4xi1
 (一 惊)	yi4jing1
-(㊀ 惊)	yi4jing1
 (一 意)	yi2yi4
-(㊀ 意)	yi2yi4
 (一 愣)	yi2leng4
-(㊀ 愣)	yi2leng4
 (一 應)	yi4ying1
-(㊀ 應)	yi4ying1
 (一 所)	yi4suo3
-(㊀ 所)	yi4suo3
 (一 扇)	yi2shan4
-(㊀ 扇)	yi2shan4
 (一 手)	yi4shou3
-(㊀ 手)	yi4shou3
 (一 打)	yi4da2
-(㊀ 打)	yi4da2
 (一 扣)	yi2kou4
-(㊀ 扣)	yi2kou4
 (一 批)	yi4pi1
-(㊀ 批)	yi4pi1
 (一 把)	yi4ba3
-(㊀ 把)	yi4ba3
 (一 折)	yi4zhe2
-(㊀ 折)	yi4zhe2
 (一 抹)	yi4mo3
-(㊀ 抹)	yi4mo3
 (一 拥)	yi4yong1
-(㊀ 拥)	yi4yong1
 (一 拨)	yi4bo1
-(㊀ 拨)	yi4bo1
 (一 挺)	yi4ting3
-(㊀ 挺)	yi4ting3
 (一 排)	yi4pai2
-(㊀ 排)	yi4pai2
 (一 搭)	yi4da1
-(㊀ 搭)	yi4da1
 (一 撥)	yi4bo1
-(㊀ 撥)	yi4bo1
 (一 擁)	yi4yong1
-(㊀ 擁)	yi4yong1
 (一 擊)	yi4ji1
-(㊀ 擊)	yi4ji1
 (一 支)	yi4zhi1
-(㊀ 支)	yi4zhi1
 (一 斑)	yi4ban1
-(㊀ 斑)	yi4ban1
 (一 新)	yi4xin1
-(㊀ 新)	yi4xin1
 (一 方)	yi4fang1
-(㊀ 方)	yi4fang1
 (一 旁)	yi4pang2
-(㊀ 旁)	yi4pang2
 (一 无)	yi4wu2
-(㊀ 无)	yi4wu2
 (一 旦)	yi2dan4
-(㊀ 旦)	yi2dan4
 (一 早)	yi4zao3
-(㊀ 早)	yi4zao3
 (一 时)	yi4shi2
-(㊀ 时)	yi4shi2
 (一 星)	yi4xing1
-(㊀ 星)	yi4xing1
 (一 昨)	yi4zuo2
-(㊀ 昨)	yi4zuo2
 (一 是)	yi2shi4
-(㊀ 是)	yi2shi4
 (一 時)	yi4shi2
-(㊀ 時)	yi4shi2
 (一 晃)	yi2huang4
-(㊀ 晃)	yi2huang4
 (一 晌)	yi4shang3
-(㊀ 晌)	yi4shang3
 (一 曲)	yi4qu3
-(㊀ 曲)	yi4qu3
 (一 會)	yi2hui4
-(㊀ 會)	yi2hui4
 (一 服)	yi4fu2
-(㊀ 服)	yi4fu2
 (一 朝)	yi4zhao1
-(㊀ 朝)	yi4zhao1
 (一 本)	yi4ben3
-(㊀ 本)	yi4ben3
 (一 朵)	yi4duo3
-(㊀ 朵)	yi4duo3
 (一 杆)	yi4gan3
-(㊀ 杆)	yi4gan3
 (一 束)	yi2shu4
-(㊀ 束)	yi2shu4
 (一 条)	yi4tiao2
-(㊀ 条)	yi4tiao2
 (一 来)	yi4lai2
-(㊀ 来)	yi4lai2
 (一 杯)	yi4bei1
-(㊀ 杯)	yi4bei1
 (一 枚)	yi4mei2
-(㊀ 枚)	yi4mei2
 (一 枝)	yi4zhi1
-(㊀ 枝)	yi4zhi1
 (一 架)	yi2jia4
-(㊀ 架)	yi2jia4
 (一 栋)	yi2dong4
-(㊀ 栋)	yi2dong4
 (一 株)	yi4zhu1
-(㊀ 株)	yi4zhu1
-(一 ㊑)	yi4zhu1
 (一 样)	yi2yang4
-(㊀ 样)	yi2yang4
 (一 根)	yi4gen1
-(㊀ 根)	yi4gen1
 (一 档)	yi2dang4
-(㊀ 档)	yi2dang4
 (一 桿)	yi4gan3
-(㊀ 桿)	yi4gan3
 (一 條)	yi4tiao2
-(㊀ 條)	yi4tiao2
 (一 棟)	yi2dong4
-(㊀ 棟)	yi2dong4
 (一 棵)	yi4ke1
-(㊀ 棵)	yi4ke1
 (一 楼)	yi4lou2
-(㊀ 楼)	yi4lou2
 (一 榀)	yi4pin3
-(㊀ 榀)	yi4pin3
 (一 概)	yi2gai4
-(㊀ 概)	yi2gai4
 (一 榜)	yi4bang3
-(㊀ 榜)	yi4bang3
 (一 樓)	yi4lou2
-(㊀ 樓)	yi4lou2
 (一 樓)	yi4lou2
-(㊀ 樓)	yi4lou2
 (一 樘)	yi4tang2
-(㊀ 樘)	yi4tang2
 (一 樣)	yi2yang4
-(㊀ 樣)	yi2yang4
 (一 檔)	yi2dang4
-(㊀ 檔)	yi2dang4
 (一 次)	yi2ci4
-(㊀ 次)	yi2ci4
 (一 歇)	yi4xie1
-(㊀ 歇)	yi4xie1
 (一 步)	yi2bu4
-(㊀ 步)	yi2bu4
 (一 歲)	yi2sui4
-(㊀ 歲)	yi2sui4
 (一 段)	yi2duan4
-(㊀ 段)	yi2duan4
 (一 毛)	yi4mao2
-(㊀ 毛)	yi4mao2
 (一 毫)	yi4hao2
-(㊀ 毫)	yi4hao2
 (一 气)	yi2qi4
-(㊀ 气)	yi2qi4
 (一 氣)	yi2qi4
-(㊀ 氣)	yi2qi4
 (一 汪)	yi4wang1
-(㊀ 汪)	yi4wang1
 (一 泡)	yi4pao1
-(㊀ 泡)	yi4pao1
 (一 流)	yi4liu2
-(㊀ 流)	yi4liu2
 (一 流)	yi4liu2
-(㊀ 流)	yi4liu2
 (一 流)	yi4liu2
-(㊀ 流)	yi4liu2
 (一 準)	yi4zhun3
-(㊀ 準)	yi4zhun3
 (一 溜)	yi2liu4
-(㊀ 溜)	yi2liu4
 (一 溜)	yi2liu4
-(㊀ 溜)	yi2liu4
 (一 点)	yi4dian3
-(㊀ 点)	yi4dian3
 (一 無)	yi4wu2
-(㊀ 無)	yi4wu2
 (一 片)	yi2pian4
-(㊀ 片)	yi2pian4
 (一 班)	yi4ban1
-(㊀ 班)	yi4ban1
 (一 理)	yi4li3
-(㊀ 理)	yi4li3
 (一 理)	yi4li3
-(㊀ 理)	yi4li3
 (一 瓶)	yi4ping2
-(㊀ 瓶)	yi4ping2
 (一 生)	yi4sheng1
-(㊀ 生)	yi4sheng1
 (一 甬)	yi4yong3
-(㊀ 甬)	yi4yong3
 (一 畝)	yi4mu3
-(㊀ 畝)	yi4mu3
 (一 番)	yi4fan1
-(㊀ 番)	yi4fan1
 (一 發)	yi4fa1
-(㊀ 發)	yi4fa1
 (一 百)	yi4bai3
-(㊀ 百)	yi4bai3
 (一 盏)	yi4zhan3
-(㊀ 盏)	yi4zhan3
 (一 盘)	yi4pan2
-(㊀ 盘)	yi4pan2
 (一 盞)	yi4zhan3
-(㊀ 盞)	yi4zhan3
 (一 盤)	yi4pan2
-(㊀ 盤)	yi4pan2
 (一 直)	yi4zhi2
-(㊀ 直)	yi4zhi2
 (一 直)	yi4zhi2
-(㊀ 直)	yi4zhi2
 (一 眼)	yi4yan3
-(㊀ 眼)	yi4yan3
 (一 瞥)	yi4pie1
-(㊀ 瞥)	yi4pie1
 (一 瞬)	yi2shun4
-(㊀ 瞬)	yi2shun4
 (一 碗)	yi4wan3
-(㊀ 碗)	yi4wan3
 (一 碧)	yi2bi4
-(㊀ 碧)	yi2bi4
 (一 秋)	yi4qiu1
-(㊀ 秋)	yi4qiu1
 (一 种)	yi4zhong3
-(㊀ 种)	yi4zhong3
 (一 秘)	yi2mi4
-(㊀ 秘)	yi2mi4
-(一 ㊙)	yi2mi4
 (一 程)	yi4cheng2
-(㊀ 程)	yi4cheng2
 (一 種)	yi4zhong3
-(㊀ 種)	yi4zhong3
 (一 空)	yi4kong1
-(㊀ 空)	yi4kong1
 (一 端)	yi4duan1
-(㊀ 端)	yi4duan1
 (一 笔)	yi4bi3
-(㊀ 笔)	yi4bi3
 (一 筆)	yi4bi3
-(㊀ 筆)	yi4bi3
 (一 等)	yi4deng3
-(㊀ 等)	yi4deng3
 (一 筹)	yi4chou2
-(㊀ 筹)	yi4chou2
 (一 箇)	yi2ge4
-(㊀ 箇)	yi2ge4
 (一 算)	yi2suan4
-(㊀ 算)	yi2suan4
 (一 節)	yi4jie2
-(㊀ 節)	yi4jie2
 (一 節)	yi4jie2
-(㊀ 節)	yi4jie2
 (一 節)	yi4jie2
-(㊀ 節)	yi4jie2
 (一 篇)	yi4pian1
-(㊀ 篇)	yi4pian1
 (一 簇)	yi2cu4
-(㊀ 簇)	yi2cu4
 (一 籌)	yi4chou2
-(㊀ 籌)	yi4chou2
 (一 米)	yi4mi3
-(㊀ 米)	yi4mi3
 (一 类)	yi2lei4
-(㊀ 类)	yi2lei4
 (一 类)	yi2lei4
-(㊀ 类)	yi2lei4
 (一 粒)	yi2li4
-(㊀ 粒)	yi2li4
 (一 粒)	yi2li4
-(㊀ 粒)	yi2li4
 (一 粟)	yi2su4
-(㊀ 粟)	yi2su4
 (一 紀)	yi2ji4
-(㊀ 紀)	yi2ji4
 (一 級)	yi4ji2
-(㊀ 級)	yi4ji2
 (一 絕)	yi4jue2
-(㊀ 絕)	yi4jue2
 (一 絞)	yi4jiao3
-(㊀ 絞)	yi4jiao3
 (一 統)	yi4tong3
-(㊀ 統)	yi4tong3
 (一 經)	yi4jing1
-(㊀ 經)	yi4jing1
 (一 維)	yi4wei2
-(㊀ 維)	yi4wei2
 (一 線)	yi2xian4
-(㊀ 線)	yi2xian4
 (一 總)	yi4zong3
-(㊀ 總)	yi4zong3
 (一 级)	yi4ji2
-(㊀ 级)	yi4ji2
 (一 纪)	yi2ji4
-(㊀ 纪)	yi2ji4
 (一 线)	yi2xian4
-(㊀ 线)	yi2xian4
 (一 经)	yi4jing1
-(㊀ 经)	yi4jing1
 (一 绝)	yi4jue2
-(㊀ 绝)	yi4jue2
 (一 绞)	yi4jiao3
-(㊀ 绞)	yi4jiao3
 (一 统)	yi4tong3
-(㊀ 统)	yi4tong3
 (一 维)	yi4wei2
-(㊀ 维)	yi4wei2
 (一 缸)	yi4gang1
-(㊀ 缸)	yi4gang1
 (一 群)	yi4qun2
-(㊀ 群)	yi4qun2
 (一 義)	yi2yi4
-(㊀ 義)	yi2yi4
 (一 聲)	yi4sheng1
-(㊀ 聲)	yi4sheng1
 (一 聽)	yi4ting1
-(㊀ 聽)	yi4ting1
 (一 股)	yi4gu3
-(㊀ 股)	yi4gu3
 (一 胎)	yi4tai1
-(㊀ 胎)	yi4tai1
 (一 脸)	yi4lian3
-(㊀ 脸)	yi4lian3
 (一 腔)	yi4qiang1
-(㊀ 腔)	yi4qiang1
 (一 臉)	yi4lian3
-(㊀ 臉)	yi4lian3
 (一 自)	yi2zi4
-(㊀ 自)	yi2zi4
 (一 至)	yi2zhi4
-(㊀ 至)	yi2zhi4
 (一 致)	yi2zhi4
-(㊀ 致)	yi2zhi4
 (一 臺)	yi4tai2
-(㊀ 臺)	yi4tai2
 (一 舉)	yi4ju3
-(㊀ 舉)	yi4ju3
 (一 般)	yi4ban1
-(㊀ 般)	yi4ban1
 (一 艘)	yi4sou1
-(㊀ 艘)	yi4sou1
 (一 色)	yi4shai3
-(㊀ 色)	yi4shai3
 (一 节)	yi4jie2
-(㊀ 节)	yi4jie2
 (一 若)	yi2ruo4
-(㊀ 若)	yi2ruo4
 (一 若)	yi2ruo4
-(㊀ 若)	yi2ruo4
 (一 萬)	yi2wan4
-(㊀ 萬)	yi2wan4
 (一 處)	yi2chu4
-(㊀ 處)	yi2chu4
 (一 號)	yi2hao4
-(㊀ 號)	yi2hao4
 (一 行)	yi4xing2
-(㊀ 行)	yi4xing2
 (一 行)	yi4xing2
-(㊀ 行)	yi4xing2
 (一 袭)	yi4xi2
-(㊀ 袭)	yi4xi2
 (一 襲)	yi4xi2
-(㊀ 襲)	yi4xi2
 (一 覽)	yi4lan3
-(㊀ 覽)	yi4lan3
 (一 览)	yi4lan3
-(㊀ 览)	yi4lan3
 (一 角)	yi4jiao3
-(㊀ 角)	yi4jiao3
 (一 言)	yi4yan2
-(㊀ 言)	yi4yan2
 (一 語)	yi4yu3
-(㊀ 語)	yi4yu3
 (一 說)	yi4shuo1
-(㊀ 說)	yi4shuo1
 (一 說)	yi4shuo1
-(㊀ 說)	yi4shuo1
 (一 說)	yi4shuo1
-(㊀ 說)	yi4shuo1
 (一 誰)	yi4shui2
-(㊀ 誰)	yi4shui2
 (一 讀)	yi4du2
-(㊀ 讀)	yi4du2
 (一 讀)	yi4du2
-(㊀ 讀)	yi4du2
 (一 语)	yi4yu3
-(㊀ 语)	yi4yu3
 (一 说)	yi4shuo1
-(㊀ 说)	yi4shuo1
 (一 读)	yi4du2
-(㊀ 读)	yi4du2
 (一 谁)	yi4shui2
-(㊀ 谁)	yi4shui2
 (一 貫)	yi2guan4
-(㊀ 貫)	yi2guan4
 (一 贯)	yi2guan4
-(㊀ 贯)	yi2guan4
 (一 起)	yi4qi3
-(㊀ 起)	yi4qi3
 (一 趟)	yi2tang4
-(㊀ 趟)	yi2tang4
 (一 路)	yi2lu4
-(㊀ 路)	yi2lu4
 (一 路)	yi2lu4
-(㊀ 路)	yi2lu4
 (一 跳)	yi2tiao4
-(㊀ 跳)	yi2tiao4
 (一 身)	yi4shen1
-(㊀ 身)	yi4shen1
 (一 輛)	yi2liang4
-(㊀ 輛)	yi2liang4
 (一 輪)	yi4lun2
-(㊀ 輪)	yi4lun2
 (一 輪)	yi4lun2
-(㊀ 輪)	yi4lun2
 (一 轮)	yi4lun2
-(㊀ 轮)	yi4lun2
 (一 辆)	yi2liang4
-(㊀ 辆)	yi2liang4
 (一 边)	yi4bian1
-(㊀ 边)	yi4bian1
 (一 这)	yi2zhe4
-(㊀ 这)	yi2zhe4
 (一 连)	yi4lian2
-(㊀ 连)	yi4lian2
 (一 這)	yi2zhe4
-(㊀ 這)	yi2zhe4
 (一 連)	yi4lian2
-(㊀ 連)	yi4lian2
 (一 連)	yi4lian2
-(㊀ 連)	yi4lian2
 (一 遍)	yi2bian4
-(㊀ 遍)	yi2bian4
 (一 道)	yi2dao4
-(㊀ 道)	yi2dao4
 (一 遭)	yi4zao1
-(㊀ 遭)	yi4zao1
 (一 邊)	yi4bian1
-(㊀ 邊)	yi4bian1
 (一 那)	yi2na4
-(㊀ 那)	yi2na4
 (一 部)	yi2bu4
-(㊀ 部)	yi2bu4
 (一 門)	yi4men2
-(㊀ 門)	yi4men2
 (一 間)	yi4jian1
-(㊀ 間)	yi4jian1
 (一 门)	yi4men2
-(㊀ 门)	yi4men2
 (一 间)	yi4jian1
-(㊀ 间)	yi4jian1
 (一 阵)	yi2zhen4
-(㊀ 阵)	yi2zhen4
 (一 阶)	yi4jie1
-(㊀ 阶)	yi4jie1
 (一 陣)	yi2zhen4
-(㊀ 陣)	yi2zhen4
 (一 隅)	yi4yu2
-(㊀ 隅)	yi4yu2
 (一 階)	yi4jie1
-(㊀ 階)	yi4jie1
 (一 隻)	yi4zhi1
-(㊀ 隻)	yi4zhi1
 (一 集)	yi4ji2
-(㊀ 集)	yi4ji2
 (一 雙)	yi4shuang1
-(㊀ 雙)	yi4shuang1
 (一 霎)	yi2sha4
-(㊀ 霎)	yi2sha4
 (一 霸)	yi2ba4
-(㊀ 霸)	yi2ba4
 (一 面)	yi2mian4
-(㊀ 面)	yi2mian4
 (一 音)	yi4yin1
-(㊀ 音)	yi4yin1
 (一 響)	yi4xiang3
-(㊀ 響)	yi4xiang3
 (一 響)	yi4xiang3
-(㊀ 響)	yi4xiang3
 (一 響)	yi4xiang3
-(㊀ 響)	yi4xiang3
 (一 頂)	yi4ding3
-(㊀ 頂)	yi4ding3
 (一 項)	yi2xiang4
-(一 ㊠)	yi2xiang4
-(㊀ 項)	yi2xiang4
 (一 順)	yi2shun4
-(㊀ 順)	yi2shun4
 (一 頓)	yi2dun4
-(㊀ 頓)	yi2dun4
 (一 頭)	yi4tou2
-(㊀ 頭)	yi4tou2
 (一 顆)	yi4ke1
-(㊀ 顆)	yi4ke1
 (一 類)	yi2lei4
-(㊀ 類)	yi2lei4
 (一 類)	yi2lei4
-(㊀ 類)	yi2lei4
 (一 顶)	yi4ding3
-(㊀ 顶)	yi4ding3
 (一 项)	yi2xiang4
-(㊀ 项)	yi2xiang4
 (一 顺)	yi2shun4
-(㊀ 顺)	yi2shun4
 (一 顿)	yi2dun4
-(㊀ 顿)	yi2dun4
 (一 颗)	yi4ke1
-(㊀ 颗)	yi4ke1
 (一 餐)	yi4can1
-(㊀ 餐)	yi4can1
 (一 首)	yi4shou3
-(㊀ 首)	yi4shou3
 (一 驚)	yi4jing1
-(㊀ 驚)	yi4jing1
 (一 體)	yi4ti3
-(㊀ 體)	yi4ti3
 (一 點)	yi4dian3
-(㊀ 點)	yi4dian3
 (一 黨)	yi4dang3
-(㊀ 黨)	yi4dang3
 (一 齊)	yi4qi2
-(㊀ 齊)	yi4qi2
 (一 齐)	yi4qi2
-(㊀ 齐)	yi4qi2
 (一 齣)	yi4chu1
-(㊀ 齣)	yi4chu1
 (丁 丑)	ding1chou3
 (丁 卯)	ding1mao3
 (丁 点)	ding1dian3
@@ -22648,242 +22216,124 @@ $textmode
 (丁 酉)	ding1you3
 (丁 點)	ding1dian3
 (七 个)	qi1ge5
-(㊆ 个)	qi1ge5
 (七 個)	qi1ge5
-(㊆ 個)	qi1ge5
 (七 百)	qi1bai3
-(㊆ 百)	qi1bai3
 (万 个)	wan4ge5
 (万 個)	wan4ge5
 (万 古)	wan4gu3
 (万 有)	wan4you3
-(万 ㊒)	wan4you3
 (万 里)	wan4li3
 (万 里)	wan4li3
 (三 个)	san1ge5
-(㊂ 个)	san1ge5
 (三 井)	san1jing3
-(㊂ 井)	san1jing3
 (三 個)	san1ge5
-(㊂ 個)	san1ge5
 (三 宝)	san1bao3
-(㊂ 宝)	san1bao3
 (三 寶)	san1bao3
-(㊂ 寶)	san1bao3
 (三 点)	san1dian3
-(㊂ 点)	san1dian3
 (三 百)	san1bai3
-(㊂ 百)	san1bai3
 (三 藏)	san1zang4
-(㊂ 藏)	san1zang4
 (三 角)	san1jiao3
-(㊂ 角)	san1jiao3
 (三 重)	san1chong2
-(㊂ 重)	san1chong2
 (三 點)	san1dian3
-(㊂ 點)	san1dian3
 (上 九)	shang4jiu3
-(㊤ 九)	shang4jiu3
-(上 ㊈)	shang4jiu3
 (上 來)	shang4lai5
-(㊤ 來)	shang4lai5
 (上 來)	shang4lai5
-(㊤ 來)	shang4lai5
 (上 午)	shang4wu3
-(㊤ 午)	shang4wu3
 (上 去)	shang4qu5
-(㊤ 去)	shang4qu5
 (上 口)	shang4kou3
-(㊤ 口)	shang4kou3
 (上 古)	shang4gu3
-(㊤ 古)	shang4gu3
 (上 司)	shang4si5
-(㊤ 司)	shang4si5
 (上 品)	shang4pin3
-(㊤ 品)	shang4pin3
 (上 地)	shang4di4
-(㊤ 地)	shang4di4
 (上 场)	shang4chang3
-(㊤ 场)	shang4chang3
 (上 場)	shang4chang3
-(㊤ 場)	shang4chang3
 (上 声)	shang3sheng1
-(㊤ 声)	shang3sheng1
 (上 头)	shang4tou5
-(㊤ 头)	shang4tou5
 (上 好)	shang4hao3
-(㊤ 好)	shang4hao3
 (上 将)	shang4jiang4
-(㊤ 将)	shang4jiang4
 (上 將)	shang4jiang4
-(㊤ 將)	shang4jiang4
 (上 当)	shang4dang4
-(㊤ 当)	shang4dang4
 (上 手)	shang4shou3
-(㊤ 手)	shang4shou3
 (上 指)	shang4zhi3
-(㊤ 指)	shang4zhi3
 (上 杆)	shang4gan3
-(㊤ 杆)	shang4gan3
 (上 来)	shang4lai5
-(㊤ 来)	shang4lai5
 (上 桿)	shang4gan3
-(㊤ 桿)	shang4gan3
 (上 水)	shang4shui3
-(㊤ 水)	shang4shui3
-(上 ㊌)	shang4shui3
 (上 海)	shang4hai3
-(㊤ 海)	shang4hai3
 (上 海)	shang4hai3
-(㊤ 海)	shang4hai3
 (上 涨)	shang4zhang3
-(㊤ 涨)	shang4zhang3
 (上 演)	shang4yan3
-(㊤ 演)	shang4yan3
 (上 漲)	shang4zhang3
-(㊤ 漲)	shang4zhang3
 (上 火)	shang4huo3
-(㊤ 火)	shang4huo3
-(上 ㊋)	shang4huo3
 (上 當)	shang4dang4
-(㊤ 當)	shang4dang4
 (上 瘾)	shang4yin3
-(㊤ 瘾)	shang4yin3
 (上 癮)	shang4yin3
-(㊤ 癮)	shang4yin3
 (上 相)	shang4xiang4
-(㊤ 相)	shang4xiang4
 (上 睑)	shang4jian3
-(㊤ 睑)	shang4jian3
 (上 瞼)	shang4jian3
-(㊤ 瞼)	shang4jian3
 (上 礼)	shang4li3
-(㊤ 礼)	shang4li3
 (上 礼)	shang4li3
-(㊤ 礼)	shang4li3
 (上 禮)	shang4li3
-(㊤ 禮)	shang4li3
 (上 禮)	shang4li3
-(㊤ 禮)	shang4li3
 (上 等)	shang4deng3
-(㊤ 等)	shang4deng3
 (上 網)	shang4wang3
-(㊤ 網)	shang4wang3
 (上 网)	shang4wang3
-(㊤ 网)	shang4wang3
 (上 聲)	shang3sheng1
-(㊤ 聲)	shang3sheng1
 (上 表)	shang4biao3
-(㊤ 表)	shang4biao3
 (上 訴)	shang4su4
-(㊤ 訴)	shang4su4
 (上 調)	shang4tiao2
-(㊤ 調)	shang4tiao2
 (上 調)	shang4tiao2
-(㊤ 調)	shang4tiao2
 (上 诉)	shang4su4
-(㊤ 诉)	shang4su4
 (上 调)	shang4tiao2
-(㊤ 调)	shang4tiao2
 (上 边)	shang4bian5
-(㊤ 边)	shang4bian5
 (上 邊)	shang4bian5
-(㊤ 邊)	shang4bian5
 (上 野)	shang4ye3
-(㊤ 野)	shang4ye3
 (上 錶)	shang4biao3
-(㊤ 錶)	shang4biao3
 (上 面)	shang4mian5
-(㊤ 面)	shang4mian5
 (上 頭)	shang4tou5
-(㊤ 頭)	shang4tou5
 (上 馬)	shang4ma3
-(㊤ 馬)	shang4ma3
 (上 马)	shang4ma3
-(㊤ 马)	shang4ma3
 (上 齒)	shang4chi3
-(㊤ 齒)	shang4chi3
 (上 齿)	shang4chi3
-(㊤ 齿)	shang4chi3
 (下 体)	xia4ti3
-(㊦ 体)	xia4ti3
 (下 來)	xia4lai5
-(㊦ 來)	xia4lai5
 (下 來)	xia4lai5
-(㊦ 來)	xia4lai5
 (下 保)	xia4bao3
-(㊦ 保)	xia4bao3
 (下 午)	xia4wu3
-(㊦ 午)	xia4wu3
 (下 去)	xia4qu5
-(㊦ 去)	xia4qu5
 (下 品)	xia4pin3
-(㊦ 品)	xia4pin3
 (下 地)	xia4di4
-(㊦ 地)	xia4di4
 (下 场)	xia4chang3
-(㊦ 场)	xia4chang3
 (下 場)	xia4chang3
-(㊦ 場)	xia4chang3
 (下 头)	xia4tou5
-(㊦ 头)	xia4tou5
 (下 属)	xia4shu3
-(㊦ 属)	xia4shu3
 (下 屬)	xia4shu3
-(㊦ 屬)	xia4shu3
 (下 岗)	xia4gang3
-(㊦ 岗)	xia4gang3
 (下 崗)	xia4gang3
-(㊦ 崗)	xia4gang3
 (下 手)	xia4shou3
-(㊦ 手)	xia4shou3
 (下 把)	xia4ba3
-(㊦ 把)	xia4ba3
 (下 来)	xia4lai5
-(㊦ 来)	xia4lai5
 (下 水)	xia4shui3
-(㊦ 水)	xia4shui3
-(下 ㊌)	xia4shui3
 (下 海)	xia4hai3
-(㊦ 海)	xia4hai3
 (下 海)	xia4hai3
-(㊦ 海)	xia4hai3
 (下 笔)	xia4bi3
-(㊦ 笔)	xia4bi3
 (下 筆)	xia4bi3
-(㊦ 筆)	xia4bi3
 (下 等)	xia4deng3
-(㊦ 等)	xia4deng3
 (下 網)	xia4wang3
-(㊦ 網)	xia4wang3
 (下 网)	xia4wang3
-(㊦ 网)	xia4wang3
 (下 走)	xia4zou3
-(㊦ 走)	xia4zou3
 (下 边)	xia4bian5
-(㊦ 边)	xia4bian5
 (下 邊)	xia4bian5
-(㊦ 邊)	xia4bian5
 (下 野)	xia4ye3
-(㊦ 野)	xia4ye3
 (下 雨)	xia4yu3
-(㊦ 雨)	xia4yu3
 (下 雪)	xia4xue3
-(㊦ 雪)	xia4xue3
 (下 面)	xia4mian5
-(㊦ 面)	xia4mian5
 (下 頭)	xia4tou5
-(㊦ 頭)	xia4tou5
 (下 馬)	xia4ma3
-(㊦ 馬)	xia4ma3
 (下 马)	xia4ma3
-(㊦ 马)	xia4ma3
 (下 體)	xia4ti3
-(㊦ 體)	xia4ti3
 (下 齒)	xia4chi3
-(㊦ 齒)	xia4chi3
 (下 齿)	xia4chi3
-(㊦ 齿)	xia4chi3
 (不 㐄)	bu2kua4
 (不 㐄)	bu2kua4
 (不 㐌)	bu2si4
@@ -27203,13 +26653,9 @@ $textmode
 (不 丈)	bu2zhang4
 (不 丈)	bu2zhang4
 (不 上)	bu2shang4
-(不 ㊤)	bu2shang4
 (不 上)	bu2shang4
-(不 ㊤)	bu2shang4
 (不 下)	bu2xia4
-(不 ㊦)	bu2xia4
 (不 下)	bu2xia4
-(不 ㊦)	bu2xia4
 (不 丐)	bu2gai4
 (不 丐)	bu2gai4
 (不 世)	bu2shi4
@@ -27265,9 +26711,7 @@ $textmode
 (不 事)	bu2shi4
 (不 事)	bu2shi4
 (不 二)	bu2er4
-(不 ㊁)	bu2er4
 (不 二)	bu2er4
-(不 ㊁)	bu2er4
 (不 亍)	bu2chu4
 (不 亍)	bu2chu4
 (不 互)	bu2hu4
@@ -27770,10 +27214,8 @@ $textmode
 (不 內)	bu2nei4
 (不 內)	bu2nei4
 (不 六)	bu2liu4
-(不 ㊅)	bu2liu4
 (不 六)	bu2liu4
 (不 六)	bu2liu4
-(不 ㊅)	bu2liu4
 (不 共)	bu2gong4
 (不 共)	bu2gong4
 (不 兴)	bu4xing1
@@ -28124,9 +27566,7 @@ $textmode
 (不 卫)	bu2wei4
 (不 卫)	bu2wei4
 (不 印)	bu2yin4
-(不 ㊞)	bu2yin4
 (不 印)	bu2yin4
-(不 ㊞)	bu2yin4
 (不 却)	bu2que4
 (不 却)	bu2que4
 (不 卶)	bu2shi4
@@ -28223,9 +27663,7 @@ $textmode
 (不 叱)	bu2chi4
 (不 叱)	bu2chi4
 (不 右)	bu2you4
-(不 ㊨)	bu2you4
 (不 右)	bu2you4
-(不 ㊨)	bu2you4
 (不 叶)	bu2ye4
 (不 叶)	bu2ye4
 (不 号)	bu2hao4
@@ -28627,9 +28065,7 @@ $textmode
 (不 囓)	bu2nie4
 (不 囓)	bu2nie4
 (不 四)	bu2si4
-(不 ㊃)	bu2si4
 (不 四)	bu2si4
-(不 ㊃)	bu2si4
 (不 囟)	bu2xin4
 (不 囟)	bu2xin4
 (不 囥)	bu2kang4
@@ -28992,9 +28428,7 @@ $textmode
 (不 夙)	bu2su4
 (不 夙)	bu2su4
 (不 夜)	bu2ye4
-(不 ㊰)	bu2ye4
 (不 夜)	bu2ye4
-(不 ㊰)	bu2ye4
 (不 够)	bu2gou4
 (不 够)	bu2gou4
 (不 夠)	bu2gou4
@@ -30996,9 +30430,7 @@ $textmode
 (不 旤)	bu2huo4
 (不 旤)	bu2huo4
 (不 日)	bu2ri4
-(不 ㊐)	bu2ri4
 (不 日)	bu2ri4
-(不 ㊐)	bu2ri4
 (不 旦)	bu2dan4
 (不 旦)	bu2dan4
 (不 旧)	bu2jiu4
@@ -31211,9 +30643,7 @@ $textmode
 (不 朅)	bu2qie4
 (不 朅)	bu2qie4
 (不 月)	bu2yue4
-(不 ㊊)	bu2yue4
 (不 月)	bu2yue4
-(不 ㊊)	bu2yue4
 (不 朒)	bu2nv4
 (不 朒)	bu2nv4
 (不 朓)	bu2tiao4
@@ -31226,9 +30656,7 @@ $textmode
 (不 望)	bu2wang4
 (不 望)	bu2wang4
 (不 木)	bu2mu4
-(不 ㊍)	bu2mu4
 (不 木)	bu2mu4
-(不 ㊍)	bu2mu4
 (不 未)	bu2wei4
 (不 未)	bu2wei4
 (不 末)	bu2mo4
@@ -31751,9 +31179,7 @@ $textmode
 (不 歠)	bu2chuo4
 (不 歠)	bu2chuo4
 (不 正)	bu2zheng4
-(不 ㊣)	bu2zheng4
 (不 正)	bu2zheng4
-(不 ㊣)	bu2zheng4
 (不 步)	bu2bu4
 (不 步)	bu2bu4
 (不 歨)	bu2bu4
@@ -32010,9 +31436,7 @@ $textmode
 (不 泧)	bu2yue4
 (不 泧)	bu2yue4
 (不 注)	bu2zhu4
-(不 ㊟)	bu2zhu4
 (不 注)	bu2zhu4
-(不 ㊟)	bu2zhu4
 (不 泪)	bu2lei4
 (不 泪)	bu2lei4
 (不 泫)	bu2xuan4
@@ -32985,9 +32409,7 @@ $textmode
 (不 牸)	bu2zi4
 (不 牸)	bu2zi4
 (不 特)	bu2te4
-(不 ㊕)	bu2te4
 (不 特)	bu2te4
-(不 ㊕)	bu2te4
 (不 牿)	bu2gu4
 (不 牿)	bu2gu4
 (不 犆)	bu2te4
@@ -34015,10 +33437,8 @@ $textmode
 (不 礻)	bu2shi4
 (不 礻)	bu2shi4
 (不 社)	bu2she4
-(不 ㊓)	bu2she4
 (不 社)	bu2she4
 (不 社)	bu2she4
-(不 ㊓)	bu2she4
 (不 礿)	bu2yue4
 (不 礿)	bu2yue4
 (不 祀)	bu2si4
@@ -34049,9 +33469,7 @@ $textmode
 (不 祜)	bu2hu4
 (不 祜)	bu2hu4
 (不 祝)	bu2zhu4
-(不 ㊗)	bu2zhu4
 (不 祝)	bu2zhu4
-(不 ㊗)	bu2zhu4
 (不 祝)	bu2zhu4
 (不 祟)	bu2sui4
 (不 祟)	bu2sui4
@@ -34120,9 +33538,7 @@ $textmode
 (不 秗)	bu2yu4
 (不 秗)	bu2yu4
 (不 秘)	bu2mi4
-(不 ㊙)	bu2mi4
 (不 秘)	bu2mi4
-(不 ㊙)	bu2mi4
 (不 秙)	bu2ku4
 (不 秙)	bu2ku4
 (不 秚)	bu2ban4
@@ -37658,9 +37074,7 @@ $textmode
 (不 遦)	bu2guan4
 (不 遦)	bu2guan4
 (不 適)	bu2shi4
-(不 ㊜)	bu2shi4
 (不 適)	bu2shi4
-(不 ㊜)	bu2shi4
 (不 遪)	bu2ce4
 (不 遪)	bu2ce4
 (不 遫)	bu2su4
@@ -38826,9 +38240,7 @@ $textmode
 (不 頁)	bu2ye4
 (不 頁)	bu2ye4
 (不 項)	bu2xiang4
-(不 ㊠)	bu2xiang4
 (不 項)	bu2xiang4
-(不 ㊠)	bu2xiang4
 (不 順)	bu2shun4
 (不 順)	bu2shun4
 (不 頋)	bu2gu4
@@ -39839,7 +39251,6 @@ $textmode
 (丑 诋)	chou3di3
 (专 好)	zhuan1hao4
 (专 有)	zhuan1you3
-(专 ㊒)	zhuan1you3
 (专 款)	zhuan1kuan3
 (专 管)	zhuan1guan3
 (专 著)	zhuan1zhu4
@@ -39850,7 +39261,6 @@ $textmode
 (世 行)	shi4hang2
 (世 行)	shi4hang2
 (丘 北)	qiu1bei3
-(丘 🀃)	qiu1bei3
 (丘 北)	qiu1bei3
 (丘 疹)	qiu1zhen3
 (丘 脑)	qiu1nao3
@@ -39865,24 +39275,14 @@ $textmode
 (业 海)	ye4hai3
 (业 绩)	ye4ji4
 (东 北)	dong1bei3
-(🀀 北)	dong1bei3
-(东 🀃)	dong1bei3
 (东 北)	dong1bei3
-(🀀 北)	dong1bei3
 (东 家)	dong1jia5
-(🀀 家)	dong1jia5
 (东 海)	dong1hai3
-(🀀 海)	dong1hai3
 (东 海)	dong1hai3
-(🀀 海)	dong1hai3
 (东 莞)	dong1wan3
-(🀀 莞)	dong1wan3
 (东 边)	dong1bian5
-(🀀 边)	dong1bian5
 (东 阿)	dong1e1
-(🀀 阿)	dong1e1
 (东 面)	dong1mian5
-(🀀 面)	dong1mian5
 (丝 柏)	si1bo2
 (丝 缕)	si1lv3
 (丝 雨)	si1yu3
@@ -39937,216 +39337,75 @@ $textmode
 (丫 頭)	ya1tou5
 (丫 鬟)	ya1huan5
 (中 举)	zhong4ju3
-(🀄 举)	zhong4ju3
-(㊥ 举)	zhong4ju3
 (中 产)	zhong1chan3
-(🀄 产)	zhong1chan3
-(㊥ 产)	zhong1chan3
 (中 伤)	zhong4shang1
-(🀄 伤)	zhong4shang1
-(㊥ 伤)	zhong4shang1
 (中 保)	zhong1bao3
-(🀄 保)	zhong1bao3
-(㊥ 保)	zhong1bao3
 (中 傷)	zhong4shang1
-(🀄 傷)	zhong4shang1
-(㊥ 傷)	zhong4shang1
 (中 兴)	zhong1xing1
-(🀄 兴)	zhong1xing1
-(㊥ 兴)	zhong1xing1
 (中 午)	zhong1wu3
-(🀄 午)	zhong1wu3
-(㊥ 午)	zhong1wu3
 (中 古)	zhong1gu3
-(🀄 古)	zhong1gu3
-(㊥ 古)	zhong1gu3
 (中 吃)	zhong4chi1
-(🀄 吃)	zhong4chi1
-(㊥ 吃)	zhong4chi1
 (中 土)	zhong1tu3
-(🀄 土)	zhong1tu3
-(㊥ 土)	zhong1tu3
-(中 ㊏)	zhong1tu3
-(🀄 ㊏)	zhong1tu3
 (中 场)	zhong1chang3
-(🀄 场)	zhong1chang3
-(㊥ 场)	zhong1chang3
 (中 場)	zhong1chang3
-(🀄 場)	zhong1chang3
-(㊥ 場)	zhong1chang3
 (中 奖)	zhong4jiang3
-(🀄 奖)	zhong4jiang3
-(㊥ 奖)	zhong4jiang3
 (中 子)	zhong1zi3
-(🀄 子)	zhong1zi3
-(㊥ 子)	zhong1zi3
 (中 将)	zhong1jiang4
-(🀄 将)	zhong1jiang4
-(㊥ 将)	zhong1jiang4
 (中 將)	zhong1jiang4
-(🀄 將)	zhong1jiang4
-(㊥ 將)	zhong1jiang4
 (中 岛)	zhong1dao3
-(🀄 岛)	zhong1dao3
-(㊥ 岛)	zhong1dao3
 (中 島)	zhong1dao3
-(🀄 島)	zhong1dao3
-(㊥ 島)	zhong1dao3
 (中 巴)	zhong1ba1
-(🀄 巴)	zhong1ba1
-(㊥ 巴)	zhong1ba1
 (中 弹)	zhong4dan4
-(🀄 弹)	zhong4dan4
-(㊥ 弹)	zhong4dan4
 (中 彈)	zhong4dan4
-(🀄 彈)	zhong4dan4
-(㊥ 彈)	zhong4dan4
 (中 彩)	zhong4cai3
-(🀄 彩)	zhong4cai3
-(㊥ 彩)	zhong4cai3
 (中 彩)	zhong4cai3
-(🀄 彩)	zhong4cai3
-(㊥ 彩)	zhong4cai3
 (中 悔)	zhong1hui3
-(🀄 悔)	zhong1hui3
-(㊥ 悔)	zhong1hui3
 (中 悔)	zhong1hui3
-(🀄 悔)	zhong1hui3
-(㊥ 悔)	zhong1hui3
 (中 意)	zhong4yi4
-(🀄 意)	zhong4yi4
-(㊥ 意)	zhong4yi4
 (中 指)	zhong1zhi3
-(🀄 指)	zhong1zhi3
-(㊥ 指)	zhong1zhi3
 (中 暑)	zhong4shu3
-(🀄 暑)	zhong4shu3
-(㊥ 暑)	zhong4shu3
 (中 暑)	zhong4shu3
-(🀄 暑)	zhong4shu3
-(㊥ 暑)	zhong4shu3
 (中 枪)	zhong4qiang1
-(🀄 枪)	zhong4qiang1
-(㊥ 枪)	zhong4qiang1
 (中 标)	zhong4biao1
-(🀄 标)	zhong4biao1
-(㊥ 标)	zhong4biao1
 (中 槍)	zhong4qiang1
-(🀄 槍)	zhong4qiang1
-(㊥ 槍)	zhong4qiang1
 (中 標)	zhong4biao1
-(🀄 標)	zhong4biao1
-(㊥ 標)	zhong4biao1
 (中 止)	zhong1zhi3
-(🀄 止)	zhong1zhi3
-(㊥ 止)	zhong1zhi3
 (中 毒)	zhong4du2
-(🀄 毒)	zhong4du2
-(㊥ 毒)	zhong4du2
 (中 油)	zhong4you2
-(🀄 油)	zhong4you2
-(㊥ 油)	zhong4you2
 (中 法)	zhong1fa3
-(🀄 法)	zhong1fa3
-(㊥ 法)	zhong1fa3
 (中 港)	zhong1gang3
-(🀄 港)	zhong1gang3
-(㊥ 港)	zhong1gang3
 (中 点)	zhong1dian3
-(🀄 点)	zhong1dian3
-(㊥ 点)	zhong1dian3
 (中 獎)	zhong4jiang3
-(🀄 獎)	zhong4jiang3
-(㊥ 獎)	zhong4jiang3
 (中 產)	zhong1chan3
-(🀄 產)	zhong1chan3
-(㊥ 產)	zhong1chan3
 (中 等)	zhong1deng3
-(🀄 等)	zhong1deng3
-(㊥ 等)	zhong1deng3
 (中 签)	zhong4qian1
-(🀄 签)	zhong4qian1
-(㊥ 签)	zhong4qian1
 (中 簽)	zhong4qian1
-(🀄 簽)	zhong4qian1
-(㊥ 簽)	zhong4qian1
 (中 美)	zhong1mei3
-(🀄 美)	zhong1mei3
-(㊥ 美)	zhong1mei3
 (中 耳)	zhong1er3
-(🀄 耳)	zhong1er3
-(㊥ 耳)	zhong1er3
 (中 肯)	zhong4ken3
-(🀄 肯)	zhong4ken3
-(㊥ 肯)	zhong4ken3
 (中 脊)	zhong1ji3
-(🀄 脊)	zhong1ji3
-(㊥ 脊)	zhong1ji3
 (中 興)	zhong1xing1
-(🀄 興)	zhong1xing1
-(㊥ 興)	zhong1xing1
 (中 舉)	zhong4ju3
-(🀄 舉)	zhong4ju3
-(㊥ 舉)	zhong4ju3
 (中 行)	zhong1hang2
-(🀄 行)	zhong1hang2
-(㊥ 行)	zhong1hang2
 (中 行)	zhong1hang2
-(🀄 行)	zhong1hang2
-(㊥ 行)	zhong1hang2
 (中 西)	zhong1xi1
-(中 🀂)	zhong1xi1
-(🀄 西)	zhong1xi1
-(㊥ 西)	zhong1xi1
-(㊥ 🀂)	zhong1xi1
 (中 計)	zhong4ji4
-(🀄 計)	zhong4ji4
-(㊥ 計)	zhong4ji4
 (中 计)	zhong4ji4
-(🀄 计)	zhong4ji4
-(㊥ 计)	zhong4ji4
 (中 轉)	zhong1zhuan3
-(🀄 轉)	zhong1zhuan3
-(㊥ 轉)	zhong1zhuan3
 (中 转)	zhong1zhuan3
-(🀄 转)	zhong1zhuan3
-(㊥ 转)	zhong1zhuan3
 (中 选)	zhong4xuan3
-(🀄 选)	zhong4xuan3
-(㊥ 选)	zhong4xuan3
 (中 選)	zhong4xuan3
-(🀄 選)	zhong4xuan3
-(㊥ 選)	zhong4xuan3
 (中 邪)	zhong4xie2
-(🀄 邪)	zhong4xie2
-(㊥ 邪)	zhong4xie2
 (中 阮)	zhong1ruan3
-(🀄 阮)	zhong1ruan3
-(㊥ 阮)	zhong1ruan3
 (中 阮)	zhong1ruan3
-(🀄 阮)	zhong1ruan3
-(㊥ 阮)	zhong1ruan3
 (中 風)	zhong4feng1
-(🀄 風)	zhong4feng1
-(㊥ 風)	zhong4feng1
 (中 风)	zhong4feng1
-(🀄 风)	zhong4feng1
-(㊥ 风)	zhong4feng1
 (中 飽)	zhong1bao3
-(🀄 飽)	zhong1bao3
-(㊥ 飽)	zhong1bao3
 (中 饱)	zhong1bao3
-(🀄 饱)	zhong1bao3
-(㊥ 饱)	zhong1bao3
 (中 魔)	zhong4mo2
-(🀄 魔)	zhong4mo2
-(㊥ 魔)	zhong4mo2
 (中 點)	zhong1dian3
-(🀄 點)	zhong1dian3
-(㊥ 點)	zhong1dian3
 (丰 产)	feng1chan3
 (丰 水)	feng1shui3
-(丰 ㊌)	feng1shui3
 (丰 满)	feng1man3
 (丰 美)	feng1mei3
 (丰 都)	feng1du1
@@ -40159,7 +39418,6 @@ $textmode
 (串 行)	chuan4hang2
 (临 产)	lin2chan3
 (临 写)	lin2xie3
-(临 ㊢)	lin2xie3
 (临 场)	lin2chang3
 (临 帖)	lin2tie4
 (临 武)	lin2wu3
@@ -40168,7 +39426,6 @@ $textmode
 (临 海)	lin2hai3
 (临 澧)	lin2li3
 (临 西)	lin2xi1
-(临 🀂)	lin2xi1
 (临 难)	lin2nan4
 (丹 参)	dan1shen1
 (丹 参)	dan1shen1
@@ -40214,7 +39471,6 @@ $textmode
 (主 我)	zhu3wo3
 (主 旨)	zhu3zhi3
 (主 有)	zhu3you3
-(主 ㊒)	zhu3you3
 (主 板)	zhu3ban3
 (主 母)	zhu3mu3
 (主 演)	zhu3yan3
@@ -40224,7 +39480,6 @@ $textmode
 (主 语)	zhu3yu3
 (主 體)	zhu3ti3
 (丽 水)	li2shui3
-(丽 ㊌)	li2shui3
 (举 手)	ju3shou3
 (举 止)	ju3zhi3
 (举 起)	ju3qi3
@@ -40235,7 +39490,6 @@ $textmode
 (久 远)	jiu3yuan3
 (久 遠)	jiu3yuan3
 (么 二)	yao1er4
-(么 ㊁)	yao1er4
 (么 小)	yao1xiao3
 (么 点)	yao1dian3
 (么 點)	yao1dian3
@@ -40261,7 +39515,6 @@ $textmode
 (乌 海)	wu1hai3
 (乌 玛)	wu1ma3
 (乌 西)	wu1xi1
-(乌 🀂)	wu1xi1
 (乌 语)	wu1yu3
 (乌 鳢)	wu1li3
 (乍 得)	zha4de2
@@ -40297,36 +39550,27 @@ $textmode
 (乙 腦)	yi3nao3
 (乙 酉)	yi3you3
 (九 个)	jiu3ge5
-(㊈ 个)	jiu3ge5
 (九 個)	jiu3ge5
-(㊈ 個)	jiu3ge5
 (九 巴)	jiu3ba1
-(㊈ 巴)	jiu3ba1
 (九 百)	jiu3bai3
-(㊈ 百)	jiu3bai3
 (乞 兒)	qi3er2
 (乞 討)	qi3tao3
 (乞 讨)	qi3tao3
 (也 好)	ye3hao3
 (也 得)	ye3dei3
 (也 有)	ye3you3
-(也 ㊒)	ye3you3
 (也 許)	ye3xu3
 (也 许)	ye3xu3
 (习 得)	xi2de2
 (习 水)	xi2shui3
-(习 ㊌)	xi2shui3
 (乡 下)	xiang1xia5
-(乡 ㊦)	xiang1xia5
 (乡 土)	xiang1tu3
-(乡 ㊏)	xiang1tu3
 (乡 戚)	xiang1qi1
 (乡 曲)	xiang1qu3
 (乡 里)	xiang1li3
 (乡 里)	xiang1li3
 (书 体)	shu1ti3
 (书 写)	shu1xie3
-(书 ㊢)	shu1xie3
 (书 卷)	shu1juan4
 (书 反)	shu1fan3
 (书 展)	shu1zhan3
@@ -40344,7 +39588,6 @@ $textmode
 (买 好)	mai3hao3
 (乱 党)	luan4dang3
 (乱 写)	luan4xie3
-(乱 ㊢)	luan4xie3
 (乱 滚)	luan4gun3
 (乱 码)	luan4ma3
 (乱 跑)	luan4pao3
@@ -40457,29 +39700,17 @@ $textmode
 (事 迹)	shi4ji4
 (事 體)	shi4ti3
 (二 个)	er4ge5
-(㊁ 个)	er4ge5
 (二 個)	er4ge5
-(㊁ 個)	er4ge5
 (二 奶)	er4nai3
-(㊁ 奶)	er4nai3
 (二 手)	er4shou3
-(㊁ 手)	er4shou3
 (二 百)	er4bai3
-(㊁ 百)	er4bai3
 (二 等)	er4deng3
-(㊁ 等)	er4deng3
 (二 老)	er4lao3
-(㊁ 老)	er4lao3
 (二 老)	er4lao3
-(㊁ 老)	er4lao3
 (二 者)	er4zhe3
-(㊁ 者)	er4zhe3
 (二 者)	er4zhe3
-(㊁ 者)	er4zhe3
 (二 者)	er4zhe3
-(㊁ 者)	er4zhe3
 (二 重)	er4chong2
-(㊁ 重)	er4chong2
 (于 此)	yu2ci3
 (于 都)	yu2du1
 (于 都)	yu2du1
@@ -40500,28 +39731,17 @@ $textmode
 (互 訪)	hu4fang3
 (互 访)	hu4fang3
 (五 个)	wu3ge5
-(㊄ 个)	wu3ge5
 (五 個)	wu3ge5
-(㊄ 個)	wu3ge5
 (五 百)	wu3bai3
-(㊄ 百)	wu3bai3
 (五 穀)	wu3gu3
-(㊄ 穀)	wu3gu3
 (五 穀)	wu3gu3
-(㊄ 穀)	wu3gu3
 (五 笔)	wu3bi3
-(㊄ 笔)	wu3bi3
 (五 筆)	wu3bi3
-(㊄ 筆)	wu3bi3
 (五 角)	wu3jiao3
-(㊄ 角)	wu3jiao3
 (五 谷)	wu3gu3
-(㊄ 谷)	wu3gu3
 (五 鬼)	wu3gui3
-(㊄ 鬼)	wu3gui3
 (井 口)	jing3kou3
 (井 水)	jing3shui3
-(井 ㊌)	jing3shui3
 (亚 卡)	ya4ka3
 (亚 塔)	ya4ta3
 (亚 巴)	ya4ba1
@@ -40561,7 +39781,6 @@ $textmode
 (亡 者)	wang2zhe3
 (亡 者)	wang2zhe3
 (交 九)	jiao1jiu3
-(交 ㊈)	jiao1jiu3
 (交 卷)	jiao1juan4
 (交 友)	jiao1you3
 (交 口)	jiao1kou3
@@ -40571,7 +39790,6 @@ $textmode
 (交 情)	jiao1qing5
 (交 手)	jiao1shou3
 (交 火)	jiao1huo3
-(交 ㊋)	jiao1huo3
 (交 点)	jiao1dian3
 (交 給)	jiao1gei3
 (交 给)	jiao1gei3
@@ -40590,7 +39808,6 @@ $textmode
 (产 品)	chan3pin3
 (产 地)	chan3di4
 (享 有)	xiang3you3
-(享 ㊒)	xiang3you3
 (京 广)	jing1guang3
 (京 廣)	jing1guang3
 (京 都)	jing1du1
@@ -40644,9 +39861,7 @@ $textmode
 (人 马)	ren2ma3
 (人 體)	ren2ti3
 (什 一)	shi2yi1
-(什 ㊀)	shi2yi1
 (什 一)	shi2yi1
-(什 ㊀)	shi2yi1
 (什 亭)	shi2ting2
 (什 亭)	shi2ting2
 (什 叶)	shi2ye4
@@ -40662,7 +39877,6 @@ $textmode
 (什 麽)	shen2me5
 (仅 仅)	jin3jin3
 (仅 有)	jin3you3
-(仅 ㊒)	jin3you3
 (今 儿)	jin1r5
 (今 晚)	jin1wan3
 (今 晨)	jin1chen2
@@ -40672,10 +39886,8 @@ $textmode
 (介 於)	jie4yu2
 (介 殼)	jie4qiao4
 (仍 有)	reng2you3
-(仍 ㊒)	reng2you3
 (从 古)	cong2gu3
 (从 女)	cong2nv3
-(从 ㊛)	cong2nv3
 (从 女)	cong2nv3
 (从 小)	cong2xiao3
 (从 属)	cong2shu3
@@ -40692,7 +39904,6 @@ $textmode
 (他 瑪)	ta1ma3
 (他 罕)	ta1han3
 (仗 火)	zhang4huo3
-(仗 ㊋)	zhang4huo3
 (付 梓)	fu4zi3
 (付 款)	fu4kuan3
 (付 給)	fu4gei3
@@ -40701,7 +39912,6 @@ $textmode
 (仙 台)	xian1tai2
 (仙 境)	xian1jing4
 (仙 女)	xian1nv3
-(仙 ㊛)	xian1nv3
 (仙 女)	xian1nv3
 (仙 姑)	xian1gu1
 (仙 居)	xian1ju1
@@ -40717,7 +39927,6 @@ $textmode
 (仟 悔)	qian1hui3
 (仟 悔)	qian1hui3
 (代 写)	dai4xie3
-(代 ㊢)	dai4xie3
 (代 寫)	dai4xie3
 (代 理)	dai4li3
 (代 理)	dai4li3
@@ -40736,7 +39945,6 @@ $textmode
 (以 免)	yi3mian3
 (以 免)	yi3mian3
 (以 北)	yi3bei3
-(以 🀃)	yi3bei3
 (以 北)	yi3bei3
 (以 坦)	yi3tan3
 (以 往)	yi3wang3
@@ -40749,7 +39957,6 @@ $textmode
 (以 瓦)	yi3wa3
 (以 米)	yi3mi3
 (以 西)	yi3xi1
-(以 🀂)	yi3xi1
 (以 里)	yi3li3
 (以 里)	yi3li3
 (以 鐵)	yi3tie3
@@ -40780,7 +39987,6 @@ $textmode
 (仿 紙)	fang3zhi3
 (仿 纸)	fang3zhi3
 (企 劃)	qi3hua4
-(㊭ 劃)	qi3hua4
 (伊 塔)	yi1ta3
 (伊 朗)	yi1lang3
 (伊 朗)	yi1lang3
@@ -40797,17 +40003,11 @@ $textmode
 (伏 筆)	fu2bi3
 (伏 虎)	fu2hu3
 (休 假)	xiu1jia4
-(㊡ 假)	xiu1jia4
 (休 养)	xiu1yang3
-(㊡ 养)	xiu1yang3
 (休 想)	xiu1xiang3
-(㊡ 想)	xiu1xiang3
 (休 整)	xiu1zheng3
-(㊡ 整)	xiu1zheng3
 (休 止)	xiu1zhi3
-(㊡ 止)	xiu1zhi3
 (休 養)	xiu1yang3
-(㊡ 養)	xiu1yang3
 (优 格)	you1ge1
 (优 点)	you1dian3
 (优 等)	you1deng3
@@ -40827,7 +40027,6 @@ $textmode
 (伟 举)	wei3ju3
 (伟 绩)	wei3ji4
 (传 写)	chuan2xie3
-(传 ㊢)	chuan2xie3
 (传 寄)	chuan3ji4
 (传 导)	chuan2dao3
 (传 感)	chuan2gan3
@@ -40905,7 +40104,6 @@ $textmode
 (低 语)	di1yu3
 (低 谷)	di1gu3
 (住 下)	zhu4xia5
-(住 ㊦)	zhu4xia5
 (住 友)	zhu4you3
 (住 口)	zhu4kou3
 (住 嘴)	zhu4zui3
@@ -40924,7 +40122,6 @@ $textmode
 (体 表)	ti3biao3
 (体 面)	ti3mian5
 (佔 有)	zhan4you3
-(佔 ㊒)	zhan4you3
 (佔 領)	zhan4ling3
 (佔 領)	zhan4ling3
 (佔 领)	zhan4ling3
@@ -41003,7 +40200,6 @@ $textmode
 (你 老)	ni3lao3
 (你 老)	ni3lao3
 (佣 金)	yong4jin1
-(佣 ㊎)	yong4jin1
 (佣 金)	yong4jin1
 (佩 服)	pei4fu5
 (佳 港)	jia1gang3
@@ -41011,7 +40207,6 @@ $textmode
 (使 唤)	shi3huan5
 (使 喚)	shi3huan5
 (使 女)	shi3nv3
-(使 ㊛)	shi3nv3
 (使 女)	shi3nv3
 (使 盡)	shi3jin4
 (使 者)	shi3zhe3
@@ -41023,16 +40218,13 @@ $textmode
 (使 馆)	shi3guan3
 (侄 儿)	zhi2r5
 (侄 女)	zhi2nv3
-(侄 ㊛)	zhi2nv3
 (侄 女)	zhi2nv3
 (來 使)	lai2shi3
 (來 使)	lai2shi3
 (來 往)	lai2wang3
 (來 往)	lai2wang3
 (來 火)	lai2huo3
-(來 ㊋)	lai2huo3
 (來 火)	lai2huo3
-(來 ㊋)	lai2huo3
 (來 者)	lai2zhe3
 (來 者)	lai2zhe3
 (來 者)	lai2zhe3
@@ -41046,7 +40238,6 @@ $textmode
 (例 语)	li4yu3
 (例 语)	li4yu3
 (侍 女)	shi4nv3
-(侍 ㊛)	shi4nv3
 (侍 女)	shi4nv3
 (侍 者)	shi4zhe3
 (侍 者)	shi4zhe3
@@ -41058,7 +40249,6 @@ $textmode
 (供 应)	gong1ying4
 (供 應)	gong1ying4
 (供 水)	gong1shui3
-(供 ㊌)	gong1shui3
 (供 物)	gong4wu4
 (供 給)	gong1ji3
 (供 给)	gong1ji3
@@ -41131,7 +40321,6 @@ $textmode
 (保 尔)	bao3er3
 (保 底)	bao3di3
 (保 有)	bao3you3
-(保 ㊒)	bao3you3
 (保 本)	bao3ben3
 (保 爾)	bao3er3
 (保 管)	bao3guan3
@@ -41158,14 +40347,12 @@ $textmode
 (修 养)	xiu1yang3
 (修 剪)	xiu1jian3
 (修 女)	xiu1nv3
-(修 ㊛)	xiu1nv3
 (修 女)	xiu1nv3
 (修 好)	xiu1hao3
 (修 改)	xiu1gai3
 (修 整)	xiu1zheng3
 (修 武)	xiu1wu3
 (修 水)	xiu1shui3
-(修 ㊌)	xiu1shui3
 (修 理)	xiu1li3
 (修 理)	xiu1li3
 (修 脚)	xiu1jiao3
@@ -41185,11 +40372,9 @@ $textmode
 (倍 塔)	bei4ta3
 (們 得)	men5dei3
 (倒 下)	dao3xia4
-(倒 ㊦)	dao3xia4
 (倒 仓)	dao3cang1
 (倒 伏)	dao3fu2
 (倒 休)	dao3xiu1
-(倒 ㊡)	dao3xiu1
 (倒 位)	dao3wei4
 (倒 倉)	dao3cang1
 (倒 卖)	dao3mai4
@@ -41220,7 +40405,6 @@ $textmode
 (倒 是)	dao4shi5
 (倒 替)	dao3ti4
 (倒 有)	dao4you3
-(倒 ㊒)	dao4you3
 (倒 槽)	dao3cao2
 (倒 毙)	dao3bi4
 (倒 满)	dao4man3
@@ -41271,7 +40455,6 @@ $textmode
 (借 款)	jie4kuan3
 (借 此)	jie4ci3
 (借 火)	jie4huo3
-(借 ㊋)	jie4huo3
 (借 給)	jie4gei3
 (借 给)	jie4gei3
 (倡 导)	chang4dao3
@@ -41297,7 +40480,6 @@ $textmode
 (假 扮)	jia3ban4
 (假 拱)	jia3gong3
 (假 日)	jia4ri4
-(假 ㊐)	jia4ri4
 (假 期)	jia4qi1
 (假 条)	jia4tiao2
 (假 條)	jia4tiao2
@@ -41313,7 +40495,6 @@ $textmode
 (偏 远)	pian1yuan3
 (偏 遠)	pian1yuan3
 (做 上)	zuo4shang5
-(做 ㊤)	zuo4shang5
 (做 为)	zuo4wei2
 (做 主)	zuo4zhu3
 (做 作)	zuo4zuo5
@@ -41322,7 +40503,6 @@ $textmode
 (做 得)	zuo4de2
 (做 手)	zuo4shou3
 (做 水)	zuo4shui3
-(做 ㊌)	zuo4shui3
 (做 法)	zuo4fa3
 (做 為)	zuo4wei2
 (做 盡)	zuo4jin4
@@ -41336,7 +40516,6 @@ $textmode
 (停 止)	ting2zhi3
 (停 泊)	ting2bo2
 (停 火)	ting2huo3
-(停 ㊋)	ting2huo3
 (停 產)	ting2chan3
 (健 美)	jian4mei3
 (健 診)	jian4zhen3
@@ -41363,12 +40542,10 @@ $textmode
 (備 品)	bei4pin3
 (備 抵)	bei4di3
 (備 有)	bei4you3
-(備 ㊒)	bei4you3
 (備 考)	bei4kao3
 (傢 伙)	jia1huo5
 (傧 相)	bin1xiang4
 (储 水)	chu3shui3
-(储 ㊌)	chu3shui3
 (催 乳)	cui1ru3
 (催 产)	cui1chan3
 (催 吐)	cui1tu4
@@ -41417,7 +40594,6 @@ $textmode
 (傾 訴)	qing1su4
 (僅 僅)	jin3jin3
 (僅 有)	jin3you3
-(僅 ㊒)	jin3you3
 (像 儿)	xiang4r5
 (像 片)	xiang4pian1
 (僧 侣)	seng1lv3
@@ -41442,21 +40618,13 @@ $textmode
 (儘 管)	jin3guan3
 (償 還)	chang2huan2
 (優 於)	you1yu2
-(㊝ 於)	you1yu2
 (優 格)	you1ge1
-(㊝ 格)	you1ge1
 (優 等)	you1deng3
-(㊝ 等)	you1deng3
 (優 美)	you1mei3
-(㊝ 美)	you1mei3
 (優 雅)	you1ya3
-(㊝ 雅)	you1ya3
 (優 點)	you1dian3
-(㊝ 點)	you1dian3
 (儲 水)	chu3shui3
-(儲 ㊌)	chu3shui3
 (儿 女)	er2nv3
-(儿 ㊛)	er2nv3
 (儿 女)	er2nv3
 (允 准)	yun3zhun3
 (允 宜)	yun3yi2
@@ -41529,10 +40697,8 @@ $textmode
 (克 朗)	ke4lang3
 (克 架)	kei1jia4
 (克 西)	ke4xi1
-(克 🀂)	ke4xi1
 (兒 化)	er2hua4
 (兒 女)	er2nv3
-(兒 ㊛)	er2nv3
 (兒 女)	er2nv3
 (兒 媳)	er2xi2
 (兒 子)	er2zi5
@@ -41554,11 +40720,9 @@ $textmode
 (入 伙)	ru4huo3
 (入 口)	ru4kou3
 (入 土)	ru4tu3
-(入 ㊏)	ru4tu3
 (入 地)	ru4di4
 (入 手)	ru4shou3
 (入 水)	ru4shui3
-(入 ㊌)	ru4shui3
 (入 股)	ru4gu3
 (入 选)	ru4xuan3
 (入 選)	ru4xuan3
@@ -41566,9 +40730,7 @@ $textmode
 (內 地)	nei4di4
 (內 場)	nei4chang3
 (內 有)	nei4you3
-(內 ㊒)	nei4you3
 (內 監)	nei4jian4
-(內 ㊬)	nei4jian4
 (內 碼)	nei4ma3
 (內 耳)	nei4er3
 (內 蒙)	nei4meng3
@@ -41619,21 +40781,13 @@ $textmode
 (兩 腿)	liang3tui3
 (兩 腿)	liang3tui3
 (八 个)	ba1ge5
-(㊇ 个)	ba1ge5
 (八 仙)	ba1xian1
-(㊇ 仙)	ba1xian1
 (八 個)	ba1ge5
-(㊇ 個)	ba1ge5
 (八 宝)	ba1bao3
-(㊇ 宝)	ba1bao3
 (八 寶)	ba1bao3
-(㊇ 寶)	ba1bao3
 (八 百)	ba1bai3
-(㊇ 百)	ba1bai3
 (八 股)	ba1gu3
-(㊇ 股)	ba1gu3
 (八 角)	ba1jiao3
-(㊇ 角)	ba1jiao3
 (公 两)	gong1liang3
 (公 主)	gong1zhu3
 (公 亩)	gong1mu3
@@ -41654,7 +40808,6 @@ $textmode
 (公 引)	gong1yin3
 (公 斗)	gong1dou3
 (公 有)	gong1you3
-(公 ㊒)	gong1you3
 (公 款)	gong1kuan3
 (公 法)	gong1fa3
 (公 海)	gong1hai3
@@ -41683,28 +40836,22 @@ $textmode
 (公 館)	gong1guan3
 (公 馆)	gong1guan3
 (六 个)	liu4ge5
-(㊅ 个)	liu4ge5
 (六 个)	liu4ge5
 (六 個)	liu4ge5
-(㊅ 個)	liu4ge5
 (六 個)	liu4ge5
 (六 百)	liu4bai3
-(㊅ 百)	liu4bai3
 (六 百)	liu4bai3
 (六 腑)	liu4fu3
-(㊅ 腑)	liu4fu3
 (六 腑)	liu4fu3
 (兰 塞)	lan2sai4
 (兰 塞)	lan2sai4
 (兰 考)	lan2kao3
 (兰 西)	lan2xi1
-(兰 🀂)	lan2xi1
 (兰 谱)	lan2pu3
 (共 产)	gong4chan3
 (共 享)	gong4xiang3
 (共 处)	gong4chu3
 (共 有)	gong4you3
-(共 ㊒)	gong4you3
 (共 產)	gong4chan3
 (共 管)	gong4guan3
 (共 處)	gong4chu3
@@ -41712,7 +40859,6 @@ $textmode
 (共 識)	gong4shi2
 (共 识)	gong4shi2
 (关 上)	guan1shang5
-(关 ㊤)	guan1shang5
 (关 乎)	guan1hu1
 (关 卡)	guan1qia3
 (关 厂)	guan1chang3
@@ -41723,7 +40869,6 @@ $textmode
 (关 羽)	guan1yu3
 (关 羽)	guan1yu3
 (关 西)	guan1xi1
-(关 🀂)	guan1xi1
 (兴 义)	xing1yi4
 (兴 亡)	xing1wang2
 (兴 仁)	xing1ren2
@@ -41766,7 +40911,6 @@ $textmode
 (具 保)	ju4bao3
 (具 尔)	ju4er3
 (具 有)	ju4you3
-(具 ㊒)	ju4you3
 (具 爾)	ju4er3
 (具 體)	ju4ti3
 (典 礼)	dian3li3
@@ -41777,7 +40921,6 @@ $textmode
 (养 分)	yang3fen4
 (养 地)	yang3di4
 (养 女)	yang3nv3
-(养 ㊛)	yang3nv3
 (养 女)	yang3nv3
 (养 子)	yang3zi3
 (养 母)	yang3mu3
@@ -41789,7 +40932,6 @@ $textmode
 (内 地)	nei4di4
 (内 场)	nei4chang3
 (内 有)	nei4you3
-(内 ㊒)	nei4you3
 (内 监)	nei4jian4
 (内 码)	nei4ma3
 (内 耳)	nei4er3
@@ -41821,9 +40963,7 @@ $textmode
 (冒 領)	mao4ling3
 (冒 领)	mao4ling3
 (写 法)	xie3fa3
-(㊢ 法)	xie3fa3
 (写 给)	xie3gei3
-(㊢ 给)	xie3gei3
 (军 务)	jun1wu4
 (军 委)	jun1wei3
 (军 旅)	jun1lv3
@@ -41832,7 +40972,6 @@ $textmode
 (军 港)	jun1gang3
 (军 演)	jun1yan3
 (军 火)	jun1huo3
-(军 ㊋)	jun1huo3
 (军 长)	jun1zhang3
 (农 产)	nong2chan3
 (农 地)	nong2di4
@@ -41858,7 +40997,6 @@ $textmode
 (冰 岛)	bing1dao3
 (冰 島)	bing1dao3
 (冰 水)	bing1shui3
-(冰 ㊌)	bing1shui3
 (冰 点)	bing1dian3
 (冰 點)	bing1dian3
 (冲 垮)	chong1kua3
@@ -41873,9 +41011,7 @@ $textmode
 (冷 冷)	leng3leng3
 (冷 冷)	leng3leng3
 (冷 水)	leng3shui3
-(冷 ㊌)	leng3shui3
 (冷 水)	leng3shui3
-(冷 ㊌)	leng3shui3
 (冷 清)	leng3qing5
 (冷 清)	leng3qing5
 (冷 眼)	leng3yan3
@@ -41897,11 +41033,9 @@ $textmode
 (冷 饮)	leng3yin3
 (冷 饮)	leng3yin3
 (冻 土)	dong4tu3
-(冻 ㊏)	dong4tu3
 (冻 死)	dong4si3
 (冻 雨)	dong4yu3
 (净 土)	jing4tu3
-(净 ㊏)	jing4tu3
 (凄 婉)	qi1wan3
 (凄 惋)	qi1wan3
 (凄 惨)	qi1can3
@@ -41913,14 +41047,11 @@ $textmode
 (准 得)	zhun3dei3
 (准 许)	zhun3xu3
 (凈 土)	jing4tu3
-(凈 ㊏)	jing4tu3
 (凈 盡)	jing4jin4
 (凉 快)	liang2kuai5
 (凉 快)	liang2kuai5
 (凉 水)	liang2shui3
-(凉 ㊌)	liang2shui3
 (凉 水)	liang2shui3
-(凉 ㊌)	liang2shui3
 (凉 爽)	liang2shuang3
 (凉 爽)	liang2shuang3
 (凌 晨)	ling2chen2
@@ -41931,7 +41062,6 @@ $textmode
 (凌 辱)	ling2ru3
 (凌 辱)	ling2ru3
 (凍 土)	dong4tu3
-(凍 ㊏)	dong4tu3
 (凍 死)	dong4si3
 (凍 雨)	dong4yu3
 (减 产)	jian3chan3
@@ -41972,14 +41102,12 @@ $textmode
 (凭 险)	ping2xian3
 (凯 尔)	kai3er3
 (凯 西)	kai3xi1
-(凯 🀂)	kai3xi1
 (凯 里)	kai3li3
 (凯 里)	kai3li3
 (凱 爾)	kai3er3
 (凱 裡)	kai3li3
 (凱 裡)	kai3li3
 (凱 西)	kai3xi1
-(凱 🀂)	kai3xi1
 (凶 党)	xiong1dang3
 (凶 手)	xiong1shou3
 (凶 死)	xiong1si3
@@ -42005,7 +41133,6 @@ $textmode
 (出 品)	chu1pin3
 (出 喪)	chu1sang1
 (出 土)	chu1tu3
-(出 ㊏)	chu1tu3
 (出 场)	chu1chang3
 (出 場)	chu1chang3
 (出 差)	chu1chai1
@@ -42016,7 +41143,6 @@ $textmode
 (出 来)	chu1lai5
 (出 榜)	chu1bang3
 (出 水)	chu1shui3
-(出 ㊌)	chu1shui3
 (出 沒)	chu1mo4
 (出 没)	chu1mo4
 (出 海)	chu1hai3
@@ -42025,7 +41151,6 @@ $textmode
 (出 溜)	chu1liu5
 (出 溜)	chu1liu5
 (出 火)	chu1huo3
-(出 ㊋)	chu1huo3
 (出 版)	chu1ban3
 (出 產)	chu1chan3
 (出 落)	chu1luo5
@@ -42043,8 +41168,6 @@ $textmode
 (出 馬)	chu1ma3
 (出 马)	chu1ma3
 (击 中)	ji1zhong4
-(击 🀄)	ji1zhong4
-(击 ㊥)	ji1zhong4
 (击 倒)	ji1dao3
 (击 打)	ji1da3
 (击 掌)	ji1zhang3
@@ -42094,11 +41217,7 @@ $textmode
 (分 量)	fen4liang4
 (分 點)	fen1dian3
 (切 中)	qie4zhong4
-(切 🀄)	qie4zhong4
-(切 ㊥)	qie4zhong4
 (切 中)	qie4zhong4
-(切 🀄)	qie4zhong4
-(切 ㊥)	qie4zhong4
 (切 割)	qie1ge1
 (切 割)	qie1ge1
 (切 去)	qie1qu4
@@ -42179,7 +41298,6 @@ $textmode
 (划 桨)	hua2jiang3
 (划 槳)	hua2jiang3
 (划 水)	hua2shui3
-(划 ㊌)	hua2shui3
 (划 痕)	hua2hen2
 (划 破)	hua2po4
 (划 算)	hua2suan4
@@ -42317,9 +41435,7 @@ $textmode
 (刺 骨)	ci4gu3
 (刺 骨)	ci4gu3
 (刻 上)	ke4shang5
-(刻 ㊤)	ke4shang5
 (刻 写)	ke4xie3
-(刻 ㊢)	ke4xie3
 (刻 寫)	ke4xie3
 (刻 本)	ke4ben3
 (刻 板)	ke4ban3
@@ -42364,7 +41480,6 @@ $textmode
 (剧 场)	ju4chang3
 (剧 本)	ju4ben3
 (剩 下)	sheng4xia5
-(剩 ㊦)	sheng4xia5
 (剪 切)	jian3qie1
 (剪 切)	jian3qie1
 (剪 发)	jian3fa4
@@ -42388,7 +41503,6 @@ $textmode
 (創 舉)	chuang4ju3
 (剿 匪)	jiao3fei3
 (劃 一)	hua4yi1
-(劃 ㊀)	hua4yi1
 (劃 價)	hua4jia4
 (劃 出)	hua4chu1
 (劃 分)	hua4fen1
@@ -42508,7 +41622,6 @@ $textmode
 (劲 草)	jing4cao3
 (劲 风)	jing4feng1
 (劳 苦)	lao2ku3
-(㊘ 苦)	lao2ku3
 (势 力)	shi4li5
 (势 力)	shi4li5
 (势 阱)	shi4jing3
@@ -42669,65 +41782,44 @@ $textmode
 (化 為)	hua4wei2
 (化 解)	hua4jie3
 (北 史)	bei3shi3
-(🀃 史)	bei3shi3
 (北 史)	bei3shi3
 (北 岛)	bei3dao3
-(🀃 岛)	bei3dao3
 (北 岛)	bei3dao3
 (北 島)	bei3dao3
-(🀃 島)	bei3dao3
 (北 島)	bei3dao3
 (北 斗)	bei3dou3
-(🀃 斗)	bei3dou3
 (北 斗)	bei3dou3
 (北 海)	bei3hai3
-(🀃 海)	bei3hai3
 (北 海)	bei3hai3
-(🀃 海)	bei3hai3
 (北 海)	bei3hai3
 (北 燕)	bei3yan1
-(🀃 燕)	bei3yan1
 (北 燕)	bei3yan1
 (北 緯)	bei3wei3
-(🀃 緯)	bei3wei3
 (北 緯)	bei3wei3
 (北 纬)	bei3wei3
-(🀃 纬)	bei3wei3
 (北 纬)	bei3wei3
 (北 美)	bei3mei3
-(🀃 美)	bei3mei3
 (北 美)	bei3mei3
 (匪 首)	fei3shou3
 (匯 劃)	hui4hua4
 (匯 款)	hui4kuan3
 (匯 水)	hui4shui3
-(匯 ㊌)	hui4shui3
 (匯 點)	hui4dian3
 (匹 馬)	pi3ma3
 (匹 马)	pi3ma3
 (医 务)	yi1wu4
-(㊩ 务)	yi1wu4
 (医 卜)	yi1bu3
-(㊩ 卜)	yi1bu3
 (匿 跡)	ni4ji4
 (匿 跡)	ni4ji4
 (匿 迹)	ni4ji4
 (匿 迹)	ni4ji4
 (區 劃)	qu1hua4
 (十 个)	shi2ge5
-(㊉ 个)	shi2ge5
 (十 九)	shi2jiu3
-(十 ㊈)	shi2jiu3
-(㊉ 九)	shi2jiu3
 (十 五)	shi2wu3
-(㊉ 五)	shi2wu3
-(十 ㊄)	shi2wu3
 (十 個)	shi2ge5
-(㊉ 個)	shi2ge5
 (十 几)	shi2ji3
-(㊉ 几)	shi2ji3
 (十 幾)	shi2ji3
-(㊉ 幾)	shi2ji3
 (千 卡)	qian1ka3
 (千 古)	qian1gu3
 (千 夫)	qian1fu1
@@ -42743,7 +41835,6 @@ $textmode
 (午 馬)	wu3ma3
 (午 马)	wu3ma3
 (半 上)	ban4shang3
-(半 ㊤)	ban4shang3
 (半 个)	ban4ge5
 (半 個)	ban4ge5
 (半 响)	ban4xiang3
@@ -42761,7 +41852,6 @@ $textmode
 (半 點)	ban4dian3
 (华 佗)	hua4tuo2
 (华 北)	hua2bei3
-(华 🀃)	hua2bei3
 (华 北)	hua2bei3
 (华 山)	hua4shan1
 (华 府)	hua2fu3
@@ -42783,15 +41873,10 @@ $textmode
 (卓 著)	zhuo2zhu4
 (卓 著)	zhuo2zhu4
 (協 理)	xie2li3
-(㊯ 理)	xie2li3
 (協 理)	xie2li3
-(㊯ 理)	xie2li3
 (協 管)	xie2guan3
-(㊯ 管)	xie2guan3
 (協 調)	xie2tiao2
-(㊯ 調)	xie2tiao2
 (協 調)	xie2tiao2
-(㊯ 調)	xie2tiao2
 (单 丛)	dong1cong2
 (单 于)	chan2yu2
 (单 体)	dan1ti3
@@ -42810,50 +41895,27 @@ $textmode
 (卖 点)	mai4dian3
 (卖 给)	mai4gei3
 (南 乐)	nan2yue4
-(🀁 乐)	nan2yue4
 (南 北)	nan2bei3
-(🀁 北)	nan2bei3
-(南 🀃)	nan2bei3
 (南 北)	nan2bei3
-(🀁 北)	nan2bei3
 (南 史)	nan2shi3
-(🀁 史)	nan2shi3
 (南 地)	nan2di4
-(🀁 地)	nan2di4
 (南 岛)	nan2dao3
-(🀁 岛)	nan2dao3
 (南 岭)	nan2ling3
-(🀁 岭)	nan2ling3
 (南 島)	nan2dao3
-(🀁 島)	nan2dao3
 (南 嶺)	nan2ling3
-(🀁 嶺)	nan2ling3
 (南 嶺)	nan2ling3
-(🀁 嶺)	nan2ling3
 (南 樂)	nan2yue4
-(🀁 樂)	nan2yue4
 (南 樂)	nan2yue4
-(🀁 樂)	nan2yue4
 (南 樂)	nan2yue4
-(🀁 樂)	nan2yue4
 (南 樂)	nan2yue4
-(🀁 樂)	nan2yue4
 (南 海)	nan2hai3
-(🀁 海)	nan2hai3
 (南 海)	nan2hai3
-(🀁 海)	nan2hai3
 (南 燕)	nan2yan1
-(🀁 燕)	nan2yan1
 (南 緯)	nan2wei3
-(🀁 緯)	nan2wei3
 (南 纬)	nan2wei3
-(🀁 纬)	nan2wei3
 (南 美)	nan2mei3
-(🀁 美)	nan2mei3
 (南 边)	nan2bian5
-(🀁 边)	nan2bian5
 (南 邊)	nan2bian5
-(🀁 邊)	nan2bian5
 (博 兴)	bo2xing1
 (博 取)	bo2qu3
 (博 古)	bo2gu3
@@ -42886,7 +41948,6 @@ $textmode
 (占 卜)	zhan1bu3
 (占 星)	zhan1xing1
 (占 有)	zhan4you3
-(占 ㊒)	zhan4you3
 (占 領)	zhan4ling3
 (占 領)	zhan4ling3
 (占 领)	zhan4ling3
@@ -42897,7 +41958,6 @@ $textmode
 (卢 比)	lu2bi3
 (卤 属)	lu3shu3
 (卤 水)	lu3shui3
-(卤 ㊌)	lu3shui3
 (卤 法)	lu3fa3
 (卤 莽)	lu3mang3
 (卧 佛)	wo4fo2
@@ -42908,11 +41968,8 @@ $textmode
 (卫 冕)	wei4mian3
 (卯 榫)	mao3sun3
 (印 巴)	yin4ba1
-(㊞ 巴)	yin4ba1
 (印 染)	yin4ran3
-(㊞ 染)	yin4ran3
 (印 版)	yin4ban3
-(㊞ 版)	yin4ban3
 (危 笃)	wei1du3
 (危 篤)	wei1du3
 (危 险)	wei1xian3
@@ -42934,7 +41991,6 @@ $textmode
 (卵 子)	luan3zi3
 (卷 发)	quan2fa4
 (卷 宗)	juan4zong1
-(卷 ㊪)	juan4zong1
 (卷 尺)	juan3chi3
 (卷 走)	juan3zou3
 (卷 起)	juan3qi3
@@ -42980,7 +42036,6 @@ $textmode
 (原 委)	yuan2wei3
 (原 子)	yuan2zi3
 (原 有)	yuan2you3
-(原 ㊒)	yuan2you3
 (原 本)	yuan2ben3
 (原 点)	yuan2dian3
 (原 為)	yuan2wei2
@@ -43064,7 +42119,6 @@ $textmode
 (反 掌)	fan3zhang3
 (反 比)	fan3bi3
 (反 水)	fan3shui3
-(反 ㊌)	fan3shui3
 (反 演)	fan3yan3
 (反 省)	fan3xing3
 (反 省)	fan3xing3
@@ -43098,7 +42152,6 @@ $textmode
 (发 抖)	fa1dou3
 (发 泡)	fa1pao2
 (发 火)	fa1huo3
-(发 ㊋)	fa1huo3
 (发 痒)	fa1yang3
 (发 窘)	fa1jiong3
 (发 粉)	fa4fen3
@@ -43121,7 +42174,6 @@ $textmode
 (叔 祖)	shu1zu3
 (叔 祖)	shu1zu3
 (取 下)	qu3xia5
-(取 ㊦)	qu3xia5
 (取 巧)	qu3qiao3
 (取 得)	qu3de2
 (取 捨)	qu3she3
@@ -43186,11 +42238,9 @@ $textmode
 (叛 黨)	pan4dang3
 (叠 起)	die2qi3
 (口 北)	kou3bei3
-(口 🀃)	kou3bei3
 (口 北)	kou3bei3
 (口 感)	kou3gan3
 (口 水)	kou3shui3
-(口 ㊌)	kou3shui3
 (口 渴)	kou3ke3
 (口 給)	kou3ji3
 (口 给)	kou3ji3
@@ -43223,7 +42273,6 @@ $textmode
 (句 首)	ju4shou3
 (句 首)	ju4shou3
 (另 有)	ling4you3
-(另 ㊒)	ling4you3
 (叨 唠)	dao1lao5
 (叨 嘮)	dao1lao5
 (叩 首)	kou4shou3
@@ -43232,7 +42281,6 @@ $textmode
 (只 得)	zhi3de2
 (只 手)	zhi1shou3
 (只 有)	zhi3you3
-(只 ㊒)	zhi3you3
 (只 眼)	zhi1yan3
 (只 管)	zhi3guan3
 (只 許)	zhi3xu3
@@ -43246,7 +42294,6 @@ $textmode
 (叫 横)	jiao4heng4
 (叫 橫)	jiao4heng4
 (叫 水)	jiao4shui3
-(叫 ㊌)	jiao4shui3
 (叫 法)	jiao4fa3
 (叫 醒)	jiao4xing3
 (叮 咬)	ding1yao3
@@ -43281,7 +42328,6 @@ $textmode
 (可 调)	ke3tiao2
 (可 鄙)	ke3bi3
 (台 北)	tai2bei3
-(台 🀃)	tai2bei3
 (台 北)	tai2bei3
 (台 地)	tai2di4
 (台 州)	tai1zhou1
@@ -43296,17 +42342,11 @@ $textmode
 (史 传)	shi3zhuan4
 (史 傳)	shi3zhuan4
 (右 手)	you4shou3
-(㊨ 手)	you4shou3
 (右 脚)	you4jiao3
-(㊨ 脚)	you4jiao3
 (右 腳)	you4jiao3
-(㊨ 腳)	you4jiao3
 (右 腿)	you4tui3
-(㊨ 腿)	you4tui3
 (右 边)	you4bian5
-(㊨ 边)	you4bian5
 (右 邊)	you4bian5
-(㊨ 邊)	you4bian5
 (叶 挺)	ye4ting3
 (叶 枕)	ye4zhen3
 (叶 柄)	ye4bing3
@@ -43325,7 +42365,6 @@ $textmode
 (叹 息)	tan4xi1
 (叹 赏)	tan4shang3
 (吃 上)	chi1shang5
-(吃 ㊤)	chi1shang5
 (吃 主)	chi1zhu3
 (吃 儿)	chi1r5
 (吃 头)	chi1tou5
@@ -43352,7 +42391,6 @@ $textmode
 (吆 喝)	yao1he5
 (吆 喝)	yao1he5
 (合 上)	he2shang5
-(合 ㊤)	he2shang5
 (合 为)	he2wei2
 (合 乎)	he2hu1
 (合 伙)	he2huo3
@@ -43367,7 +42405,6 @@ $textmode
 (合 攏)	he2long3
 (合 於)	he2yu2
 (合 水)	he2shui3
-(合 ㊌)	he2shui3
 (合 法)	he2fa3
 (合 浦)	he2pu3
 (合 演)	he2yan3
@@ -43387,7 +42424,6 @@ $textmode
 (吉 他)	ji2ta5
 (吉 普)	ji2pu3
 (吉 水)	ji2shui3
-(吉 ㊌)	ji2shui3
 (吉 珥)	ji2er3
 (吉 甲)	ji2jia3
 (吉 野)	ji2ye3
@@ -43417,41 +42453,23 @@ $textmode
 (同 等)	tong2deng3
 (同 黨)	tong2dang3
 (名 为)	ming2wei2
-(㊔ 为)	ming2wei2
 (名 产)	ming2chan3
-(㊔ 产)	ming2chan3
 (名 分)	ming2fen4
-(㊔ 分)	ming2fen4
 (名 堂)	ming2tang5
-(㊔ 堂)	ming2tang5
 (名 字)	ming2zi5
-(㊔ 字)	ming2zi5
 (名 将)	ming2jiang4
-(㊔ 将)	ming2jiang4
 (名 將)	ming2jiang4
-(㊔ 將)	ming2jiang4
 (名 帖)	ming2tie3
-(㊔ 帖)	ming2tie3
 (名 手)	ming2shou3
-(㊔ 手)	ming2shou3
 (名 曲)	ming2qu3
-(㊔ 曲)	ming2qu3
 (名 气)	ming2qi5
-(㊔ 气)	ming2qi5
 (名 氣)	ming2qi5
-(㊔ 氣)	ming2qi5
 (名 為)	ming2wei2
-(㊔ 為)	ming2wei2
 (名 產)	ming2chan3
-(㊔ 產)	ming2chan3
 (名 著)	ming2zhu4
-(㊔ 著)	ming2zhu4
 (名 著)	ming2zhu4
-(㊔ 著)	ming2zhu4
 (名 角)	ming2jue2
-(㊔ 角)	ming2jue2
 (名 酒)	ming2jiu3
-(㊔ 酒)	ming2jiu3
 (后 冠)	hou4guan1
 (后 头)	hou4tou5
 (后 影)	hou4ying3
@@ -43471,20 +42489,16 @@ $textmode
 (吐 诉)	tu3su4
 (向 使)	xiang4shi3
 (向 北)	xiang4bei3
-(向 🀃)	xiang4bei3
 (向 北)	xiang4bei3
 (向 导)	xiang4dao3
 (向 導)	xiang4dao3
 (向 左)	xiang4zuo3
-(向 ㊧)	xiang4zuo3
 (向 往)	xiang4wang3
 (向 晚)	xiang4wan3
 (向 海)	xiang4hai3
 (向 海)	xiang4hai3
 (向 火)	xiang4huo3
-(向 ㊋)	xiang4huo3
 (向 西)	xiang4xi1
-(向 🀂)	xiang4xi1
 (吓 倒)	xia4dao3
 (吓 傻)	xia4sha3
 (吓 声)	he4sheng1
@@ -43503,11 +42517,8 @@ $textmode
 (吧 台)	ba1tai2
 (吩 咐)	fen1fu4
 (含 有)	han2you3
-(含 ㊒)	han2you3
 (含 水)	han2shui3
-(含 ㊌)	han2shui3
 (听 写)	ting1xie3
-(听 ㊢)	ting1xie3
 (听 取)	ting1qu3
 (听 听)	ting1ting5
 (听 头)	ting1tou5
@@ -43534,7 +42545,6 @@ $textmode
 (吸 引)	xi1yin3
 (吸 氧)	xi1yang3
 (吸 水)	xi1shui3
-(吸 ㊌)	xi1shui3
 (吸 盡)	xi1jin4
 (吸 着)	xi1zhuo2
 (吸 着)	xi1zhuo2
@@ -43547,7 +42557,6 @@ $textmode
 (吹 打)	chui1da3
 (吹 捧)	chui1peng3
 (吹 火)	chui1huo3
-(吹 ㊋)	chui1huo3
 (吹 走)	chui1zou3
 (吹 響)	chui1xiang3
 (吹 響)	chui1xiang3
@@ -43569,7 +42578,6 @@ $textmode
 (呜 咽)	wu1ye4
 (呢 喃)	ni2nan2
 (周 五)	zhou1wu3
-(周 ㊄)	zhou1wu3
 (周 到)	zhou1dao5
 (周 口)	zhou1kou3
 (周 礼)	zhou1li3
@@ -43612,8 +42620,6 @@ $textmode
 (呼 瑪)	hu1ma3
 (呼 號)	hu1hao2
 (命 中)	ming4zhong4
-(命 🀄)	ming4zhong4
-(命 ㊥)	ming4zhong4
 (咆 哮)	pao2xiao4
 (咋 不)	zha1bu5
 (咋 不)	zha1bu5
@@ -43650,7 +42656,6 @@ $textmode
 (咬 死)	yao3si3
 (咳 嗽)	ke2sou5
 (咸 水)	xian2shui3
-(咸 ㊌)	xian2shui3
 (咸 海)	xian2hai3
 (咸 海)	xian2hai3
 (咸 草)	xian2cao3
@@ -43699,7 +42704,6 @@ $textmode
 (响 声)	xiang3sheng5
 (响 应)	xiang3ying4
 (响 水)	xiang3shui3
-(响 ㊌)	xiang3shui3
 (响 起)	xiang3qi3
 (哎 呀)	ai1ya1
 (哑 鼓)	ya3gu3
@@ -43716,7 +42720,6 @@ $textmode
 (哪 儿)	na3r5
 (哪 吒)	ne2zha1
 (哪 有)	na3you3
-(哪 ㊒)	na3you3
 (哪 裏)	na3li3
 (哪 裏)	na3li3
 (哪 里)	na3li5
@@ -43760,7 +42763,6 @@ $textmode
 (商 旅)	shang1lv3
 (商 旅)	shang1lv3
 (商 水)	shang1shui3
-(商 ㊌)	shang1shui3
 (商 港)	shang1gang3
 (商 討)	shang1tao3
 (商 讨)	shang1tao3
@@ -43815,11 +42817,8 @@ $textmode
 (喝 彩)	he4cai3
 (喝 彩)	he4cai3
 (喝 水)	he1shui3
-(喝 ㊌)	he1shui3
 (喝 水)	he1shui3
-(喝 ㊌)	he1shui3
 (喝 水)	he1shui3
-(喝 ㊌)	he1shui3
 (喝 酒)	he1jiu3
 (喝 酒)	he1jiu3
 (喝 酒)	he1jiu3
@@ -43957,21 +42956,13 @@ $textmode
 (囊 腫)	nang2zhong3
 (囊 膪)	nang1chuai4
 (四 个)	si4ge5
-(㊃ 个)	si4ge5
 (四 体)	si4ti3
-(㊃ 体)	si4ti3
 (四 個)	si4ge5
-(㊃ 個)	si4ge5
 (四 地)	si4di5
-(㊃ 地)	si4di5
 (四 百)	si4bai3
-(㊃ 百)	si4bai3
 (四 角)	si4jiao3
-(㊃ 角)	si4jiao3
 (四 起)	si4qi3
-(㊃ 起)	si4qi3
 (四 體)	si4ti3
-(㊃ 體)	si4ti3
 (回 來)	hui2lai5
 (回 來)	hui2lai5
 (回 去)	hui2qu5
@@ -43983,7 +42974,6 @@ $textmode
 (回 暖)	hui2nuan3
 (回 来)	hui2lai5
 (回 火)	hui2huo3
-(回 ㊋)	hui2huo3
 (回 礼)	hui2li3
 (回 礼)	hui2li3
 (回 禀)	hui2bing3
@@ -44034,18 +43024,14 @@ $textmode
 (固 始)	gu4shi3
 (固 守)	gu4shou3
 (固 有)	gu4you3
-(固 ㊒)	gu4you3
 (固 體)	gu4ti3
 (国 乐)	guo2yue4
 (国 产)	guo2chan3
 (国 企)	guo2qi3
-(国 ㊭)	guo2qi3
 (国 史)	guo2shi3
 (国 土)	guo2tu3
-(国 ㊏)	guo2tu3
 (国 宝)	guo2bao3
 (国 有)	guo2you3
-(国 ㊒)	guo2you3
 (国 法)	guo2fa3
 (国 玺)	guo2xi3
 (国 美)	guo2mei3
@@ -44067,14 +43053,11 @@ $textmode
 (圆 饼)	yuan2bing3
 (圈 地)	quan1di4
 (國 企)	guo2qi3
-(國 ㊭)	guo2qi3
 (國 史)	guo2shi3
 (國 土)	guo2tu3
-(國 ㊏)	guo2tu3
 (國 寶)	guo2bao3
 (國 恥)	guo2chi3
 (國 有)	guo2you3
-(國 ㊒)	guo2you3
 (國 樂)	guo2yue4
 (國 樂)	guo2yue4
 (國 樂)	guo2yue4
@@ -44110,25 +43093,15 @@ $textmode
 (團 長)	tuan2zhang3
 (團 體)	tuan2ti3
 (土 产)	tu3chan3
-(㊏ 产)	tu3chan3
 (土 匪)	tu3fei3
-(㊏ 匪)	tu3fei3
 (土 地)	tu3di4
-(㊏ 地)	tu3di4
 (土 壤)	tu3rang3
-(㊏ 壤)	tu3rang3
 (土 岗)	tu3gang3
-(㊏ 岗)	tu3gang3
 (土 崗)	tu3gang3
-(㊏ 崗)	tu3gang3
 (土 狗)	tu3gou3
-(㊏ 狗)	tu3gou3
 (土 產)	tu3chan3
-(㊏ 產)	tu3chan3
 (土 著)	tu3zhu4
-(㊏ 著)	tu3zhu4
 (土 著)	tu3zhu4
-(㊏ 著)	tu3zhu4
 (圣 体)	sheng4ti3
 (圣 地)	sheng4di4
 (圣 子)	sheng4zi3
@@ -44137,10 +43110,8 @@ $textmode
 (圣 旨)	sheng4zhi3
 (圣 母)	sheng4mu3
 (圣 水)	sheng4shui3
-(圣 ㊌)	sheng4shui3
 (圣 洗)	sheng4xi3
 (圣 火)	sheng4huo3
-(圣 ㊋)	sheng4huo3
 (圣 礼)	sheng4li3
 (圣 礼)	sheng4li3
 (圣 者)	sheng4zhe3
@@ -44157,9 +43128,7 @@ $textmode
 (在 行)	zai4hang2
 (在 野)	zai4ye3
 (地 上)	di4shang5
-(地 ㊤)	di4shang5
 (地 下)	di4xia4
-(地 ㊦)	di4xia4
 (地 主)	di4zhu3
 (地 产)	di4chan3
 (地 亩)	di4mu3
@@ -44175,11 +43144,9 @@ $textmode
 (地 區)	di4qu1
 (地 史)	di4shi3
 (地 名)	di4ming2
-(地 ㊔)	di4ming2
 (地 图)	di4tu2
 (地 圖)	di4tu2
 (地 土)	di4tu3
-(地 ㊏)	di4tu3
 (地 址)	di4zhi3
 (地 块)	di4kuai4
 (地 坛)	di4tan2
@@ -44304,7 +43271,6 @@ $textmode
 (坏 死)	huai4si3
 (坏 种)	huai4zhong3
 (坐 下)	zuo4xia5
-(坐 ㊦)	zuo4xia5
 (坐 地)	zuo4di4
 (坐 好)	zuo4hao3
 (坐 椅)	zuo4yi3
@@ -44354,7 +43320,6 @@ $textmode
 (執 著)	zhi2zhuo2
 (培 养)	pei2yang3
 (培 土)	pei2tu3
-(培 ㊏)	pei2tu3
 (培 養)	pei2yang3
 (基 准)	ji1zhun3
 (基 地)	ji1di4
@@ -44378,7 +43343,6 @@ $textmode
 (基 脚)	ji1jiao3
 (基 腳)	ji1jiao3
 (基 西)	ji1xi1
-(基 🀂)	ji1xi1
 (基 輔)	ji1fu3
 (基 辅)	ji1fu3
 (基 點)	ji1dian3
@@ -44433,9 +43397,7 @@ $textmode
 (塞 滿)	sai1man3
 (塞 滿)	sai1man3
 (塞 特)	sai4te4
-(塞 ㊕)	sai4te4
 (塞 特)	sai4te4
-(塞 ㊕)	sai4te4
 (塞 給)	sai1gei3
 (塞 給)	sai1gei3
 (塞 给)	sai1gei3
@@ -44445,7 +43407,6 @@ $textmode
 (塞 语)	sai1yu3
 (塞 语)	sai1yu3
 (填 写)	tian2xie3
-(填 ㊢)	tian2xie3
 (填 堵)	tian2du3
 (填 寫)	tian2xie3
 (填 海)	tian2hai3
@@ -44460,14 +43421,12 @@ $textmode
 (填 饱)	tian2bao3
 (塬 地)	yuan2di4
 (塵 土)	chen2tu3
-(塵 ㊏)	chen2tu3
 (境 地)	jing4di4
 (墊 圈)	dian4juan4
 (墊 款)	dian4kuan3
 (墊 腳)	dian4jiao5
 (墊 補)	dian4bu5
 (墒 土)	shang1tu3
-(墒 ㊏)	shang1tu3
 (墓 主)	mu4zhu3
 (墓 地)	mu4di4
 (墓 塔)	mu4ta3
@@ -44491,9 +43450,7 @@ $textmode
 (墨 斗)	mo4dou3
 (墨 斗)	mo4dou3
 (墨 水)	mo4shui3
-(墨 ㊌)	mo4shui3
 (墨 水)	mo4shui3
-(墨 ㊌)	mo4shui3
 (墨 笔)	mo4bi3
 (墨 笔)	mo4bi3
 (墨 筆)	mo4bi3
@@ -44526,7 +43483,6 @@ $textmode
 (壞 種)	huai4zhong3
 (壞 處)	huai4chu5
 (壤 土)	rang3tu3
-(壤 ㊏)	rang3tu3
 (壬 午)	ren2wu3
 (壬 子)	ren2zi3
 (壮 举)	zhuang4ju3
@@ -44552,7 +43508,6 @@ $textmode
 (处 在)	chu3zai4
 (处 境)	chu3jing4
 (处 女)	chu3nv3
-(处 ㊛)	chu3nv3
 (处 女)	chu3nv3
 (处 所)	chu4suo3
 (处 方)	chu3fang1
@@ -44563,7 +43518,6 @@ $textmode
 (处 理)	chu3li3
 (处 理)	chu3li3
 (处 男)	chu3nan2
-(处 ㊚)	chu3nan2
 (处 罚)	chu3fa2
 (处 置)	chu3zhi4
 (处 身)	chu3shen1
@@ -44571,11 +43525,9 @@ $textmode
 (备 品)	bei4pin3
 (备 抵)	bei4di3
 (备 有)	bei4you3
-(备 ㊒)	bei4you3
 (备 考)	bei4kao3
 (复 兴)	fu4xing1
 (复 写)	fu4xie3
-(复 ㊢)	fu4xie3
 (复 古)	fu4gu3
 (复 审)	fu4shen3
 (复 本)	fu4ben3
@@ -44589,7 +43541,6 @@ $textmode
 (夏 甲)	xia4jia3
 (夏 衍)	xia4yan3
 (外 企)	wai4qi3
-(外 ㊭)	wai4qi3
 (外 典)	wai4dian3
 (外 务)	wai4wu4
 (外 務)	wai4wu4
@@ -44653,21 +43604,13 @@ $textmode
 (多 马)	duo1ma3
 (多 黨)	duo1dang3
 (夜 叉)	ye4cha5
-(㊰ 叉)	ye4cha5
 (夜 晚)	ye4wan3
-(㊰ 晚)	ye4wan3
 (夜 景)	ye4jing3
-(㊰ 景)	ye4jing3
 (夜 曲)	ye4qu3
-(㊰ 曲)	ye4qu3
 (夜 里)	ye4li5
-(㊰ 里)	ye4li5
 (夜 里)	ye4li5
-(㊰ 里)	ye4li5
 (夜 鳥)	ye4niao3
-(㊰ 鳥)	ye4niao3
 (夜 鸟)	ye4niao3
-(㊰ 鸟)	ye4niao3
 (夢 想)	meng4xiang3
 (夢 景)	meng4jing3
 (夢 見)	meng4jian5
@@ -44684,7 +43627,6 @@ $textmode
 (大 偉)	da4wei3
 (大 兴)	da4xing1
 (大 写)	da4xie3
-(大 ㊢)	da4xie3
 (大 冶)	da4ye3
 (大 勇)	da4yong3
 (大 勇)	da4yong3
@@ -44721,15 +43663,12 @@ $textmode
 (大 暑)	da4shu3
 (大 暑)	da4shu3
 (大 有)	da4you3
-(大 ㊒)	da4you3
 (大 桶)	da4tong3
 (大 比)	da4bi3
 (大 水)	da4shui3
-(大 ㊌)	da4shui3
 (大 海)	da4hai3
 (大 海)	da4hai3
 (大 火)	da4huo3
-(大 ㊋)	da4huo3
 (大 為)	da4wei2
 (大 爷)	da4ye2
 (大 爺)	da4ye2
@@ -44792,7 +43731,6 @@ $textmode
 (天 子)	tian1zi3
 (天 府)	tian1fu3
 (天 水)	tian1shui3
-(天 ㊌)	tian1shui3
 (天 演)	tian1yan3
 (天 等)	tian1deng3
 (天 篷)	tian1peng2
@@ -44824,7 +43762,6 @@ $textmode
 (央 行)	yang1hang2
 (央 行)	yang1hang2
 (夯 土)	hang1tu3
-(夯 ㊏)	hang1tu3
 (失 主)	shi1zhu3
 (失 口)	shi1kou3
 (失 地)	shi1di4
@@ -44839,7 +43776,6 @@ $textmode
 (失 欢)	shi1huan1
 (失 歡)	shi1huan1
 (失 火)	shi1huo3
-(失 ㊋)	shi1huo3
 (失 當)	shi1dang4
 (失 着)	shi1zhao1
 (失 着)	shi1zhao1
@@ -44969,33 +43905,24 @@ $textmode
 (奮 勇)	fen4yong3
 (奮 起)	fen4qi3
 (女 傭)	nv3yong1
-(㊛ 傭)	nv3yong1
 (女 傭)	nv3yong1
 (女 兒)	nv3er2
-(㊛ 兒)	nv3er2
 (女 兒)	nv3er2
 (女 友)	nv3you3
-(㊛ 友)	nv3you3
 (女 友)	nv3you3
 (女 婿)	nv3xu5
-(㊛ 婿)	nv3xu5
 (女 婿)	nv3xu5
 (女 子)	nv3zi3
-(㊛ 子)	nv3zi3
 (女 子)	nv3zi3
 (女 紅)	nv3gong1
-(㊛ 紅)	nv3gong1
 (女 紅)	nv3gong1
 (女 红)	nv3gong1
-(㊛ 红)	nv3gong1
 (女 红)	nv3gong1
 (女 警)	nv3jing3
-(㊛ 警)	nv3jing3
 (女 警)	nv3jing3
 (奶 嘴)	nai3zui3
 (奶 奶)	nai3nai5
 (奶 水)	nai3shui3
-(奶 ㊌)	nai3shui3
 (奶 粉)	nai3fen3
 (奸 党)	jian1dang3
 (奸 夫)	jian1fu1
@@ -45018,7 +43945,6 @@ $textmode
 (好 奇)	hao4qi2
 (好 好)	hao3hao1
 (好 学)	hao4xue2
-(好 ㊫)	hao4xue2
 (好 學)	hao4xue2
 (好 客)	hao4ke4
 (好 幾)	hao3ji3
@@ -45043,11 +43969,9 @@ $textmode
 (好 辯)	hao4bian4
 (好 鬥)	hao4dou4
 (如 有)	ru2you3
-(如 ㊒)	ru2you3
 (如 果)	ru2guo3
 (如 此)	ru2ci3
 (如 火)	ru2huo3
-(如 ㊋)	ru2huo3
 (如 草)	ru2cao3
 (妄 为)	wang4wei2
 (妄 取)	wang4qu3
@@ -45056,7 +43980,6 @@ $textmode
 (妄 語)	wang4yu3
 (妄 语)	wang4yu3
 (妇 女)	fu4nv3
-(妇 ㊛)	fu4nv3
 (妇 女)	fu4nv3
 (妇 道)	fu4dao5
 (妈 咪)	ma1mi5
@@ -45064,7 +43987,6 @@ $textmode
 (妈 祖)	ma1zu3
 (妈 祖)	ma1zu3
 (妓 女)	ji4nv3
-(妓 ㊛)	ji4nv3
 (妓 女)	ji4nv3
 (妖 冶)	yao1ye3
 (妖 精)	yao1jing5
@@ -45100,7 +44022,6 @@ $textmode
 (姨 母)	yi2mu3
 (姨 父)	yi2fu5
 (姪 女)	zhi2nv3
-(姪 ㊛)	zhi2nv3
 (姪 女)	zhi2nv3
 (威 吓)	wei1he4
 (威 嚇)	wei1he4
@@ -45124,7 +44045,6 @@ $textmode
 (娜 亞)	nuo2ya4
 (娩 痛)	mian3tong4
 (娼 女)	chang1nv3
-(娼 ㊛)	chang1nv3
 (娼 女)	chang1nv3
 (婀 娜)	e1nuo2
 (婁 底)	lou2di3
@@ -45137,12 +44057,9 @@ $textmode
 (婚 禮)	hun1li3
 (婚 禮)	hun1li3
 (婢 女)	bi4nv3
-(婢 ㊛)	bi4nv3
 (婢 女)	bi4nv3
-(婢 ㊛)	bi4nv3
 (婢 女)	bi4nv3
 (婦 女)	fu4nv3
-(婦 ㊛)	fu4nv3
 (婦 女)	fu4nv3
 (婦 道)	fu4dao5
 (婶 婶)	shen3shen5
@@ -45178,9 +44095,7 @@ $textmode
 (子 代)	zi3dai4
 (子 叶)	zi3ye4
 (子 夜)	zi3ye4
-(子 ㊰)	zi3ye4
 (子 女)	zi3nv3
-(子 ㊛)	zi3nv3
 (子 女)	zi3nv3
 (子 孙)	zi3sun1
 (子 孫)	zi3sun1
@@ -45238,10 +44153,8 @@ $textmode
 (存 儲)	cun2chu3
 (存 取)	cun2qu3
 (存 有)	cun2you3
-(存 ㊒)	cun2you3
 (存 款)	cun2kuan3
 (孙 女)	sun1nv3
-(孙 ㊛)	sun1nv3
 (孙 女)	sun1nv3
 (孙 子)	sun1zi3
 (孙 武)	sun1wu3
@@ -45260,27 +44173,16 @@ $textmode
 (孤 膽)	gu1dan3
 (孤 苦)	gu1ku3
 (学 好)	xue2hao3
-(㊫ 好)	xue2hao3
 (学 府)	xue2fu3
-(㊫ 府)	xue2fu3
 (学 海)	xue2hai3
-(㊫ 海)	xue2hai3
 (学 海)	xue2hai3
-(㊫ 海)	xue2hai3
 (学 生)	xue2sheng5
-(㊫ 生)	xue2sheng5
 (学 者)	xue2zhe3
-(㊫ 者)	xue2zhe3
 (学 者)	xue2zhe3
-(㊫ 者)	xue2zhe3
 (学 者)	xue2zhe3
-(㊫ 者)	xue2zhe3
 (学 识)	xue2shi2
-(㊫ 识)	xue2shi2
 (学 问)	xue2wen5
-(㊫ 问)	xue2wen5
 (孫 女)	sun1nv3
-(孫 ㊛)	sun1nv3
 (孫 女)	sun1nv3
 (孫 子)	sun1zi3
 (孫 武)	sun1wu3
@@ -45319,7 +44221,6 @@ $textmode
 (守 分)	shou3fen4
 (守 喪)	shou3sang1
 (守 土)	shou3tu3
-(守 ㊏)	shou3tu3
 (守 寡)	shou3gua3
 (守 更)	shou3geng1
 (守 更)	shou3geng1
@@ -45340,7 +44241,6 @@ $textmode
 (安 稳)	an1wen3
 (安 穩)	an1wen3
 (安 西)	an1xi1
-(安 🀂)	an1xi1
 (安 远)	an1yuan3
 (安 遠)	an1yuan3
 (宋 体)	song4ti3
@@ -45354,7 +44254,6 @@ $textmode
 (宏 伟)	hong2wei3
 (宏 偉)	hong2wei3
 (宗 旨)	zong1zhi3
-(㊪ 旨)	zong1zhi3
 (官 倒)	guan1dao3
 (官 司)	guan1si5
 (官 场)	guan1chang3
@@ -45387,7 +44286,6 @@ $textmode
 (定 禮)	ding4li3
 (定 興)	ding4xing1
 (定 西)	ding4xi1
-(定 🀂)	ding4xi1
 (定 語)	ding4yu3
 (定 语)	ding4yu3
 (定 远)	ding4yuan3
@@ -45429,11 +44327,9 @@ $textmode
 (实 务)	shi2wu4
 (实 地)	shi2di4
 (实 女)	shi2nv3
-(实 ㊛)	shi2nv3
 (实 女)	shi2nv3
 (实 干)	shi2gan4
 (实 有)	shi2you3
-(实 ㊒)	shi2you3
 (实 肘)	shi2zhou3
 (审 处)	shen3chu3
 (审 干)	shen3gan4
@@ -45458,19 +44354,16 @@ $textmode
 (宣 讲)	xuan1jiang3
 (室 友)	shi4you3
 (室 女)	shi4nv3
-(室 ㊛)	shi4nv3
 (室 女)	shi4nv3
 (室 町)	shi4ting3
 (宦 海)	huan4hai3
 (宦 海)	huan4hai3
 (宪 法)	xian4fa3
 (宫 女)	gong1nv3
-(宫 ㊛)	gong1nv3
 (宫 女)	gong1nv3
 (宫 阙)	gong1que4
 (宫 颈)	gong1jing3
 (宮 女)	gong1nv3
-(宮 ㊛)	gong1nv3
 (宮 女)	gong1nv3
 (宮 闕)	gong1que4
 (宮 頸)	gong1jing3
@@ -45562,7 +44455,6 @@ $textmode
 (富 態)	fu4tai5
 (富 於)	fu4yu2
 (富 有)	fu4you3
-(富 ㊒)	fu4you3
 (富 給)	fu4ji3
 (富 给)	fu4ji3
 (富 錦)	fu4jin3
@@ -45581,10 +44473,8 @@ $textmode
 (實 務)	shi2wu4
 (實 地)	shi2di4
 (實 女)	shi2nv3
-(實 ㊛)	shi2nv3
 (實 女)	shi2nv3
 (實 有)	shi2you3
-(實 ㊒)	shi2you3
 (實 肘)	shi2zhou3
 (實 體)	shi2ti3
 (寧 可)	ning4ke3
@@ -45664,7 +44554,6 @@ $textmode
 (对 本)	dui4ben3
 (对 比)	dui4bi3
 (对 火)	dui4huo3
-(对 ㊋)	dui4huo3
 (对 相)	dui4xiang4
 (对 眼)	dui4yan3
 (对 称)	dui4chen4
@@ -45689,19 +44578,15 @@ $textmode
 (寿 险)	shou4xian3
 (封 口)	feng1kou3
 (封 土)	feng1tu3
-(封 ㊏)	feng1tu3
 (封 地)	feng1di4
 (封 底)	feng1di3
 (封 港)	feng1gang3
 (封 火)	feng1huo3
-(封 ㊋)	feng1huo3
 (封 鎖)	feng1suo3
 (封 锁)	feng1suo3
 (封 頂)	feng1ding3
 (封 顶)	feng1ding3
 (射 中)	she4zhong4
-(射 🀄)	she4zhong4
-(射 ㊥)	she4zhong4
 (射 影)	she4ying3
 (射 手)	she4shou3
 (将 士)	jiang4shi4
@@ -45721,7 +44606,6 @@ $textmode
 (將 領)	jiang4ling3
 (專 好)	zhuan1hao4
 (專 有)	zhuan1you3
-(專 ㊒)	zhuan1you3
 (專 款)	zhuan1kuan3
 (專 管)	zhuan1guan3
 (專 著)	zhuan1zhu4
@@ -45758,7 +44642,6 @@ $textmode
 (對 比)	dui4bi3
 (對 準)	dui4zhun3
 (對 火)	dui4huo3
-(對 ㊋)	dui4huo3
 (對 相)	dui4xiang4
 (對 眼)	dui4yan3
 (對 稱)	dui4chen4
@@ -45773,11 +44656,9 @@ $textmode
 (小 传)	xiao3zhuan4
 (小 傳)	xiao3zhuan4
 (小 写)	xiao3xie3
-(小 ㊢)	xiao3xie3
 (小 卒)	xiao3zu2
 (小 品)	xiao3pin3
 (小 女)	xiao3nv3
-(小 ㊛)	xiao3nv3
 (小 女)	xiao3nv3
 (小 寫)	xiao3xie3
 (小 小)	xiao3xiao3
@@ -45813,7 +44694,6 @@ $textmode
 (少 壮)	shao4zhuang4
 (少 壯)	shao4zhuang4
 (少 女)	shao4nv3
-(少 ㊛)	shao4nv3
 (少 女)	shao4nv3
 (少 妇)	shao4fu4
 (少 婦)	shao4fu4
@@ -45823,12 +44703,10 @@ $textmode
 (少 年)	shao4nian2
 (少 年)	shao4nian2
 (少 有)	shao3you3
-(少 ㊒)	shao3you3
 (少 林)	shao4lin2
 (少 林)	shao4lin2
 (少 校)	shao4xiao4
 (少 男)	shao4nan2
-(少 ㊚)	shao4nan2
 (少 給)	shao3gei3
 (少 给)	shao3gei3
 (尔 雅)	er3ya3
@@ -45836,7 +44714,6 @@ $textmode
 (尖 頂)	jian1ding3
 (尖 顶)	jian1ding3
 (尘 土)	chen2tu3
-(尘 ㊏)	chen2tu3
 (尚 且)	shang4qie3
 (尝 尝)	chang2chang5
 (尤 坎)	you2kan3
@@ -45878,7 +44755,6 @@ $textmode
 (尽 量)	jin3liang4
 (尽 量)	jin3liang4
 (尾 水)	wei3shui3
-(尾 ㊌)	wei3shui3
 (尾 綴)	wei3zhui4
 (尾 缀)	wei3zhui4
 (尾 羽)	wei3yu3
@@ -45937,9 +44813,7 @@ $textmode
 (山 本)	shan1ben3
 (山 楂)	shan1zha1
 (山 水)	shan1shui3
-(山 ㊌)	shan1shui3
 (山 火)	shan1huo3
-(山 ㊋)	shan1huo3
 (山 脊)	shan1ji3
 (山 脚)	shan1jiao3
 (山 腳)	shan1jiao3
@@ -45948,7 +44822,6 @@ $textmode
 (山 裡)	shan1li3
 (山 裡)	shan1li3
 (山 西)	shan1xi1
-(山 🀂)	shan1xi1
 (山 谷)	shan1gu3
 (山 都)	shan1du1
 (山 都)	shan1du1
@@ -45971,9 +44844,7 @@ $textmode
 (岡 本)	gang1ben3
 (岳 母)	yue4mu3
 (岳 西)	yue4xi1
-(岳 🀂)	yue4xi1
 (岸 上)	an4shang5
-(岸 ㊤)	an4shang5
 (峇 里)	ke1li3
 (峇 里)	ke1li3
 (峡 谷)	xia2gu3
@@ -45983,7 +44854,6 @@ $textmode
 (峻 嶺)	jun4ling3
 (峽 谷)	xia2gu3
 (崇 左)	chong2zuo3
-(崇 ㊧)	chong2zuo3
 (崇 礼)	chong2li3
 (崇 礼)	chong2li3
 (崇 禮)	chong2li3
@@ -46000,7 +44870,6 @@ $textmode
 (川 党)	chuan1dang3
 (川 藏)	chuan1zang4
 (川 西)	chuan1xi1
-(川 🀂)	chuan1xi1
 (川 黨)	chuan1dang3
 (州 長)	zhou1zhang3
 (州 长)	zhou1zhang3
@@ -46020,21 +44889,13 @@ $textmode
 (工 钱)	gong1qian5
 (工 黨)	gong1dang3
 (左 传)	zuo3zhuan4
-(㊧ 传)	zuo3zhuan4
 (左 傳)	zuo3zhuan4
-(㊧ 傳)	zuo3zhuan4
 (左 手)	zuo3shou3
-(㊧ 手)	zuo3shou3
 (左 掌)	zuo3zhang3
-(㊧ 掌)	zuo3zhang3
 (左 脚)	zuo3jiao3
-(㊧ 脚)	zuo3jiao3
 (左 腳)	zuo3jiao3
-(㊧ 腳)	zuo3jiao3
 (左 边)	zuo3bian5
-(㊧ 边)	zuo3bian5
 (左 邊)	zuo3bian5
-(㊧ 邊)	zuo3bian5
 (巧 匠)	qiao3jiang4
 (巧 干)	qiao3gan4
 (巧 手)	qiao3shou3
@@ -46090,10 +44951,7 @@ $textmode
 (已 經)	yi3jing5
 (已 经)	yi3jing5
 (巴 东)	ba1dong1
-(巴 🀀)	ba1dong1
 (巴 中)	ba1zhong1
-(巴 🀄)	ba1zhong1
-(巴 ㊥)	ba1zhong1
 (巴 乌)	ba1wu1
 (巴 兰)	ba1lan2
 (巴 列)	ba1lie4
@@ -46143,7 +45001,6 @@ $textmode
 (巴 烏)	ba1wu1
 (巴 爾)	ba1er3
 (巴 特)	ba1te4
-(巴 ㊕)	ba1te4
 (巴 珊)	ba1shan1
 (巴 生)	ba1sheng1
 (巴 登)	ba1deng1
@@ -46159,14 +45016,12 @@ $textmode
 (巴 裡)	ba1li3
 (巴 裡)	ba1li3
 (巴 西)	ba1xi1
-(巴 🀂)	ba1xi1
 (巴 豆)	ba1dou4
 (巴 赫)	ba1he4
 (巴 里)	ba1li3
 (巴 里)	ba1li3
 (巴 釐)	ba1li2
 (巴 金)	ba1jin1
-(巴 ㊎)	ba1jin1
 (巴 金)	ba1jin1
 (巴 錄)	ba1lu4
 (巴 錄)	ba1lu4
@@ -46197,7 +45052,6 @@ $textmode
 (布 穀)	bu4gu3
 (布 穀)	bu4gu3
 (布 西)	bu4xi1
-(布 🀂)	bu4xi1
 (布 谷)	bu4gu3
 (帅 哥)	shuai4ge5
 (帆 板)	fan1ban3
@@ -46215,7 +45069,6 @@ $textmode
 (帐 棚)	zhang4peng5
 (帐 蓬)	zhang4peng5
 (帕 西)	pa4xi1
-(帕 🀂)	pa4xi1
 (帕 鐵)	pa4tie3
 (帕 铁)	pa4tie3
 (帝 都)	di4du1
@@ -46225,7 +45078,6 @@ $textmode
 (带 去)	dai4qu5
 (带 手)	dai4shou3
 (带 有)	dai4you3
-(带 ㊒)	dai4you3
 (带 给)	dai4gei3
 (带 走)	dai4zou3
 (带 过)	dai4guo5
@@ -46242,7 +45094,6 @@ $textmode
 (帶 去)	dai4qu5
 (帶 手)	dai4shou3
 (帶 有)	dai4you3
-(帶 ㊒)	dai4you3
 (帶 給)	dai4gei3
 (帶 走)	dai4zou3
 (帶 過)	dai4guo5
@@ -46253,7 +45104,6 @@ $textmode
 (常 好)	chang2hao4
 (常 委)	chang2wei3
 (常 有)	chang2you3
-(常 ㊒)	chang2you3
 (常 熟)	chang2shou2
 (常 理)	chang2li3
 (常 理)	chang2li3
@@ -46324,9 +45174,7 @@ $textmode
 (平 魯)	ping2lu3
 (平 鲁)	ping2lu3
 (年 下)	nian2xia5
-(年 ㊦)	nian2xia5
 (年 下)	nian2xia5
-(年 ㊦)	nian2xia5
 (年 友)	nian2you3
 (年 友)	nian2you3
 (年 少)	nian2shao4
@@ -46338,9 +45186,7 @@ $textmode
 (年 息)	nian2xi1
 (年 息)	nian2xi1
 (年 月)	nian2yue5
-(年 ㊊)	nian2yue5
 (年 月)	nian2yue5
-(年 ㊊)	nian2yue5
 (年 老)	nian2lao3
 (年 老)	nian2lao3
 (年 老)	nian2lao3
@@ -46372,7 +45218,6 @@ $textmode
 (幼 体)	you4ti3
 (幼 兒)	you4er2
 (幼 女)	you4nv3
-(幼 ㊛)	you4nv3
 (幼 女)	you4nv3
 (幼 子)	you4zi3
 (幼 馬)	you4ma3
@@ -46393,13 +45238,10 @@ $textmode
 (幾 諫)	ji1jian4
 (幾 點)	ji1dian3
 (广 九)	guang3jiu3
-(广 ㊈)	guang3jiu3
 (广 场)	guang3chang3
 (广 岛)	guang3dao3
 (广 水)	guang3shui3
-(广 ㊌)	guang3shui3
 (广 西)	guang3xi1
-(广 🀂)	guang3xi1
 (庄 子)	zhuang1zi3
 (庄 老)	zhuang1lao3
 (庄 老)	zhuang1lao3
@@ -46420,7 +45262,6 @@ $textmode
 (应 急)	ying4ji2
 (应 战)	ying4zhan4
 (应 有)	ying1you3
-(应 ㊒)	ying1you3
 (应 用)	ying4yong4
 (应 答)	ying4da2
 (应 约)	ying4yue1
@@ -46431,7 +45272,6 @@ $textmode
 (应 门)	ying4men2
 (应 验)	ying4yan4
 (底 下)	di3xia5
-(底 ㊦)	di3xia5
 (底 本)	di3ben3
 (底 版)	di3ban3
 (底 甲)	di3jia3
@@ -46457,7 +45297,6 @@ $textmode
 (废 品)	fei4pin3
 (废 止)	fei4zhi3
 (废 水)	fei4shui3
-(废 ㊌)	fei4shui3
 (废 纸)	fei4zhi3
 (废 铁)	fei4tie3
 (度 假)	du4jia4
@@ -46505,17 +45344,13 @@ $textmode
 (廢 品)	fei4pin3
 (廢 止)	fei4zhi3
 (廢 水)	fei4shui3
-(廢 ㊌)	fei4shui3
 (廢 紙)	fei4zhi3
 (廢 鐵)	fei4tie3
 (廣 九)	guang3jiu3
-(廣 ㊈)	guang3jiu3
 (廣 場)	guang3chang3
 (廣 島)	guang3dao3
 (廣 水)	guang3shui3
-(廣 ㊌)	guang3shui3
 (廣 西)	guang3xi1
-(廣 🀂)	guang3xi1
 (廳 長)	ting1zhang3
 (延 展)	yan2zhan3
 (延 揽)	yan2lan3
@@ -46530,7 +45365,6 @@ $textmode
 (建 好)	jian4hao3
 (建 始)	jian4shi3
 (建 水)	jian4shui3
-(建 ㊌)	jian4shui3
 (建 都)	jian4du1
 (建 都)	jian4du1
 (建 黨)	jian4dang3
@@ -46554,11 +45388,9 @@ $textmode
 (开 朗)	kai1lang3
 (开 本)	kai1ben3
 (开 水)	kai1shui3
-(开 ㊌)	kai1shui3
 (开 满)	kai1man3
 (开 演)	kai1yan3
 (开 火)	kai1huo3
-(开 ㊋)	kai1huo3
 (开 眼)	kai1yan3
 (开 笔)	kai1bi3
 (开 脸)	kai1lian3
@@ -46595,9 +45427,7 @@ $textmode
 (引 得)	yin3de2
 (引 徵)	yin3zheng1
 (引 水)	yin3shui3
-(引 ㊌)	yin3shui3
 (引 火)	yin3huo3
-(引 ㊋)	yin3huo3
 (引 產)	yin3chan3
 (引 語)	yin3yu3
 (引 语)	yin3yu3
@@ -46613,7 +45443,6 @@ $textmode
 (弟 子)	di4zi3
 (弟 弟)	di4di5
 (张 北)	zhang1bei3
-(张 🀃)	zhang1bei3
 (张 北)	zhang1bei3
 (张 华)	zhang1hua4
 (张 口)	zhang1kou3
@@ -46638,7 +45467,6 @@ $textmode
 (弱 鹼)	ruo4jian3
 (弱 點)	ruo4dian3
 (張 北)	zhang1bei3
-(張 🀃)	zhang1bei3
 (張 北)	zhang1bei3
 (張 口)	zhang1kou3
 (張 嘴)	zhang1zui3
@@ -46733,12 +45561,10 @@ $textmode
 (归 拢)	gui1long3
 (归 给)	gui1gei3
 (归 西)	gui1xi1
-(归 🀂)	gui1xi1
 (归 还)	gui1huan2
 (归 降)	gui1xiang2
 (归 降)	gui1xiang2
 (当 上)	dang1shang5
-(当 ㊤)	dang1shang5
 (当 为)	dang1wei2
 (当 作)	dang4zuo4
 (当 做)	dang4zuo4
@@ -46749,7 +45575,6 @@ $textmode
 (当 成)	dang4cheng2
 (当 晚)	dang4wan3
 (当 月)	dang4yue4
-(当 ㊊)	dang4yue4
 (当 涂)	dang1tu2
 (当 真)	dang4zhen1
 (当 选)	dang1xuan3
@@ -46780,7 +45605,6 @@ $textmode
 (彷 徨)	pang2huang2
 (彻 底)	che4di3
 (彻 西)	che4xi1
-(彻 🀂)	che4xi1
 (彻 骨)	che4gu3
 (彼 得)	bi3de2
 (彼 息)	bi3xi1
@@ -46831,17 +45655,13 @@ $textmode
 (後 面)	hou4mian5
 (後 頭)	hou4tou5
 (徐 水)	xu2shui3
-(徐 ㊌)	xu2shui3
 (徐 緩)	xu2huan3
 (徐 缓)	xu2huan3
 (徑 跡)	jing4ji4
 (徒 弟)	tu2di5
 (徒 手)	tu2shou3
 (得 上)	de2shang4
-(得 ㊤)	de2shang4
 (得 中)	de2zhong4
-(得 🀄)	de2zhong4
-(得 ㊥)	de2zhong4
 (得 主)	de2zhu3
 (得 了)	de2le5
 (得 了)	de2le5
@@ -46867,7 +45687,6 @@ $textmode
 (得 勝)	de2sheng4
 (得 勢)	de2shi4
 (得 名)	de2ming2
-(得 ㊔)	de2ming2
 (得 君)	de2jun1
 (得 听)	de2ting1
 (得 味)	de2wei4
@@ -46962,7 +45781,6 @@ $textmode
 (得 體)	de2ti3
 (從 古)	cong2gu3
 (從 女)	cong2nv3
-(從 ㊛)	cong2nv3
 (從 女)	cong2nv3
 (從 小)	cong2xiao3
 (從 屬)	cong2shu3
@@ -46986,7 +45804,6 @@ $textmode
 (微 扰)	wei1rao3
 (微 擾)	wei1rao3
 (微 火)	wei1huo3
-(微 ㊋)	wei1huo3
 (微 管)	wei1guan3
 (微 米)	wei1mi3
 (微 薄)	wei1bo2
@@ -47023,13 +45840,10 @@ $textmode
 (德 里)	de2li3
 (徹 底)	che4di3
 (徹 西)	che4xi1
-(徹 🀂)	che4xi1
 (徹 骨)	che4gu3
 (心 上)	xin1shang5
-(心 ㊤)	xin1shang5
 (心 事)	xin1shi5
 (心 土)	xin1tu3
-(心 ㊏)	xin1tu3
 (心 地)	xin1di4
 (心 坎)	xin1kan3
 (心 底)	xin1di3
@@ -47097,7 +45911,6 @@ $textmode
 (忽 闪)	hu1shan3
 (怀 古)	huai2gu3
 (怀 有)	huai2you3
-(怀 ㊒)	huai2you3
 (怀 表)	huai2biao3
 (怀 远)	huai2yuan3
 (怀 里)	huai2li3
@@ -47115,9 +45928,7 @@ $textmode
 (怒 喝)	nu4he4
 (怒 喝)	nu4he4
 (怒 火)	nu4huo3
-(怒 ㊋)	nu4huo3
 (怒 火)	nu4huo3
-(怒 ㊋)	nu4huo3
 (怒 號)	nu4hao2
 (怒 號)	nu4hao2
 (怔 怔)	zheng4zheng4
@@ -47151,7 +45962,6 @@ $textmode
 (总 务)	zong3wu4
 (总 得)	zong3dei3
 (总 有)	zong3you3
-(总 ㊒)	zong3you3
 (总 理)	zong3li3
 (总 理)	zong3li3
 (总 管)	zong3guan3
@@ -47208,7 +46018,6 @@ $textmode
 (恶 搞)	e4gao3
 (恶 果)	e4guo3
 (恶 水)	e4shui3
-(恶 ㊌)	e4shui3
 (恶 犬)	e4quan3
 (恶 狠)	e4hen3
 (恶 癖)	e4pi3
@@ -47219,7 +46028,6 @@ $textmode
 (恶 鬼)	e4gui3
 (恺 撒)	kai3sa3
 (恼 火)	nao3huo3
-(恼 ㊋)	nao3huo3
 (悄 悄)	qiao3qiao3
 (悄 然)	qiao3ran2
 (悅 耳)	yue4er3
@@ -47273,10 +46081,8 @@ $textmode
 (惊 马)	jing1ma3
 (惊 鸟)	jing1niao3
 (惟 有)	wei2you3
-(惟 ㊒)	wei2you3
 (惠 普)	hui4pu3
 (惠 水)	hui4shui3
-(惠 ㊌)	hui4shui3
 (惡 口)	e4kou3
 (惡 口)	e4kou3
 (惡 少)	e4shao4
@@ -47294,9 +46100,7 @@ $textmode
 (惡 果)	e4guo3
 (惡 果)	e4guo3
 (惡 水)	e4shui3
-(惡 ㊌)	e4shui3
 (惡 水)	e4shui3
-(惡 ㊌)	e4shui3
 (惡 犬)	e4quan3
 (惡 犬)	e4quan3
 (惡 狠)	e4hen3
@@ -47316,7 +46120,6 @@ $textmode
 (惨 惨)	can3can3
 (惨 景)	can3jing3
 (惱 火)	nao3huo3
-(惱 ㊋)	nao3huo3
 (想 想)	xiang3xiang5
 (想 死)	xiang3si3
 (想 法)	xiang3fa3
@@ -47328,7 +46131,6 @@ $textmode
 (惹 恼)	re3nao3
 (惹 惱)	re3nao3
 (惹 火)	re3huo3
-(惹 ㊋)	re3huo3
 (惹 起)	re3qi3
 (愁 苦)	chou2ku3
 (意 思)	yi4si5
@@ -47344,7 +46146,6 @@ $textmode
 (愚 鲁)	yu2lu3
 (愛 人)	ai4ren5
 (愛 女)	ai4nv3
-(愛 ㊛)	ai4nv3
 (愛 女)	ai4nv3
 (愛 好)	ai4hao4
 (愛 子)	ai4zi3
@@ -47377,7 +46178,6 @@ $textmode
 (慷 慨)	kang1kai3
 (慷 慨)	kang1kai3
 (慾 火)	yu4huo3
-(慾 ㊋)	yu4huo3
 (憋 悶)	bie1men5
 (憋 闷)	bie1men5
 (憎 恶)	zeng1wu4
@@ -47413,7 +46213,6 @@ $textmode
 (應 急)	ying4ji2
 (應 戰)	ying4zhan4
 (應 有)	ying1you3
-(應 ㊒)	ying1you3
 (應 用)	ying4yong4
 (應 答)	ying4da2
 (應 約)	ying4yue1
@@ -47443,7 +46242,6 @@ $textmode
 (懶 鬼)	lan3gui3
 (懷 古)	huai2gu3
 (懷 有)	huai2you3
-(懷 ㊒)	huai2you3
 (懷 表)	huai2biao3
 (懷 裡)	huai2li3
 (懷 裡)	huai2li3
@@ -47508,7 +46306,6 @@ $textmode
 (战 场)	zhan4chang3
 (战 法)	zhan4fa3
 (战 火)	zhan4huo3
-(战 ㊋)	zhan4huo3
 (战 马)	zhan4ma3
 (戚 友)	qi1you3
 (戚 属)	qi1shu3
@@ -47526,7 +46323,6 @@ $textmode
 (戰 場)	zhan4chang3
 (戰 法)	zhan4fa3
 (戰 火)	zhan4huo3
-(戰 ㊋)	zhan4huo3
 (戰 馬)	zhan4ma3
 (戲 仿)	xi4fang3
 (戲 曲)	xi4qu3
@@ -47535,9 +46331,7 @@ $textmode
 (戳 儿)	chuo1r5
 (戳 咕)	chuo1gu1
 (戴 上)	dai4shang5
-(戴 ㊤)	dai4shang5
 (戴 上)	dai4shang5
-(戴 ㊤)	dai4shang5
 (戴 尔)	dai4er3
 (戴 尔)	dai4er3
 (戴 爾)	dai4er3
@@ -47551,7 +46345,6 @@ $textmode
 (户 牖)	hu4you3
 (户 珥)	hu4er3
 (戽 水)	hu4shui3
-(戽 ㊌)	hu4shui3
 (房 主)	fang2zhu3
 (房 产)	fang2chan3
 (房 卡)	fang2ka3
@@ -47571,7 +46364,6 @@ $textmode
 (所 想)	suo3xiang3
 (所 指)	suo3zhi3
 (所 有)	suo3you3
-(所 ㊒)	suo3you3
 (所 為)	suo3wei2
 (所 給)	suo3ji3
 (所 给)	suo3ji3
@@ -47581,10 +46373,8 @@ $textmode
 (扁 擔)	bian3dan5
 (扁 骨)	bian3gu3
 (手 上)	shou3shang5
-(手 ㊤)	shou3shang5
 (手 举)	shou3ju3
 (手 写)	shou3xie3
-(手 ㊢)	shou3xie3
 (手 卷)	shou3juan4
 (手 寫)	shou3xie3
 (手 弹)	shou3tan2
@@ -47617,7 +46407,6 @@ $textmode
 (才 子)	cai2zi3
 (才 干)	cai2gan4
 (才 有)	cai2you3
-(才 ㊒)	cai2you3
 (才 識)	cai2shi2
 (才 識)	cai2shi2
 (才 识)	cai2shi2
@@ -47639,8 +46428,6 @@ $textmode
 (扒 糕)	pa2gao1
 (打 个)	da3ge5
 (打 中)	da3zhong4
-(打 🀄)	da3zhong4
-(打 ㊥)	da3zhong4
 (打 個)	da3ge5
 (打 倒)	da3dao3
 (打 发)	da3fa5
@@ -47666,7 +46453,6 @@ $textmode
 (打 死)	da3si3
 (打 比)	da3bi3
 (打 水)	da3shui3
-(打 ㊌)	da3shui3
 (打 法)	da3fa3
 (打 滚)	da3gun3
 (打 滾)	da3gun3
@@ -47699,7 +46485,6 @@ $textmode
 (打 點)	da3dian5
 (打 鼓)	da3gu3
 (扔 下)	reng1xia5
-(扔 ㊦)	reng1xia5
 (托 巴)	tuo1ba1
 (托 管)	tuo1guan3
 (托 裡)	tuo1li3
@@ -47707,7 +46492,6 @@ $textmode
 (托 里)	tuo1li3
 (托 里)	tuo1li3
 (扣 上)	kou4shang5
-(扣 ㊤)	kou4shang5
 (执 掌)	zhi2zhang3
 (执 法)	zhi2fa3
 (执 着)	zhi2zhuo2
@@ -47748,7 +46532,6 @@ $textmode
 (找 头)	zhao3tou5
 (找 死)	zhao3si3
 (找 水)	zhao3shui3
-(找 ㊌)	zhao3shui3
 (找 着)	zhao3zhao2
 (找 着)	zhao3zhao2
 (找 著)	zhao3zhao2
@@ -47764,7 +46547,6 @@ $textmode
 (技 倆)	ji4liang3
 (技 巧)	ji4qiao3
 (抄 写)	chao1xie3
-(抄 ㊢)	chao1xie3
 (抄 寫)	chao1xie3
 (抄 本)	chao1ben3
 (抄 網)	chao1wang3
@@ -47782,7 +46564,6 @@ $textmode
 (把 酒)	ba3jiu3
 (抑 止)	yi4zhi3
 (抒 写)	shu1xie3
-(抒 ㊢)	shu1xie3
 (抒 寫)	shu1xie3
 (抓 举)	zhua1ju3
 (抓 捕)	zhua1bu3
@@ -47791,8 +46572,6 @@ $textmode
 (抓 舉)	zhua1ju3
 (抓 走)	zhua1zou3
 (投 中)	tou2zhong4
-(投 🀄)	tou2zhong4
-(投 ㊥)	tou2zhong4
 (投 产)	tou2chan3
 (投 奔)	tou2ben4
 (投 奔)	tou2ben4
@@ -47810,7 +46589,6 @@ $textmode
 (抖 落)	dou3luo5
 (抗 体)	kang4ti3
 (抗 水)	kang4shui3
-(抗 ㊌)	kang4shui3
 (抗 礼)	kang4li3
 (抗 礼)	kang4li3
 (抗 禮)	kang4li3
@@ -47874,7 +46652,6 @@ $textmode
 (抬 起)	tai2qi3
 (抱 养)	bao4yang3
 (抱 有)	bao4you3
-(抱 ㊒)	bao4you3
 (抱 枕)	bao4zhen3
 (抱 養)	bao4yang3
 (抵 挡)	di3dang3
@@ -47886,8 +46663,6 @@ $textmode
 (押 玛)	ya1ma3
 (押 瑪)	ya1ma3
 (抽 中)	chou1zhong4
-(抽 🀄)	chou1zhong4
-(抽 ㊥)	chou1zhong4
 (抽 取)	chou1qu3
 (抽 奖)	chou1jiang3
 (抽 打)	chou1da3
@@ -47913,9 +46688,7 @@ $textmode
 (拇 指)	mu3zhi3
 (拇 趾)	mu3zhi3
 (拉 下)	la1xia5
-(拉 ㊦)	la1xia5
 (拉 下)	la1xia5
-(拉 ㊦)	la1xia5
 (拉 倒)	la1dao3
 (拉 倒)	la1dao3
 (拉 夫)	la1fu1
@@ -48065,7 +46838,6 @@ $textmode
 (拥 塞)	yong1se4
 (拥 挤)	yong1ji3
 (拥 有)	yong1you3
-(拥 ㊒)	yong1you3
 (拦 住)	lan2zhu5
 (拦 网)	lan2wang3
 (拦 阻)	lan2zu3
@@ -48090,7 +46862,6 @@ $textmode
 (拳 頭)	quan2tou5
 (拷 打)	kao3da3
 (拼 写)	pin1xie3
-(拼 ㊢)	pin1xie3
 (拼 寫)	pin1xie3
 (拼 抢)	pin1qiang3
 (拼 拢)	pin1long3
@@ -48102,7 +46873,6 @@ $textmode
 (拼 死)	pin1si3
 (拼 法)	pin1fa3
 (拼 火)	pin1huo3
-(拼 ㊋)	pin1huo3
 (拼 版)	pin1ban3
 (拼 綴)	pin1zhui4
 (拼 缀)	pin1zhui4
@@ -48148,7 +46918,6 @@ $textmode
 (持 久)	chi2jiu3
 (持 守)	chi2shou3
 (持 有)	chi2you3
-(持 ㊒)	chi2you3
 (挂 好)	gua4hao3
 (挂 挡)	gua4dang3
 (挂 起)	gua4qi3
@@ -48169,7 +46938,6 @@ $textmode
 (指 頭)	zhi3tou5
 (指 點)	zhi3dian3
 (按 下)	an4xia5
-(按 ㊦)	an4xia5
 (按 手)	an4shou3
 (按 理)	an4li3
 (按 理)	an4li3
@@ -48210,7 +46978,6 @@ $textmode
 (挑 頭)	tiao3tou2
 (挖 井)	wa1jing3
 (挖 土)	wa1tu3
-(挖 ㊏)	wa1tu3
 (挖 地)	wa1di4
 (挖 苦)	wa1ku5
 (挚 友)	zhi4you3
@@ -48283,7 +47050,6 @@ $textmode
 (捨 己)	she3ji3
 (据 守)	ju4shou3
 (据 有)	ju4you3
-(据 ㊒)	ju4you3
 (据 此)	ju4ci3
 (据 点)	ju4dian3
 (据 理)	ju4li3
@@ -48328,7 +47094,6 @@ $textmode
 (排 檢)	pai2jian3
 (排 比)	pai2bi3
 (排 水)	pai2shui3
-(排 ㊌)	pai2shui3
 (排 泻)	pai3xie4
 (排 瀉)	pai3xie4
 (排 版)	pai2ban3
@@ -48424,7 +47189,6 @@ $textmode
 (揉 搓)	rou2cuo5
 (揉 磨)	rou2mo5
 (描 写)	miao2xie3
-(描 ㊢)	miao2xie3
 (描 寫)	miao2xie3
 (提 取)	ti2qu3
 (提 审)	ti2shen3
@@ -48454,7 +47218,6 @@ $textmode
 (提 馬)	ti2ma3
 (提 马)	ti2ma3
 (插 上)	cha1shang5
-(插 ㊤)	cha1shang5
 (插 嘴)	cha1zui3
 (插 孔)	cha1kong3
 (插 手)	cha1shou3
@@ -48479,7 +47242,6 @@ $textmode
 (揭 晓)	jie1xiao3
 (揭 曉)	jie1xiao3
 (揭 西)	jie1xi1
-(揭 🀂)	jie1xi1
 (揮 手)	hui1shou3
 (揮 桿)	hui1gan3
 (揮 灑)	hui1sa3
@@ -48556,7 +47318,6 @@ $textmode
 (摩 撒)	ma1sa5
 (摩 爾)	mo2er3
 (摩 西)	mo2xi1
-(摩 🀂)	mo2xi1
 (摯 友)	zhi4you3
 (摸 摸)	mo1mo5
 (摸 索)	mo1suo5
@@ -48571,7 +47332,6 @@ $textmode
 (摻 假)	chan1jia3
 (摻 和)	chan1huo5
 (撇 下)	pie1xia5
-(撇 ㊦)	pie1xia5
 (撇 去)	pie1qu4
 (撇 弃)	pie1qi4
 (撇 棄)	pie1qi4
@@ -48628,7 +47388,6 @@ $textmode
 (播 种)	bo1zhong3
 (播 種)	bo1zhong3
 (撰 写)	zhuan4xie3
-(撰 ㊢)	zhuan4xie3
 (撰 寫)	zhuan4xie3
 (撲 倒)	pu1dao3
 (撲 騰)	pu1teng5
@@ -48638,15 +47397,12 @@ $textmode
 (擁 塞)	yong1se4
 (擁 擠)	yong1ji3
 (擁 有)	yong1you3
-(擁 ㊒)	yong1you3
 (擄 去)	lu3qu5
 (擄 去)	lu3qu5
 (擅 场)	shan4chang3
 (擅 場)	shan4chang3
 (擅 美)	shan4mei3
 (擊 中)	ji1zhong4
-(擊 🀄)	ji1zhong4
-(擊 ㊥)	ji1zhong4
 (擊 倒)	ji1dao3
 (擊 打)	ji1da3
 (擊 掌)	ji1zhang3
@@ -48667,7 +47423,6 @@ $textmode
 (擔 荷)	dan1he4
 (據 守)	ju4shou3
 (據 有)	ju4you3
-(據 ㊒)	ju4you3
 (據 此)	ju4ci3
 (據 理)	ju4li3
 (據 理)	ju4li3
@@ -48677,7 +47432,6 @@ $textmode
 (擠 滿)	ji3man3
 (擦 乾)	ca1gan1
 (擦 写)	ca1xie3
-(擦 ㊢)	ca1xie3
 (擦 寫)	ca1xie3
 (擦 洗)	ca1xi3
 (擦 澡)	ca1zao3
@@ -48711,7 +47465,6 @@ $textmode
 (支 点)	zhi1dian3
 (支 點)	zhi1dian3
 (收 下)	shou1xia5
-(收 ㊦)	shou1xia5
 (收 买)	shou1mai3
 (收 养)	shou1yang3
 (收 取)	shou1qu3
@@ -48730,7 +47483,6 @@ $textmode
 (收 養)	shou1yang3
 (改 为)	gai3wei2
 (改 写)	gai3xie3
-(改 ㊢)	gai3xie3
 (改 口)	gai3kou3
 (改 寫)	gai3xie3
 (改 為)	gai3wei2
@@ -48744,15 +47496,12 @@ $textmode
 (攻 取)	gong1qu3
 (攻 打)	gong1da3
 (放 上)	fang4shang5
-(放 ㊤)	fang4shang5
 (放 下)	fang4xia5
-(放 ㊦)	fang4xia5
 (放 假)	fang4jia4
 (放 养)	fang4yang3
 (放 好)	fang4hao3
 (放 手)	fang4shou3
 (放 火)	fang4huo3
-(放 ㊋)	fang4huo3
 (放 緩)	fang4huan3
 (放 缓)	fang4huan3
 (放 胆)	fang4dan3
@@ -48781,7 +47530,6 @@ $textmode
 (故 典)	gu4dian3
 (故 友)	gu4you3
 (故 土)	gu4tu3
-(故 ㊏)	gu4tu3
 (故 地)	gu4di4
 (故 址)	gu4zhi3
 (故 我)	gu4wo3
@@ -48807,10 +47555,8 @@ $textmode
 (救 難)	jiu4nan4
 (救 難)	jiu4nan4
 (敗 北)	bai4bei3
-(敗 🀃)	bai4bei3
 (敗 北)	bai4bei3
 (敗 火)	bai4huo3
-(敗 ㊋)	bai4huo3
 (敗 筆)	bai4bi3
 (敗 績)	bai4ji4
 (敗 訴)	bai4su4
@@ -48822,7 +47568,6 @@ $textmode
 (教 務)	jiao4wu4
 (教 友)	jiao4you3
 (教 女)	jiao4nv3
-(教 ㊛)	jiao4nv3
 (教 女)	jiao4nv3
 (教 子)	jiao4zi3
 (教 导)	jiao4dao3
@@ -48861,7 +47606,6 @@ $textmode
 (散 板)	san3ban3
 (散 架)	san3jia4
 (散 水)	san4shui3
-(散 ㊌)	san4shui3
 (散 沙)	san3sha1
 (散 漫)	san3man4
 (散 盡)	san4jin4
@@ -48939,7 +47683,6 @@ $textmode
 (文 本)	wen2ben3
 (文 武)	wen2wu3
 (文 水)	wen2shui3
-(文 ㊌)	wen2shui3
 (文 法)	wen2fa3
 (文 种)	wen2zhong3
 (文 種)	wen2zhong3
@@ -48954,7 +47697,6 @@ $textmode
 (斑 鳢)	ban1li3
 (斑 點)	ban1dian3
 (斗 六)	dou3liu4
-(斗 ㊅)	dou3liu4
 (斗 六)	dou3liu4
 (斗 嘴)	dou4zui3
 (斗 眼)	dou4yan3
@@ -49042,7 +47784,6 @@ $textmode
 (旋 工)	xuan4gong1
 (旋 床)	xuan4chuang2
 (旋 木)	xuan4mu4
-(旋 ㊍)	xuan4mu4
 (旋 筒)	xuan2tong3
 (旋 舞)	xuan2wu3
 (旋 踵)	xuan2zhong3
@@ -49069,11 +47810,9 @@ $textmode
 (无 我)	wu2wo3
 (无 损)	wu2sun3
 (无 有)	wu2you3
-(无 ㊒)	wu2you3
 (无 比)	wu2bi3
 (无 氧)	wu2yang3
 (无 水)	wu2shui3
-(无 ㊌)	wu2shui3
 (无 法)	wu2fa3
 (无 爪)	wu2zhua3
 (无 理)	wu2li3
@@ -49090,40 +47829,22 @@ $textmode
 (既 得)	ji4de2
 (既 得)	ji4de2
 (既 有)	ji4you3
-(既 ㊒)	ji4you3
 (既 有)	ji4you3
-(既 ㊒)	ji4you3
 (日 产)	ri4chan3
-(㊐ 产)	ri4chan3
 (日 冕)	ri4mian3
-(㊐ 冕)	ri4mian3
 (日 土)	ri4tu3
-(日 ㊏)	ri4tu3
-(㊐ 土)	ri4tu3
 (日 影)	ri4ying3
-(㊐ 影)	ri4ying3
 (日 惹)	ri4re3
-(㊐ 惹)	ri4re3
 (日 晷)	ri4gui3
-(㊐ 晷)	ri4gui3
 (日 本)	ri4ben3
-(㊐ 本)	ri4ben3
 (日 產)	ri4chan3
-(㊐ 產)	ri4chan3
 (日 給)	ri4ji3
-(㊐ 給)	ri4ji3
 (日 给)	ri4ji3
-(㊐ 给)	ri4ji3
 (日 美)	ri4mei3
-(㊐ 美)	ri4mei3
 (日 語)	ri4yu3
-(㊐ 語)	ri4yu3
 (日 语)	ri4yu3
-(㊐ 语)	ri4yu3
 (日 里)	ri4li5
-(㊐ 里)	ri4li5
 (日 里)	ri4li5
-(㊐ 里)	ri4li5
 (旦 角)	dan4jiao3
 (旧 体)	jiu4ti3
 (旧 友)	jiu4you3
@@ -49138,7 +47859,6 @@ $textmode
 (旧 都)	jiu4du1
 (旧 雨)	jiu4yu3
 (早 上)	zao3shang5
-(早 ㊤)	zao3shang5
 (早 产)	zao3chan3
 (早 场)	zao3chang3
 (早 場)	zao3chang3
@@ -49159,7 +47879,6 @@ $textmode
 (时 宜)	shi2yi2
 (时 差)	shi2cha1
 (时 有)	shi2you3
-(时 ㊒)	shi2you3
 (时 辰)	shi2chen5
 (时 辰)	shi2chen5
 (旷 古)	kuang4gu3
@@ -49182,9 +47901,7 @@ $textmode
 (明 朗)	ming2lang3
 (明 朗)	ming2lang3
 (明 水)	ming2shui3
-(明 ㊌)	ming2shui3
 (明 火)	ming2huo3
-(明 ㊋)	ming2huo3
 (明 理)	ming2li3
 (明 理)	ming2li3
 (明 白)	ming2bai5
@@ -49242,7 +47959,6 @@ $textmode
 (時 宜)	shi2yi2
 (時 差)	shi2cha1
 (時 有)	shi2you3
-(時 ㊒)	shi2you3
 (時 興)	shi2xing1
 (時 辰)	shi2chen5
 (時 辰)	shi2chen5
@@ -49258,7 +47974,6 @@ $textmode
 (晕 车)	yun4che1
 (晕 针)	yun4zhen1
 (晚 上)	wan3shang5
-(晚 ㊤)	wan3shang5
 (晚 点)	wan3dian3
 (晚 祷)	wan3dao3
 (晚 禱)	wan3dao3
@@ -49279,7 +47994,6 @@ $textmode
 (普 洱)	pu3er3
 (普 瓦)	pu3wa3
 (普 西)	pu3xi1
-(普 🀂)	pu3xi1
 (普 选)	pu3xuan3
 (普 選)	pu3xuan3
 (普 鐵)	pu3tie3
@@ -49384,7 +48098,6 @@ $textmode
 (曲 松)	qu3song1
 (曲 柄)	qu1bing3
 (曲 水)	qu3shui3
-(曲 ㊌)	qu3shui3
 (曲 江)	qu3jiang1
 (曲 沃)	qu3wo4
 (曲 笔)	qu1bi3
@@ -49414,9 +48127,7 @@ $textmode
 (更 卒)	geng1zu2
 (更 卒)	geng1zu2
 (更 名)	geng1ming2
-(更 ㊔)	geng1ming2
 (更 名)	geng1ming2
-(更 ㊔)	geng1ming2
 (更 夫)	geng1fu1
 (更 夫)	geng1fu1
 (更 好)	geng4hao3
@@ -49445,9 +48156,7 @@ $textmode
 (更 次)	geng1ci4
 (更 次)	geng1ci4
 (更 正)	geng1zheng4
-(更 ㊣)	geng1zheng4
 (更 正)	geng1zheng4
-(更 ㊣)	geng1zheng4
 (更 深)	geng1shen1
 (更 深)	geng1shen1
 (更 漏)	geng1lou4
@@ -49523,94 +48232,49 @@ $textmode
 (會 長)	hui4zhang3
 (會 首)	hui4shou3
 (月 亮)	yue4liang5
-(㊊ 亮)	yue4liang5
 (月 亮)	yue4liang5
-(㊊ 亮)	yue4liang5
 (月 晕)	yue4yun4
-(㊊ 晕)	yue4yun4
 (月 暈)	yue4yun4
-(㊊ 暈)	yue4yun4
 (月 暈)	yue4yun4
-(㊊ 暈)	yue4yun4
 (月 氏)	yue4zhi1
-(㊊ 氏)	yue4zhi1
 (月 沒)	yue4mo4
-(㊊ 沒)	yue4mo4
 (月 没)	yue4mo4
-(㊊ 没)	yue4mo4
 (月 相)	yue4xiang4
-(㊊ 相)	yue4xiang4
 (月 給)	yue4ji3
-(㊊ 給)	yue4ji3
 (月 给)	yue4ji3
-(㊊ 给)	yue4ji3
 (月 餅)	yue4bing3
-(㊊ 餅)	yue4bing3
 (月 饼)	yue4bing3
-(㊊ 饼)	yue4bing3
 (月 鱧)	yue4li3
-(㊊ 鱧)	yue4li3
 (月 鳢)	yue4li3
-(㊊ 鳢)	yue4li3
 (有 为)	you3wei2
-(㊒ 为)	you3wei2
 (有 主)	you3zhu3
-(㊒ 主)	you3zhu3
 (有 分)	you3fen4
-(㊒ 分)	you3fen4
 (有 喜)	you3xi3
-(㊒ 喜)	you3xi3
 (有 守)	you3shou3
-(㊒ 守)	you3shou3
 (有 得)	you3de2
-(㊒ 得)	you3de2
 (有 感)	you3gan3
-(㊒ 感)	you3gan3
 (有 所)	you3suo3
-(㊒ 所)	you3suo3
 (有 损)	you3sun3
-(㊒ 损)	you3sun3
 (有 損)	you3sun3
-(㊒ 損)	you3sun3
 (有 染)	you3ran3
-(㊒ 染)	you3ran3
 (有 水)	you3shui3
-(有 ㊌)	you3shui3
-(㊒ 水)	you3shui3
 (有 点)	you3dian3
-(㊒ 点)	you3dian3
 (有 為)	you3wei2
-(㊒ 為)	you3wei2
 (有 理)	you3li3
-(㊒ 理)	you3li3
 (有 理)	you3li3
-(㊒ 理)	you3li3
 (有 种)	you3zhong3
-(㊒ 种)	you3zhong3
 (有 種)	you3zhong3
-(㊒ 種)	you3zhong3
 (有 空)	you3kong4
-(㊒ 空)	you3kong4
 (有 脸)	you3lian3
-(㊒ 脸)	you3lian3
 (有 臉)	you3lian3
-(㊒ 臉)	you3lian3
 (有 請)	you3qing3
-(㊒ 請)	you3qing3
 (有 請)	you3qing3
-(㊒ 請)	you3qing3
 (有 请)	you3qing3
-(㊒ 请)	you3qing3
 (有 軌)	you3gui3
-(㊒ 軌)	you3gui3
 (有 轨)	you3gui3
-(㊒ 轨)	you3gui3
 (有 酒)	you3jiu3
-(㊒ 酒)	you3jiu3
 (有 雨)	you3yu3
-(㊒ 雨)	you3yu3
 (有 點)	you3dian3
-(㊒ 點)	you3dian3
 (朋 党)	peng2dang3
 (朋 黨)	peng2dang3
 (服 丧)	fu2sang1
@@ -49632,7 +48296,6 @@ $textmode
 (望 都)	wang4du1
 (朝 夕)	zhao1xi1
 (朝 日)	zhao1ri4
-(朝 ㊐)	zhao1ri4
 (朝 朝)	zhao1zhao1
 (朝 歌)	zhao1ge1
 (朝 气)	zhao1qi4
@@ -49649,37 +48312,21 @@ $textmode
 (期 許)	qi1xu3
 (期 许)	qi1xu3
 (木 偶)	mu4ou3
-(㊍ 偶)	mu4ou3
 (木 塔)	mu4ta3
-(㊍ 塔)	mu4ta3
 (木 头)	mu4tou5
-(㊍ 头)	mu4tou5
 (木 杆)	mu4gan3
-(㊍ 杆)	mu4gan3
 (木 板)	mu4ban3
-(㊍ 板)	mu4ban3
 (木 框)	mu4kuang4
-(㊍ 框)	mu4kuang4
 (木 桶)	mu4tong3
-(㊍ 桶)	mu4tong3
 (木 桿)	mu4gan3
-(㊍ 桿)	mu4gan3
 (木 版)	mu4ban3
-(㊍ 版)	mu4ban3
 (木 犀)	mu4xi5
-(㊍ 犀)	mu4xi5
 (木 瓦)	mu4wa3
-(㊍ 瓦)	mu4wa3
 (木 耳)	mu4er3
-(㊍ 耳)	mu4er3
 (木 薯)	mu4shu3
-(㊍ 薯)	mu4shu3
 (木 頭)	mu4tou5
-(㊍ 頭)	mu4tou5
 (木 馬)	mu4ma3
-(㊍ 馬)	mu4ma3
 (木 马)	mu4ma3
-(㊍ 马)	mu4ma3
 (未 了)	wei4liao3
 (未 了)	wei4liao3
 (未 免)	wei4mian3
@@ -49691,14 +48338,12 @@ $textmode
 (未 娶)	wei4qu3
 (未 幾)	wei4ji3
 (未 有)	wei4you3
-(未 ㊒)	wei4you3
 (未 熟)	wei4shou2
 (末 了)	mo4liao3
 (末 了)	mo4liao3
 (本 体)	ben3ti3
 (本 分)	ben3fen4
 (本 土)	ben3tu3
-(本 ㊏)	ben3tu3
 (本 地)	ben3di4
 (本 垒)	ben3lei3
 (本 壘)	ben3lei3
@@ -49708,7 +48353,6 @@ $textmode
 (本 底)	ben3di3
 (本 影)	ben3ying3
 (本 有)	ben3you3
-(本 ㊒)	ben3you3
 (本 省)	ben3sheng3
 (本 省)	ben3sheng3
 (本 草)	ben3cao3
@@ -49788,7 +48432,6 @@ $textmode
 (来 使)	lai2shi3
 (来 往)	lai2wang3
 (来 火)	lai2huo3
-(来 ㊋)	lai2huo3
 (来 者)	lai2zhe3
 (来 者)	lai2zhe3
 (来 者)	lai2zhe3
@@ -49799,7 +48442,6 @@ $textmode
 (杰 夫)	jie2fu1
 (杰 米)	jie2mi3
 (東 北)	dong1bei3
-(東 🀃)	dong1bei3
 (東 北)	dong1bei3
 (東 家)	dong1jia5
 (東 海)	dong1hai3
@@ -49809,7 +48451,6 @@ $textmode
 (東 阿)	dong1e1
 (東 面)	dong1mian5
 (松 土)	song1tu3
-(松 ㊏)	song1tu3
 (松 岛)	song1dao3
 (松 島)	song1dao3
 (松 快)	song1kuai5
@@ -49831,14 +48472,12 @@ $textmode
 (板 鼓)	ban3gu3
 (极 为)	ji2wei2
 (极 北)	ji2bei3
-(极 🀃)	ji2bei3
 (极 北)	ji2bei3
 (极 好)	ji2hao3
 (极 小)	ji2xiao3
 (极 少)	ji2shao3
 (极 点)	ji2dian3
 (极 西)	ji2xi1
-(极 🀂)	ji2xi1
 (极 角)	ji2jiao3
 (构 想)	gou4xiang3
 (枇 杷)	pi2pa5
@@ -49866,15 +48505,11 @@ $textmode
 (林 場)	lin2chang3
 (林 場)	lin2chang3
 (林 火)	lin2huo3
-(林 ㊋)	lin2huo3
 (林 火)	lin2huo3
-(林 ㊋)	lin2huo3
 (林 肯)	lin2ken3
 (林 肯)	lin2ken3
 (林 西)	lin2xi1
-(林 🀂)	lin2xi1
 (林 西)	lin2xi1
-(林 🀂)	lin2xi1
 (枘 凿)	rui4zuo4
 (枘 鑿)	rui4zuo4
 (果 品)	guo3pin3
@@ -49899,7 +48534,6 @@ $textmode
 (枯 槁)	ku1gao3
 (枯 死)	ku1si3
 (枯 水)	ku1shui3
-(枯 ㊌)	ku1shui3
 (枯 草)	ku1cao3
 (枯 萎)	ku1wei3
 (架 势)	jia4shi5
@@ -49916,7 +48550,6 @@ $textmode
 (某 种)	mou3zhong3
 (某 種)	mou3zhong3
 (染 上)	ran3shang5
-(染 ㊤)	ran3shang5
 (染 厂)	ran3chang3
 (染 发)	ran3fa4
 (染 廠)	ran3chang3
@@ -49925,9 +48558,7 @@ $textmode
 (柔 軟)	rou2ruan3
 (柔 软)	rou2ruan3
 (柜 上)	gui4shang5
-(柜 ㊤)	gui4shang5
 (柞 水)	zuo4shui3
-(柞 ㊌)	zuo4shui3
 (查 处)	cha2chu3
 (查 找)	cha2zhao3
 (查 点)	cha2dian3
@@ -49935,7 +48566,6 @@ $textmode
 (查 處)	cha2chu3
 (查 點)	cha2dian3
 (柯 西)	ke1xi1
-(柯 🀂)	ke1xi1
 (柱 体)	zhu4ti3
 (柱 頂)	zhu4ding3
 (柱 顶)	zhu4ding3
@@ -49949,7 +48579,6 @@ $textmode
 (柳 體)	liu3ti3
 (柳 體)	liu3ti3
 (柴 火)	chai2huo5
-(柴 ㊋)	chai2huo5
 (柵 欄)	zha4lan5
 (柵 欄)	zha4lan5
 (柽 柳)	cheng1liu3
@@ -49969,9 +48598,7 @@ $textmode
 (栈 板)	zhan4ban3
 (栉 比)	zhi4bi3
 (树 上)	shu4shang5
-(树 ㊤)	shu4shang5
 (树 下)	shu4xia5
-(树 ㊦)	shu4xia5
 (树 冠)	shu4guan1
 (树 干)	shu4gan4
 (树 獭)	shu4ta3
@@ -49992,7 +48619,6 @@ $textmode
 (校 对)	jiao4dui4
 (校 對)	jiao4dui4
 (校 正)	jiao4zheng4
-(校 ㊣)	jiao4zheng4
 (校 準)	jiao4zhun3
 (校 稿)	jiao4gao3
 (校 舍)	xiao4she4
@@ -50006,7 +48632,6 @@ $textmode
 (校 验)	jiao4yan4
 (栩 栩)	xu3xu3
 (株 守)	zhu1shou3
-(㊑ 守)	zhu1shou3
 (样 品)	yang4pin3
 (样 本)	yang4ben3
 (样 板)	yang4ban3
@@ -50115,14 +48740,12 @@ $textmode
 (業 海)	ye4hai3
 (業 績)	ye4ji4
 (極 北)	ji2bei3
-(極 🀃)	ji2bei3
 (極 北)	ji2bei3
 (極 好)	ji2hao3
 (極 小)	ji2xiao3
 (極 少)	ji2shao3
 (極 為)	ji2wei2
 (極 西)	ji2xi1
-(極 🀂)	ji2xi1
 (極 角)	ji2jiao3
 (極 點)	ji2dian3
 (楼 板)	lou2ban3
@@ -50278,9 +48901,7 @@ $textmode
 (樱 岛)	ying1dao3
 (樵 夫)	qiao2fu1
 (樹 上)	shu4shang5
-(樹 ㊤)	shu4shang5
 (樹 下)	shu4xia5
-(樹 ㊦)	shu4xia5
 (樹 冠)	shu4guan1
 (樹 獺)	shu4ta3
 (樹 種)	shu4zhong3
@@ -50318,7 +48939,6 @@ $textmode
 (橫 筆)	heng2bi3
 (橫 豎)	heng2shu5
 (橫 財)	heng4cai2
-(橫 ㊖)	heng4cai2
 (橫 骨)	heng2gu3
 (檉 柳)	cheng1liu3
 (檉 柳)	cheng1liu3
@@ -50334,7 +48954,6 @@ $textmode
 (檻 車)	jian4che1
 (檻 車)	jian4che1
 (櫃 上)	gui4shang5
-(櫃 ㊤)	gui4shang5
 (櫛 比)	zhi4bi3
 (櫻 島)	ying1dao3
 (權 宜)	quan2yi2
@@ -50345,7 +48964,6 @@ $textmode
 (欠 款)	qian4kuan3
 (次 品)	ci4pin3
 (次 女)	ci4nv3
-(次 ㊛)	ci4nv3
 (次 女)	ci4nv3
 (次 子)	ci4zi3
 (次 等)	ci4deng3
@@ -50380,7 +48998,6 @@ $textmode
 (欧 泊)	ou1bo2
 (欧 美)	ou1mei3
 (欲 火)	yu4huo3
-(欲 ㊋)	yu4huo3
 (欺 侮)	qi1wu3
 (欺 侮)	qi1wu3
 (欺 哄)	qi1hong3
@@ -50393,7 +49010,6 @@ $textmode
 (歌 儿)	ge1r5
 (歌 咏)	ge1yong3
 (歌 女)	ge1nv3
-(歌 ㊛)	ge1nv3
 (歌 女)	ge1nv3
 (歌 手)	ge1shou3
 (歌 曲)	ge1qu3
@@ -50430,40 +49046,22 @@ $textmode
 (止 咳)	zhi3ke2
 (止 息)	zhi3xi1
 (正 体)	zheng4ti3
-(㊣ 体)	zheng4ti3
 (正 切)	zheng4qie1
-(㊣ 切)	zheng4qie1
 (正 切)	zheng4qie1
-(㊣ 切)	zheng4qie1
 (正 午)	zheng4wu3
-(㊣ 午)	zheng4wu3
 (正 反)	zheng4fan3
-(㊣ 反)	zheng4fan3
 (正 史)	zheng4shi3
-(㊣ 史)	zheng4shi3
 (正 好)	zheng4hao3
-(㊣ 好)	zheng4hao3
 (正 巧)	zheng4qiao3
-(㊣ 巧)	zheng4qiao3
 (正 月)	zheng1yue4
-(㊣ 月)	zheng1yue4
-(正 ㊊)	zheng1yue4
 (正 楷)	zheng4kai3
-(㊣ 楷)	zheng4kai3
 (正 比)	zheng4bi3
-(㊣ 比)	zheng4bi3
 (正 点)	zheng4dian3
-(㊣ 点)	zheng4dian3
 (正 統)	zheng4tong3
-(㊣ 統)	zheng4tong3
 (正 统)	zheng4tong3
-(㊣ 统)	zheng4tong3
 (正 骨)	zheng4gu3
-(㊣ 骨)	zheng4gu3
 (正 體)	zheng4ti3
-(㊣ 體)	zheng4ti3
 (正 點)	zheng4dian3
-(㊣ 點)	zheng4dian3
 (此 地)	ci3di4
 (步 履)	bu4lv3
 (步 履)	bu4lv3
@@ -50473,7 +49071,6 @@ $textmode
 (武 將)	wu3jiang4
 (武 打)	wu3da3
 (武 水)	wu3shui3
-(武 ㊌)	wu3shui3
 (武 舉)	wu3ju3
 (武 警)	wu3jing3
 (武 都)	wu3du1
@@ -50499,7 +49096,6 @@ $textmode
 (歸 於)	gui1yu2
 (歸 給)	gui1gei3
 (歸 西)	gui1xi1
-(歸 🀂)	gui1xi1
 (歸 還)	gui1huan2
 (歸 降)	gui1xiang2
 (歸 降)	gui1xiang2
@@ -50549,7 +49145,6 @@ $textmode
 (母 亲)	mu3qin5
 (母 体)	mu3ti3
 (母 女)	mu3nv3
-(母 ㊛)	mu3nv3
 (母 女)	mu3nv3
 (母 板)	mu3ban3
 (母 犬)	mu3quan3
@@ -50604,7 +49199,6 @@ $textmode
 (民 乐)	min2yue4
 (民 改)	min2gai3
 (民 有)	min2you3
-(民 ㊒)	min2you3
 (民 樂)	min2yue4
 (民 樂)	min2yue4
 (民 樂)	min2yue4
@@ -50640,72 +49234,38 @@ $textmode
 (氯 仿)	lv4fang3
 (氯 苯)	lv4ben3
 (水 井)	shui3jing3
-(㊌ 井)	shui3jing3
 (水 产)	shui3chan3
-(㊌ 产)	shui3chan3
 (水 仙)	shui3xian1
-(㊌ 仙)	shui3xian1
 (水 体)	shui3ti3
-(㊌ 体)	shui3ti3
 (水 准)	shui3zhun3
-(㊌ 准)	shui3zhun3
 (水 分)	shui3fen4
-(㊌ 分)	shui3fen4
 (水 土)	shui3tu3
-(水 ㊏)	shui3tu3
-(㊌ 土)	shui3tu3
 (水 底)	shui3di3
-(㊌ 底)	shui3di3
 (水 手)	shui3shou3
-(㊌ 手)	shui3shou3
 (水 果)	shui3guo3
-(㊌ 果)	shui3guo3
 (水 桶)	shui3tong3
-(㊌ 桶)	shui3tong3
 (水 母)	shui3mu3
-(㊌ 母)	shui3mu3
 (水 洗)	shui3xi3
-(㊌ 洗)	shui3xi3
 (水 準)	shui3zhun3
-(㊌ 準)	shui3zhun3
 (水 点)	shui3dian3
-(㊌ 点)	shui3dian3
 (水 獭)	shui3ta3
-(㊌ 獭)	shui3ta3
 (水 獺)	shui3ta3
-(㊌ 獺)	shui3ta3
 (水 產)	shui3chan3
-(㊌ 產)	shui3chan3
 (水 碾)	shui3nian3
-(㊌ 碾)	shui3nian3
 (水 管)	shui3guan3
-(㊌ 管)	shui3guan3
 (水 肿)	shui3zhong3
-(㊌ 肿)	shui3zhong3
 (水 腫)	shui3zhong3
-(㊌ 腫)	shui3zhong3
 (水 草)	shui3cao3
-(㊌ 草)	shui3cao3
 (水 表)	shui3biao3
-(㊌ 表)	shui3biao3
 (水 解)	shui3jie3
-(㊌ 解)	shui3jie3
 (水 里)	shui3li5
-(㊌ 里)	shui3li5
 (水 里)	shui3li5
-(㊌ 里)	shui3li5
 (水 餃)	shui3jiao3
-(㊌ 餃)	shui3jiao3
 (水 饺)	shui3jiao3
-(㊌ 饺)	shui3jiao3
 (水 體)	shui3ti3
-(㊌ 體)	shui3ti3
 (水 鳥)	shui3niao3
-(㊌ 鳥)	shui3niao3
 (水 鸟)	shui3niao3
-(㊌ 鸟)	shui3niao3
 (水 點)	shui3dian3
-(㊌ 點)	shui3dian3
 (永 久)	yong3jiu3
 (永 享)	yong3xiang3
 (永 兴)	yong3xing1
@@ -50723,13 +49283,11 @@ $textmode
 (汇 整)	hui4zheng3
 (汇 款)	hui4kuan3
 (汇 水)	hui4shui3
-(汇 ㊌)	hui4shui3
 (汇 演)	hui4yan3
 (汇 点)	hui4dian3
 (汉 口)	han4kou3
 (汉 堡)	han4bao3
 (汉 水)	han4shui3
-(汉 ㊌)	han4shui3
 (汉 语)	han4yu3
 (汎 指)	fan4zhi3
 (汐 止)	xi1zhi3
@@ -50737,23 +49295,19 @@ $textmode
 (汗 国)	han2guo2
 (汗 國)	han2guo2
 (江 北)	jiang1bei3
-(江 🀃)	jiang1bei3
 (江 北)	jiang1bei3
 (江 口)	jiang1kou3
 (江 永)	jiang1yong3
 (江 浦)	jiang1pu3
 (江 西)	jiang1xi1
-(江 🀂)	jiang1xi1
 (江 都)	jiang1du1
 (江 都)	jiang1du1
 (池 水)	chi2shui3
-(池 ㊌)	chi2shui3
 (池 沼)	chi2zhao3
 (污 损)	wu1sun3
 (污 損)	wu1sun3
 (污 染)	wu1ran3
 (污 水)	wu1shui3
-(污 ㊌)	wu1shui3
 (污 点)	wu1dian3
 (污 跡)	wu1ji4
 (污 辱)	wu1ru3
@@ -50765,31 +49319,23 @@ $textmode
 (汲 取)	ji2qu3
 (汲 引)	ji2yin3
 (汲 水)	ji2shui3
-(汲 ㊌)	ji2shui3
 (汹 涌)	xiong1yong3
 (汹 湧)	xiong1yong3
 (決 口)	jue2kou3
 (汽 暖)	qi4nuan3
 (汽 水)	qi4shui3
-(汽 ㊌)	qi4shui3
 (汽 碾)	qi4nian3
 (汽 艇)	qi4ting3
 (汽 酒)	qi4jiu3
 (汾 西)	fen2xi1
-(汾 🀂)	fen2xi1
 (沁 水)	qin4shui3
-(沁 ㊌)	qin4shui3
 (沂 水)	yi2shui3
-(沂 ㊌)	yi2shui3
 (沃 土)	wo4tu3
-(沃 ㊏)	wo4tu3
 (沃 壤)	wo4rang3
 (沃 水)	wo4shui3
-(沃 ㊌)	wo4shui3
 (沃 衍)	wo4yan3
 (沃 野)	wo4ye3
 (沅 水)	yuan2shui3
-(沅 ㊌)	yuan2shui3
 (沈 积)	chen2ji1
 (沈 积)	chen2ji1
 (沈 積)	chen2ji1
@@ -50810,7 +49356,6 @@ $textmode
 (沉 著)	chen2zhuo2
 (沒 收)	mo4shou1
 (沒 有)	mei2you3
-(沒 ㊒)	mei2you3
 (沒 法)	mei2fa3
 (沒 落)	mo4luo4
 (沒 落)	mo4luo4
@@ -50821,7 +49366,6 @@ $textmode
 (沙 哑)	sha1ya3
 (沙 啞)	sha1ya3
 (沙 土)	sha1tu3
-(沙 ㊏)	sha1tu3
 (沙 地)	sha1di4
 (沙 场)	sha1chang3
 (沙 場)	sha1chang3
@@ -50843,34 +49387,28 @@ $textmode
 (沟 谷)	gou1gu3
 (没 收)	mo4shou1
 (没 有)	mei2you3
-(没 ㊒)	mei2you3
 (没 法)	mei2fa3
 (没 药)	mo4yao4
 (没 落)	mo4luo4
 (没 落)	mo4luo4
 (没 顶)	mo4ding3
 (沣 水)	feng1shui3
-(沣 ㊌)	feng1shui3
 (沦 为)	lun2wei2
 (沦 没)	lun2mo4
 (沧 海)	cang1hai3
 (沧 海)	cang1hai3
 (河 北)	he2bei3
-(河 🀃)	he2bei3
 (河 北)	he2bei3
 (河 叉)	he2cha4
 (河 口)	he2kou3
 (河 水)	he2shui3
-(河 ㊌)	he2shui3
 (河 狸)	he2li2
 (河 粉)	he2fen3
 (河 西)	he2xi1
-(河 🀂)	he2xi1
 (河 谷)	he2gu3
 (河 馬)	he2ma3
 (河 马)	he2ma3
 (沸 水)	fei4shui3
-(沸 ㊌)	fei4shui3
 (沸 点)	fei4dian3
 (沸 點)	fei4dian3
 (油 井)	you2jing3
@@ -50893,7 +49431,6 @@ $textmode
 (泄 露)	xie4lou4
 (泄 露)	xie4lou4
 (泉 水)	quan2shui3
-(泉 ㊌)	quan2shui3
 (泉 涌)	quan2yong3
 (泉 眼)	quan2yan3
 (泊 位)	bo2wei4
@@ -50916,7 +49453,6 @@ $textmode
 (法 語)	fa3yu3
 (法 语)	fa3yu3
 (泗 水)	si4shui3
-(泗 ㊌)	si4shui3
 (泛 指)	fan4zhi3
 (泛 起)	fan4qi3
 (泡 影)	pao4ying3
@@ -50935,9 +49471,7 @@ $textmode
 (泥 古)	ni4gu3
 (泥 古)	ni4gu3
 (泥 土)	ni2tu3
-(泥 ㊏)	ni2tu3
 (泥 土)	ni2tu3
-(泥 ㊏)	ni2tu3
 (泥 子)	ni4zi5
 (泥 子)	ni4zi5
 (泥 守)	ni4shou3
@@ -50949,11 +49483,8 @@ $textmode
 (泥 涂)	ni2tu2
 (泥 涂)	ni2tu2
 (注 脚)	zhu4jiao3
-(㊟ 脚)	zhu4jiao3
 (注 解)	zhu4jie3
-(㊟ 解)	zhu4jie3
 (泪 水)	lei4shui3
-(泪 ㊌)	lei4shui3
 (泰 兴)	tai4xing1
 (泰 华)	tai4hua4
 (泰 坦)	tai4tan3
@@ -50965,23 +49496,18 @@ $textmode
 (泰 華)	tai4hua4
 (泰 華)	tai4hua4
 (泰 西)	tai4xi1
-(泰 🀂)	tai4xi1
 (泰 語)	tai4yu3
 (泰 语)	tai4yu3
 (泵 柄)	beng4bing3
 (泷 水)	long2shui3
-(泷 ㊌)	long2shui3
 (泸 水)	lu2shui3
-(泸 ㊌)	lu2shui3
 (泸 西)	lu2xi1
-(泸 🀂)	lu2xi1
 (泼 妇)	po1fu4
 (泼 掉)	po1diao4
 (泼 辣)	po1la5
 (泽 塔)	ze2ta3
 (泽 普)	ze2pu3
 (泽 西)	ze2xi1
-(泽 🀂)	ze2xi1
 (洋 务)	yang2wu4
 (洋 務)	yang2wu4
 (洋 壳)	yang2qiao4
@@ -50993,7 +49519,6 @@ $textmode
 (洋 鬼)	yang2gui3
 (洋 鹼)	yang2jian3
 (洒 水)	sa3shui3
-(洒 ㊌)	sa3shui3
 (洒 满)	sa3man3
 (洒 脱)	sa3tuo5
 (洗 巴)	xi3ba1
@@ -51020,9 +49545,7 @@ $textmode
 (洞 口)	dong4kou3
 (洞 口)	dong4kou3
 (洣 水)	mi3shui3
-(洣 ㊌)	mi3shui3
 (洧 水)	wei3shui3
-(洧 ㊌)	wei3shui3
 (洩 底)	xie4di3
 (洩 露)	xie4lou4
 (洩 露)	xie4lou4
@@ -51030,10 +49553,8 @@ $textmode
 (洪 堡)	hong2bao3
 (洪 武)	hong2wu3
 (洪 水)	hong2shui3
-(洪 ㊌)	hong2shui3
 (洪 雅)	hong2ya3
 (洮 北)	tao2bei3
-(洮 🀃)	tao2bei3
 (洮 北)	tao2bei3
 (洱 海)	er3hai3
 (洱 海)	er3hai3
@@ -51043,7 +49564,6 @@ $textmode
 (活 佛)	huo2fo2
 (活 儿)	huo2r5
 (活 水)	huo2shui3
-(活 ㊌)	huo2shui3
 (洼 地)	wa1di4
 (派 差)	pai4chai1
 (派 往)	pai4wang3
@@ -51066,11 +49586,8 @@ $textmode
 (流 感)	liu2gan3
 (流 感)	liu2gan3
 (流 水)	liu2shui3
-(流 ㊌)	liu2shui3
 (流 水)	liu2shui3
-(流 ㊌)	liu2shui3
 (流 水)	liu2shui3
-(流 ㊌)	liu2shui3
 (流 淌)	liu2tang3
 (流 淌)	liu2tang3
 (流 淌)	liu2tang3
@@ -51106,7 +49623,6 @@ $textmode
 (流 體)	liu2ti3
 (浅 显)	qian3xian3
 (浅 水)	qian3shui3
-(浅 ㊌)	qian3shui3
 (浅 海)	qian3hai3
 (浅 海)	qian3hai3
 (浅 短)	qian3duan3
@@ -51114,17 +49630,13 @@ $textmode
 (浅 鲜)	qian3xian3
 (浆 果)	jiang1guo3
 (浇 水)	jiao1shui3
-(浇 ㊌)	jiao1shui3
 (浊 酒)	zhuo2jiu3
 (测 量)	ce4liang2
 (测 量)	ce4liang2
 (济 南)	ji3nan2
-(济 🀁)	ji3nan2
 (浏 览)	liu2lan3
 (浠 水)	xi1shui3
-(浠 ㊌)	xi1shui3
 (浦 北)	pu3bei3
-(浦 🀃)	pu3bei3
 (浦 北)	pu3bei3
 (浦 口)	pu3kou3
 (浩 淼)	hao4miao3
@@ -51151,9 +49663,7 @@ $textmode
 (海 兴)	hai3xing1
 (海 兴)	hai3xing1
 (海 北)	hai3bei3
-(海 🀃)	hai3bei3
 (海 北)	hai3bei3
-(海 🀃)	hai3bei3
 (海 北)	hai3bei3
 (海 参)	hai3shen1
 (海 参)	hai3shen1
@@ -51176,9 +49686,7 @@ $textmode
 (海 底)	hai3di3
 (海 底)	hai3di3
 (海 水)	hai3shui3
-(海 ㊌)	hai3shui3
 (海 水)	hai3shui3
-(海 ㊌)	hai3shui3
 (海 法)	hai3fa3
 (海 法)	hai3fa3
 (海 港)	hai3gang3
@@ -51204,9 +49712,7 @@ $textmode
 (海 藻)	hai3zao3
 (海 藻)	hai3zao3
 (海 西)	hai3xi1
-(海 🀂)	hai3xi1
 (海 西)	hai3xi1
-(海 🀂)	hai3xi1
 (海 角)	hai3jiao3
 (海 角)	hai3jiao3
 (海 里)	hai3li3
@@ -51237,9 +49743,7 @@ $textmode
 (浸 种)	jin4zhong3
 (浸 種)	jin4zhong3
 (涂 上)	tu2shang4
-(涂 ㊤)	tu2shang4
 (涂 写)	tu2xie3
-(涂 ㊢)	tu2xie3
 (涂 家)	tu2jia1
 (涂 山)	tu2shan1
 (涂 径)	tu2jing4
@@ -51269,7 +49773,6 @@ $textmode
 (消 隱)	xiao1yin3
 (涉 想)	she4xiang3
 (涉 水)	she4shui3
-(涉 ㊌)	she4shui3
 (涉 笔)	she4bi3
 (涉 筆)	she4bi3
 (涉 覽)	she4lan3
@@ -51277,18 +49780,13 @@ $textmode
 (涉 险)	she4xian3
 (涉 險)	she4xian3
 (涌 上)	yong3shang5
-(涌 ㊤)	yong3shang5
 (涌 起)	yong3qi3
 (涞 水)	lai2shui3
-(涞 ㊌)	lai2shui3
 (涟 水)	lian2shui3
-(涟 ㊌)	lian2shui3
 (润 笔)	run4bi3
 (润 饼)	run4bing3
 (涧 西)	jian4xi1
-(涧 🀂)	jian4xi1
 (涨 水)	zhang3shui3
-(涨 ㊌)	zhang3shui3
 (涨 溢)	zhang4yi4
 (涨 满)	zhang4man3
 (涨 红)	zhang4hong2
@@ -51299,13 +49797,11 @@ $textmode
 (涵 養)	han2yang3
 (涼 快)	liang2kuai5
 (涼 水)	liang2shui3
-(涼 ㊌)	liang2shui3
 (涼 爽)	liang2shuang3
 (淀 粉)	dian4fen3
 (淋 巴)	lin2ba1
 (淋 巴)	lin2ba1
 (淑 女)	shu1nv3
-(淑 ㊛)	shu1nv3
 (淑 女)	shu1nv3
 (淒 惨)	qi1can3
 (淒 慘)	qi1can3
@@ -51313,41 +49809,32 @@ $textmode
 (淘 选)	tao2xuan3
 (淘 選)	tao2xuan3
 (淚 水)	lei4shui3
-(淚 ㊌)	lei4shui3
 (淚 水)	lei4shui3
-(淚 ㊌)	lei4shui3
 (淡 水)	dan4shui3
-(淡 ㊌)	dan4shui3
 (淡 薄)	dan4bo2
 (淡 酒)	dan4jiu3
 (淤 塞)	yu1se4
 (淤 塞)	yu1se4
 (淨 土)	jing4tu3
-(淨 ㊏)	jing4tu3
 (淨 盡)	jing4jin4
 (淪 沒)	lun2mo4
 (淪 沒)	lun2mo4
 (淪 為)	lun2wei2
 (淪 為)	lun2wei2
 (淫 水)	yin2shui3
-(淫 ㊌)	yin2shui3
 (淫 猥)	yin2wei3
 (淫 辱)	yin2ru3
 (淫 鬼)	yin2gui3
 (淬 火)	cui4huo3
-(淬 ㊋)	cui4huo3
 (淮 北)	huai2bei3
-(淮 🀃)	huai2bei3
 (淮 北)	huai2bei3
 (淯 水)	yu4shui3
-(淯 ㊌)	yu4shui3
 (深 井)	shen1jing3
 (深 广)	shen1guang3
 (深 廣)	shen1guang3
 (深 得)	shen1de2
 (深 感)	shen1gan3
 (深 水)	shen1shui3
-(深 ㊌)	shen1shui3
 (深 浅)	shen1qian3
 (深 海)	shen1hai3
 (深 海)	shen1hai3
@@ -51361,7 +49848,6 @@ $textmode
 (淳 樸)	chun2pu3
 (淵 藪)	yuan1sou3
 (淶 水)	lai2shui3
-(淶 ㊌)	lai2shui3
 (混 汞)	hun4gong3
 (混 淆)	hun4xiao2
 (混 矇)	hun4meng1
@@ -51377,7 +49863,6 @@ $textmode
 (淹 沒)	yan1mo4
 (淹 没)	yan1mo4
 (淺 水)	qian3shui3
-(淺 ㊌)	qian3shui3
 (淺 海)	qian3hai3
 (淺 海)	qian3hai3
 (淺 短)	qian3duan3
@@ -51396,7 +49881,6 @@ $textmode
 (清 朗)	qing1lang3
 (清 朗)	qing1lang3
 (清 水)	qing1shui3
-(清 ㊌)	qing1shui3
 (清 洗)	qing1xi3
 (清 澄)	qing1cheng2
 (清 点)	qing1dian3
@@ -51419,7 +49903,6 @@ $textmode
 (渔 网)	yu2wang3
 (渔 鼓)	yu2gu3
 (渗 水)	shen4shui3
-(渗 ㊌)	shen4shui3
 (減 免)	jian3mian3
 (減 免)	jian3mian3
 (減 小)	jian3xiao3
@@ -51428,7 +49911,6 @@ $textmode
 (減 產)	jian3chan3
 (減 緩)	jian3huan3
 (渝 水)	yu2shui3
-(渝 ㊌)	yu2shui3
 (渡 假)	du4jia4
 (渡 口)	du4kou3
 (渡 海)	du4hai3
@@ -51446,7 +49928,6 @@ $textmode
 (測 量)	ce4liang2
 (測 量)	ce4liang2
 (渭 水)	wei4shui3
-(渭 ㊌)	wei4shui3
 (港 口)	gang3kou3
 (港 府)	gang3fu3
 (港 股)	gang3gu3
@@ -51454,7 +49935,6 @@ $textmode
 (渴 死)	ke3si3
 (游 手)	you2shou3
 (游 水)	you2shui3
-(游 ㊌)	you2shui3
 (游 泳)	you2yong3
 (游 艇)	you2ting3
 (游 走)	you2zou3
@@ -51465,7 +49945,6 @@ $textmode
 (湊 巧)	cou4qiao3
 (湊 手)	cou4shou3
 (湖 北)	hu2bei3
-(湖 🀃)	hu2bei3
 (湖 北)	hu2bei3
 (湖 口)	hu2kou3
 (湖 广)	hu2guang3
@@ -51474,7 +49953,6 @@ $textmode
 (湖 海)	hu2hai3
 (湖 海)	hu2hai3
 (湟 水)	huang2shui3
-(湟 ㊌)	huang2shui3
 (湮 沒)	yan1mo4
 (湮 没)	yan1mo4
 (湮 滅)	yin1mie4
@@ -51486,7 +49964,6 @@ $textmode
 (湾 里)	wan1li3
 (湾 里)	wan1li3
 (湿 土)	shi1tu3
-(湿 ㊏)	shi1tu3
 (湿 地)	shi1di4
 (湿 疹)	shi1zhen3
 (溆 浦)	xu4pu3
@@ -51504,13 +49981,10 @@ $textmode
 (溜 達)	liu1da5
 (溝 谷)	gou1gu3
 (溢 水)	yi4shui3
-(溢 ㊌)	yi4shui3
 (溢 满)	yi4man3
 (溢 滿)	yi4man3
 (溧 水)	li4shui3
-(溧 ㊌)	li4shui3
 (溪 水)	xi1shui3
-(溪 ㊌)	xi1shui3
 (溪 谷)	xi1gu3
 (溫 嶺)	wen1ling3
 (溫 嶺)	wen1ling3
@@ -51526,16 +50000,13 @@ $textmode
 (溺 愛)	ni4ai4
 (溺 愛)	ni4ai4
 (溺 水)	ni4shui3
-(溺 ㊌)	ni4shui3
 (溺 水)	ni4shui3
-(溺 ㊌)	ni4shui3
 (溺 爱)	ni4ai4
 (溺 爱)	ni4ai4
 (滄 海)	cang1hai3
 (滄 海)	cang1hai3
 (滅 沒)	mie4mo4
 (滅 火)	mie4huo3
-(滅 ㊋)	mie4huo3
 (滅 跡)	mie4ji4
 (滇 藏)	dian1zang4
 (滋 养)	zi1yang3
@@ -51562,9 +50033,7 @@ $textmode
 (滑 板)	hua2ban3
 (滑 板)	hua2ban3
 (滑 水)	hua2shui3
-(滑 ㊌)	hua2shui3
 (滑 水)	hua2shui3
-(滑 ㊌)	hua2shui3
 (滑 溜)	hua2liu5
 (滑 溜)	hua2liu5
 (滑 溜)	hua2liu5
@@ -51575,9 +50044,7 @@ $textmode
 (滑 鼠)	hua2shu3
 (滑 鼠)	hua2shu3
 (滚 上)	gun3shang5
-(滚 ㊤)	gun3shang5
 (滚 水)	gun3shui3
-(滚 ㊌)	gun3shui3
 (滚 滚)	gun3gun3
 (滚 筒)	gun3tong3
 (满 口)	man3kou3
@@ -51598,16 +50065,12 @@ $textmode
 (滨 海)	bin1hai3
 (滨 海)	bin1hai3
 (滲 水)	shen4shui3
-(滲 ㊌)	shen4shui3
 (滴 水)	di1shui3
-(滴 ㊌)	di1shui3
 (滴 答)	di1da5
 (滴 管)	di1guan3
 (滷 法)	lu3fa3
 (滾 上)	gun3shang5
-(滾 ㊤)	gun3shang5
 (滾 水)	gun3shui3
-(滾 ㊌)	gun3shui3
 (滾 滾)	gun3gun3
 (滾 筒)	gun3tong3
 (滿 口)	man3kou3
@@ -51646,9 +50109,7 @@ $textmode
 (漏 斗)	lou4dou3
 (漏 斗)	lou4dou3
 (漏 水)	lou4shui3
-(漏 ㊌)	lou4shui3
 (漏 水)	lou4shui3
-(漏 ㊌)	lou4shui3
 (漏 雨)	lou4yu3
 (漏 雨)	lou4yu3
 (演 武)	yan3wu3
@@ -51661,21 +50122,15 @@ $textmode
 (漢 堡)	han4bao3
 (漢 堡)	han4bao3
 (漢 水)	han4shui3
-(漢 ㊌)	han4shui3
 (漢 水)	han4shui3
-(漢 ㊌)	han4shui3
 (漢 水)	han4shui3
-(漢 ㊌)	han4shui3
 (漢 語)	han4yu3
 (漢 語)	han4yu3
 (漢 語)	han4yu3
 (漣 水)	lian2shui3
-(漣 ㊌)	lian2shui3
 (漣 水)	lian2shui3
-(漣 ㊌)	lian2shui3
 (漯 河)	luo4he2
 (漲 水)	zhang3shui3
-(漲 ㊌)	zhang3shui3
 (漲 溢)	zhang4yi4
 (漲 滿)	zhang4man3
 (漲 紅)	zhang4hong2
@@ -51689,28 +50144,23 @@ $textmode
 (潑 辣)	po1la5
 (潛 影)	qian2ying3
 (潛 水)	qian2shui3
-(潛 ㊌)	qian2shui3
 (潛 沒)	qian2mo4
 (潛 泳)	qian2yong3
 (潛 艇)	qian2ting3
 (潛 鳥)	qian2niao3
 (潜 影)	qian2ying3
 (潜 水)	qian2shui3
-(潜 ㊌)	qian2shui3
 (潜 没)	qian2mo4
 (潜 泳)	qian2yong3
 (潜 艇)	qian2ting3
 (潜 鸟)	qian2niao3
 (潞 西)	lu4xi1
-(潞 🀂)	lu4xi1
 (潤 筆)	run4bi3
 (潤 餅)	run4bing3
 (潦 倒)	liao2dao3
 (潦 草)	liao2cao3
 (潭 水)	tan2shui3
-(潭 ㊌)	tan2shui3
 (潮 水)	chao2shui3
-(潮 ㊌)	chao2shui3
 (潮 涌)	chao2yong3
 (潮 解)	chao2jie3
 (澄 城)	cheng2cheng2
@@ -51721,17 +50171,13 @@ $textmode
 (澄 迈)	cheng2mai4
 (澄 邁)	cheng2mai4
 (澆 水)	jiao1shui3
-(澆 ㊌)	jiao1shui3
 (澎 湃)	peng2pai4
 (澗 西)	jian4xi1
-(澗 🀂)	jian4xi1
 (澠 池)	mian3chi2
 (澤 塔)	ze2ta3
 (澤 普)	ze2pu3
 (澤 西)	ze2xi1
-(澤 🀂)	ze2xi1
 (澧 水)	li3shui3
-(澧 ㊌)	li3shui3
 (澱 粉)	dian4fen3
 (澳 紐)	ao4niu3
 (澳 紐)	ao4niu3
@@ -51743,11 +50189,9 @@ $textmode
 (濒 海)	bin1hai3
 (濒 海)	bin1hai3
 (濕 土)	shi1tu3
-(濕 ㊏)	shi1tu3
 (濕 地)	shi1di4
 (濕 疹)	shi1zhen3
 (濟 南)	ji3nan2
-(濟 🀁)	ji3nan2
 (濰 坊)	wei2fang1
 (濱 海)	bin1hai3
 (濱 海)	bin1hai3
@@ -51758,49 +50202,34 @@ $textmode
 (濾 餅)	lv4bing3
 (濾 餅)	lv4bing3
 (瀍 水)	chan2shui3
-(瀍 ㊌)	chan2shui3
 (瀏 覽)	liu2lan3
 (瀕 於)	bin1yu2
 (瀕 死)	bin1si3
 (瀕 海)	bin1hai3
 (瀕 海)	bin1hai3
 (瀘 水)	lu2shui3
-(瀘 ㊌)	lu2shui3
 (瀘 西)	lu2xi1
-(瀘 🀂)	lu2xi1
 (瀟 灑)	xiao1sa3
 (瀧 水)	long2shui3
-(瀧 ㊌)	long2shui3
 (灃 水)	feng1shui3
-(灃 ㊌)	feng1shui3
 (灑 水)	sa3shui3
-(灑 ㊌)	sa3shui3
 (灑 滿)	sa3man3
 (灑 脫)	sa3tuo5
 (灣 仔)	wan1zai3
 (灣 裡)	wan1li3
 (灣 裡)	wan1li3
 (火 儿)	huo3r5
-(㊋ 儿)	huo3r5
 (火 剪)	huo3jian3
-(㊋ 剪)	huo3jian3
 (火 把)	huo3ba3
-(㊋ 把)	huo3ba3
 (火 种)	huo3zhong3
-(㊋ 种)	huo3zhong3
 (火 種)	huo3zhong3
-(㊋ 種)	huo3zhong3
 (火 腿)	huo3tui3
-(㊋ 腿)	huo3tui3
 (火 警)	huo3jing3
-(㊋ 警)	huo3jing3
 (灭 没)	mie4mo4
 (灭 火)	mie4huo3
-(灭 ㊋)	mie4huo3
 (灭 迹)	mie4ji4
 (灯 塔)	deng1ta3
 (灯 火)	deng1huo3
-(灯 ㊋)	deng1huo3
 (灯 盏)	deng1zhan3
 (灯 笼)	deng1long5
 (灯 管)	deng1guan3
@@ -51821,14 +50250,11 @@ $textmode
 (災 難)	zai1nan4
 (灾 难)	zai1nan4
 (炉 火)	lu2huo3
-(炉 ㊋)	lu2huo3
 (炉 长)	lu2zhang3
 (炭 火)	tan4huo3
-(炭 ㊋)	tan4huo3
 (炮 塔)	pao4ta3
 (炮 手)	pao4shou3
 (炮 火)	pao4huo3
-(炮 ㊋)	pao4huo3
 (炮 艇)	pao4ting3
 (炯 炯)	jiong3jiong3
 (炸 死)	zha4si3
@@ -51848,9 +50274,7 @@ $textmode
 (点 染)	dian3ran3
 (点 检)	dian3jian3
 (点 水)	dian3shui3
-(点 ㊌)	dian3shui3
 (点 火)	dian3huo3
-(点 ㊋)	dian3huo3
 (点 点)	dian3dian3
 (点 着)	dian3zhao2
 (点 着)	dian3zhao2
@@ -51896,9 +50320,7 @@ $textmode
 (烈 屬)	lie4shu3
 (烈 屬)	lie4shu3
 (烈 火)	lie4huo3
-(烈 ㊋)	lie4huo3
 (烈 火)	lie4huo3
-(烈 ㊋)	lie4huo3
 (烈 酒)	lie4jiu3
 (烈 酒)	lie4jiu3
 (烏 什)	wu1shi2
@@ -51911,7 +50333,6 @@ $textmode
 (烏 爾)	wu4er3
 (烏 瑪)	wu1ma3
 (烏 西)	wu1xi1
-(烏 🀂)	wu1xi1
 (烏 語)	wu1yu3
 (烏 鱧)	wu1li3
 (烘 乾)	hong1gan1
@@ -51925,14 +50346,12 @@ $textmode
 (烟 海)	yan1hai3
 (烟 海)	yan1hai3
 (烟 火)	yan1huo3
-(烟 ㊋)	yan1huo3
 (烟 瘾)	yan1yin3
 (烟 碱)	yan1jian3
 (烟 筒)	yan1tong5
 (烟 草)	yan1cao3
 (烟 鬼)	yan1gui3
 (烤 火)	kao3huo3
-(烤 ㊋)	kao3huo3
 (烤 熟)	kao3shou2
 (烤 餅)	kao3bing3
 (烤 饼)	kao3bing3
@@ -51943,7 +50362,6 @@ $textmode
 (烧 死)	shao1si3
 (烧 毁)	shao1hui3
 (烧 火)	shao1huo3
-(烧 ㊋)	shao1huo3
 (烧 烤)	shao1kao3
 (烧 煮)	shao1zhu3
 (烧 煮)	shao1zhu3
@@ -51961,7 +50379,6 @@ $textmode
 (热 岛)	re4dao3
 (热 捧)	re4peng3
 (热 水)	re4shui3
-(热 ㊌)	re4shui3
 (热 点)	re4dian3
 (热 狗)	re4gou3
 (热 补)	re4bu3
@@ -51971,7 +50388,6 @@ $textmode
 (烹 調)	peng1tiao2
 (烹 调)	peng1tiao2
 (烽 火)	feng1huo3
-(烽 ㊋)	feng1huo3
 (焉 得)	yan1de2
 (焙 乾)	bei4gan1
 (焙 烤)	bei4kao3
@@ -51986,11 +50402,9 @@ $textmode
 (無 我)	wu2wo3
 (無 損)	wu2sun3
 (無 有)	wu2you3
-(無 ㊒)	wu2you3
 (無 比)	wu2bi3
 (無 氧)	wu2yang3
 (無 水)	wu2shui3
-(無 ㊌)	wu2shui3
 (無 法)	wu2fa3
 (無 為)	wu2wei2
 (無 爪)	wu2zhua3
@@ -52005,12 +50419,10 @@ $textmode
 (無 軌)	wu2gui3
 (無 間)	wu2jian4
 (焦 土)	jiao1tu3
-(焦 ㊏)	jiao1tu3
 (焦 点)	jiao1dian3
 (焦 耳)	jiao1er3
 (焦 點)	jiao1dian3
 (焰 火)	yan4huo3
-(焰 ㊋)	yan4huo3
 (然 也)	ran2ye3
 (煉 乳)	lian4ru3
 (煉 乳)	lian4ru3
@@ -52023,7 +50435,6 @@ $textmode
 (煙 海)	yan1hai3
 (煙 海)	yan1hai3
 (煙 火)	yan1huo3
-(煙 ㊋)	yan1huo3
 (煙 癮)	yan1yin3
 (煙 筒)	yan1tong5
 (煙 草)	yan1cao3
@@ -52059,7 +50470,6 @@ $textmode
 (煮 熟)	zhu3shou2
 (煮 熟)	zhu3shou2
 (熄 火)	xi1huo3
-(熄 ㊋)	xi1huo3
 (熊 掌)	xiong2zhang3
 (熊 本)	xiong2ben3
 (熏 染)	xun1ran3
@@ -52082,7 +50492,6 @@ $textmode
 (熱 島)	re4dao3
 (熱 捧)	re4peng3
 (熱 水)	re4shui3
-(熱 ㊌)	re4shui3
 (熱 狗)	re4gou3
 (熱 補)	re4bu3
 (熱 飲)	re4yin3
@@ -52092,10 +50501,8 @@ $textmode
 (燃 起)	ran2qi3
 (燃 點)	ran2dian3
 (燄 火)	yan4huo3
-(燄 ㊋)	yan4huo3
 (燈 塔)	deng1ta3
 (燈 火)	deng1huo3
-(燈 ㊋)	deng1huo3
 (燈 盞)	deng1zhan3
 (燈 管)	deng1guan3
 (燈 籠)	deng1long5
@@ -52104,7 +50511,6 @@ $textmode
 (燒 死)	shao1si3
 (燒 毀)	shao1hui3
 (燒 火)	shao1huo3
-(燒 ㊋)	shao1huo3
 (燒 烤)	shao1kao3
 (燒 煮)	shao1zhu3
 (燒 煮)	shao1zhu3
@@ -52133,9 +50539,7 @@ $textmode
 (爆 滿)	bao4man3
 (爆 管)	bao4guan3
 (爐 火)	lu2huo3
-(爐 ㊋)	lu2huo3
 (爐 火)	lu2huo3
-(爐 ㊋)	lu2huo3
 (爐 長)	lu2zhang3
 (爐 長)	lu2zhang3
 (爛 崽)	lan4zai3
@@ -52153,7 +50557,6 @@ $textmode
 (爭 競)	zheng1jing5
 (爱 人)	ai4ren5
 (爱 女)	ai4nv3
-(爱 ㊛)	ai4nv3
 (爱 女)	ai4nv3
 (爱 好)	ai4hao4
 (爱 子)	ai4zi3
@@ -52181,7 +50584,6 @@ $textmode
 (片 儿)	pian1r5
 (片 兒)	pian1r5
 (片 名)	pian1ming2
-(片 ㊔)	pian1ming2
 (片 子)	pian1zi5
 (片 語)	pian4yu3
 (片 语)	pian4yu3
@@ -52243,61 +50645,32 @@ $textmode
 (牵 累)	qian1lei3
 (牵 累)	qian1lei3
 (特 产)	te4chan3
-(㊕ 产)	te4chan3
 (特 使)	te4shi3
-(㊕ 使)	te4shi3
 (特 免)	te4mian3
-(㊕ 免)	te4mian3
 (特 免)	te4mian3
-(㊕ 免)	te4mian3
 (特 写)	te4xie3
-(特 ㊢)	te4xie3
-(㊕ 写)	te4xie3
 (特 地)	te4di4
-(㊕ 地)	te4di4
 (特 寫)	te4xie3
-(㊕ 寫)	te4xie3
 (特 徵)	te4zheng1
-(㊕ 徵)	te4zheng1
 (特 指)	te4zhi3
-(㊕ 指)	te4zhi3
 (特 有)	te4you3
-(特 ㊒)	te4you3
-(㊕ 有)	te4you3
 (特 此)	te4ci3
-(㊕ 此)	te4ci3
 (特 点)	te4dian3
-(㊕ 点)	te4dian3
 (特 瓦)	te4wa3
-(㊕ 瓦)	te4wa3
 (特 產)	te4chan3
-(㊕ 產)	te4chan3
 (特 种)	te4zhong3
-(㊕ 种)	te4zhong3
 (特 種)	te4zhong3
-(㊕ 種)	te4zhong3
 (特 等)	te4deng3
-(㊕ 等)	te4deng3
 (特 許)	te4xu3
-(㊕ 許)	te4xu3
 (特 調)	te4tiao2
-(㊕ 調)	te4tiao2
 (特 調)	te4tiao2
-(㊕ 調)	te4tiao2
 (特 警)	te4jing3
-(㊕ 警)	te4jing3
 (特 许)	te4xu3
-(㊕ 许)	te4xu3
 (特 调)	te4tiao2
-(㊕ 调)	te4tiao2
 (特 起)	te4qi3
-(㊕ 起)	te4qi3
 (特 輯)	te4ji2
-(㊕ 輯)	te4ji2
 (特 辑)	te4ji2
-(㊕ 辑)	te4ji2
 (特 點)	te4dian3
-(㊕ 點)	te4dian3
 (牽 引)	qian1yin3
 (牽 強)	qian1qiang3
 (牽 手)	qian1shou3
@@ -52341,7 +50714,6 @@ $textmode
 (独 得)	du2de2
 (独 揽)	du2lan3
 (独 有)	du2you3
-(独 ㊒)	du2you3
 (独 眼)	du2yan3
 (独 胆)	du2dan3
 (独 舞)	du2wu3
@@ -52367,8 +50739,6 @@ $textmode
 (猎 犬)	lie4quan3
 (猎 狗)	lie4gou3
 (猜 中)	cai1zhong4
-(猜 🀄)	cai1zhong4
-(猜 ㊥)	cai1zhong4
 (猜 度)	cai1duo2
 (猜 度)	cai1duo2
 (猜 想)	cai1xiang3
@@ -52379,7 +50749,6 @@ $textmode
 (猪 狗)	zhu1gou3
 (猫 儿)	mao1r5
 (献 上)	xian4shang5
-(献 ㊤)	xian4shang5
 (献 礼)	xian4li3
 (献 礼)	xian4li3
 (献 给)	xian4gei3
@@ -52396,7 +50765,6 @@ $textmode
 (獨 得)	du2de2
 (獨 攬)	du2lan3
 (獨 有)	du2you3
-(獨 ㊒)	du2you3
 (獨 眼)	du2yan3
 (獨 膽)	du2dan3
 (獨 舞)	du2wu3
@@ -52417,7 +50785,6 @@ $textmode
 (獵 狗)	lie4gou3
 (獵 狗)	lie4gou3
 (獻 上)	xian4shang5
-(獻 ㊤)	xian4shang5
 (獻 禮)	xian4li3
 (獻 禮)	xian4li3
 (獻 給)	xian4gei3
@@ -52446,7 +50813,6 @@ $textmode
 (王 储)	wang2chu3
 (王 儲)	wang2chu3
 (王 八)	wang2ba5
-(王 ㊇)	wang2ba5
 (王 冠)	wang2guan1
 (王 子)	wang2zi3
 (王 导)	wang2dao3
@@ -52454,7 +50820,6 @@ $textmode
 (王 府)	wang2fu3
 (王 母)	wang2mu3
 (王 水)	wang2shui3
-(王 ㊌)	wang2shui3
 (王 法)	wang2fa3
 (王 猛)	wang2meng3
 (王 码)	wang2ma3
@@ -52476,7 +50841,6 @@ $textmode
 (玩 偶)	wan2ou3
 (玩 儿)	wan2r5
 (玩 火)	wan2huo3
-(玩 ㊋)	wan2huo3
 (玩 索)	wan2suo3
 (玩 索)	wan2suo3
 (玩 者)	wan2zhe3
@@ -52491,7 +50855,6 @@ $textmode
 (环 法)	huan2fa3
 (现 场)	xian4chang3
 (现 有)	xian4you3
-(现 ㊒)	xian4you3
 (现 款)	xian4kuan3
 (玷 辱)	dian4ru3
 (玻 璃)	bo1li5
@@ -52515,7 +50878,6 @@ $textmode
 (班 长)	ban1zhang3
 (現 場)	xian4chang3
 (現 有)	xian4you3
-(現 ㊒)	xian4you3
 (現 款)	xian4kuan3
 (球 场)	qiu2chang3
 (球 場)	qiu2chang3
@@ -52603,7 +50965,6 @@ $textmode
 (甚 麽)	shen2me5
 (甜 品)	tian2pin3
 (甜 水)	tian2shui3
-(甜 ㊌)	tian2shui3
 (甜 点)	tian2dian3
 (甜 筒)	tian2tong3
 (甜 美)	tian2mei3
@@ -52613,19 +50974,15 @@ $textmode
 (生 产)	sheng1chan3
 (生 养)	sheng1yang3
 (生 土)	sheng1tu3
-(生 ㊏)	sheng1tu3
 (生 子)	sheng1zi3
 (生 息)	sheng1xi1
 (生 意)	sheng1yi5
 (生 於)	sheng1yu2
 (生 日)	sheng1ri5
-(生 ㊐)	sheng1ri5
 (生 死)	sheng1si3
 (生 母)	sheng1mu3
 (生 水)	sheng1shui3
-(生 ㊌)	sheng1shui3
 (生 火)	sheng1huo3
-(生 ㊋)	sheng1huo3
 (生 為)	sheng1wei2
 (生 理)	sheng1li3
 (生 理)	sheng1li3
@@ -52647,7 +51004,6 @@ $textmode
 (產 品)	chan3pin3
 (產 地)	chan3di4
 (甥 女)	sheng1nv3
-(甥 ㊛)	sheng1nv3
 (甥 女)	sheng1nv3
 (甦 醒)	su1xing3
 (用 主)	yong4zhu3
@@ -52659,7 +51015,6 @@ $textmode
 (用 於)	yong4yu2
 (用 武)	yong4wu3
 (用 水)	yong4shui3
-(用 ㊌)	yong4shui3
 (用 法)	yong4fa3
 (用 盡)	yong4jin4
 (用 處)	yong4chu5
@@ -52721,12 +51076,8 @@ $textmode
 (电 钮)	dian4niu3
 (电 阻)	dian4zu3
 (男 女)	nan2nv3
-(㊚ 女)	nan2nv3
-(男 ㊛)	nan2nv3
 (男 女)	nan2nv3
-(㊚ 女)	nan2nv3
 (男 子)	nan2zi3
-(㊚ 子)	nan2zi3
 (画 儿)	hua4r5
 (画 儿)	hua4r5
 (画 卷)	hua4juan4
@@ -52806,7 +51157,6 @@ $textmode
 (異 體)	yi4ti3
 (異 體)	yi4ti3
 (當 上)	dang1shang5
-(當 ㊤)	dang1shang5
 (當 作)	dang4zuo4
 (當 做)	dang4zuo4
 (當 地)	dang1di4
@@ -52815,7 +51165,6 @@ $textmode
 (當 成)	dang4cheng2
 (當 晚)	dang4wan3
 (當 月)	dang4yue4
-(當 ㊊)	dang4yue4
 (當 涂)	dang1tu2
 (當 為)	dang1wei2
 (當 真)	dang4zhen1
@@ -52823,7 +51172,6 @@ $textmode
 (當 鋪)	dang4pu4
 (畹 町)	wan3ting3
 (疆 土)	jiang1tu3
-(疆 ㊏)	jiang1tu3
 (疆 场)	jiang1chang3
 (疆 場)	jiang1chang3
 (疊 起)	die2qi3
@@ -52887,7 +51235,6 @@ $textmode
 (瘧 疾)	nve4ji5
 (瘧 蚊)	nve4wen2
 (瘪 三)	bie1san1
-(瘪 ㊂)	bie1san1
 (瘫 软)	tan1ruan3
 (瘸 腿)	que2tui3
 (療 法)	liao2fa3
@@ -52896,7 +51243,6 @@ $textmode
 (療 養)	liao2yang3
 (癖 好)	pi3hao4
 (癟 三)	bie1san1
-(癟 ㊂)	bie1san1
 (癢 癢)	yang3yang5
 (癥 候)	zheng4hou5
 (癥 結)	zheng1jie2
@@ -52918,7 +51264,6 @@ $textmode
 (發 抖)	fa1dou3
 (發 泡)	fa1pao2
 (發 火)	fa1huo3
-(發 ㊋)	fa1huo3
 (發 癢)	fa1yang3
 (發 窘)	fa1jiong3
 (發 給)	fa1gei3
@@ -52951,7 +51296,6 @@ $textmode
 (白 樸)	bai2pu3
 (白 死)	bai2si3
 (白 水)	bai2shui3
-(白 ㊌)	bai2shui3
 (白 眼)	bai2yan3
 (白 种)	bai2zhong3
 (白 種)	bai2zhong3
@@ -52989,7 +51333,6 @@ $textmode
 (的 確)	di2que4
 (皆 可)	jie1ke3
 (皇 上)	huang2shang5
-(皇 ㊤)	huang2shang5
 (皇 储)	huang2chu3
 (皇 儲)	huang2chu3
 (皇 冠)	huang2guan1
@@ -53028,7 +51371,6 @@ $textmode
 (监 考)	jian1kao3
 (盔 甲)	kui1jia3
 (盖 上)	gai4shang5
-(盖 ㊤)	gai4shang5
 (盖 儿)	gai4r5
 (盖 好)	gai4hao3
 (盖 尔)	gai4er3
@@ -53072,9 +51414,7 @@ $textmode
 (盡 速)	jin4su4
 (盡 頭)	jin4tou2
 (監 管)	jian1guan3
-(㊬ 管)	jian1guan3
 (監 考)	jian1kao3
-(㊬ 考)	jian1kao3
 (盤 古)	pan2gu3
 (盤 碗)	pan2wan3
 (盤 算)	pan2suan5
@@ -53180,10 +51520,7 @@ $textmode
 (眉 毛)	mei2mao5
 (眉 目)	mei2mu5
 (看 上)	kan4shang5
-(看 ㊤)	kan4shang5
 (看 中)	kan4zhong4
-(看 🀄)	kan4zhong4
-(看 ㊥)	kan4zhong4
 (看 來)	kan4lai5
 (看 來)	kan4lai5
 (看 准)	kan4zhun3
@@ -53281,9 +51618,7 @@ $textmode
 (着 法)	zhao1fa3
 (着 法)	zhao1fa3
 (着 火)	zhao2huo3
-(着 ㊋)	zhao2huo3
 (着 火)	zhao2huo3
-(着 ㊋)	zhao2huo3
 (着 用)	zhao2yong4
 (着 用)	zhao2yong4
 (着 眼)	zhuo2yan3
@@ -53363,7 +51698,6 @@ $textmode
 (矫 情)	jiao3qing2
 (矫 捷)	jiao3jie2
 (矫 正)	jiao3zheng4
-(矫 ㊣)	jiao3zheng4
 (矫 治)	jiao3zhi4
 (矫 矫)	jiao3jiao3
 (矫 诏)	jiao3zhao4
@@ -53384,13 +51718,11 @@ $textmode
 (矯 情)	jiao3qing2
 (矯 捷)	jiao3jie2
 (矯 正)	jiao3zheng4
-(矯 ㊣)	jiao3zheng4
 (矯 治)	jiao3zhi4
 (矯 矯)	jiao3jiao3
 (矯 詔)	jiao3zhao4
 (石 头)	shi2tou5
 (石 女)	shi2nv3
-(石 ㊛)	shi2nv3
 (石 女)	shi2nv3
 (石 子)	shi2zi3
 (石 岗)	shi2gang3
@@ -53412,7 +51744,6 @@ $textmode
 (矿 产)	kuang4chan3
 (矿 场)	kuang4chang3
 (矿 水)	kuang4shui3
-(矿 ㊌)	kuang4shui3
 (矿 难)	kuang4nan4
 (码 头)	ma3tou5
 (砍 倒)	kan3dao3
@@ -53435,7 +51766,6 @@ $textmode
 (破 产)	po4chan3
 (破 口)	po4kou3
 (破 土)	po4tu3
-(破 ㊏)	po4tu3
 (破 损)	po4sun3
 (破 損)	po4sun3
 (破 晓)	po4xiao3
@@ -53457,7 +51787,6 @@ $textmode
 (硬 朗)	ying4lang5
 (硬 朗)	ying4lang5
 (硬 水)	ying4shui3
-(硬 ㊌)	ying4shui3
 (硬 紙)	ying4zhi3
 (硬 纸)	ying4zhi3
 (硬 起)	ying4qi5
@@ -53478,7 +51807,6 @@ $textmode
 (碑 帖)	bei1tie4
 (碑 帖)	bei1tie4
 (碧 土)	bi4tu3
-(碧 ㊏)	bi4tu3
 (碧 玺)	bi4xi3
 (碧 璽)	bi4xi3
 (碧 瓦)	bi4wa3
@@ -53487,9 +51815,7 @@ $textmode
 (碰 损)	peng4sun3
 (碰 損)	peng4sun3
 (碱 土)	jian3tu3
-(碱 ㊏)	jian3tu3
 (碱 水)	jian3shui3
-(碱 ㊌)	jian3shui3
 (確 保)	que4bao3
 (確 診)	que4zhen3
 (碼 頭)	ma3tou5
@@ -53526,7 +51852,6 @@ $textmode
 (磯 法)	ji1fa3
 (磴 口)	deng4kou3
 (磷 火)	lin2huo3
-(磷 ㊋)	lin2huo3
 (礁 岛)	jiao1dao3
 (礁 島)	jiao1dao3
 (礙 口)	ai4kou3
@@ -53534,7 +51859,6 @@ $textmode
 (礦 井)	kuang4jing3
 (礦 場)	kuang4chang3
 (礦 水)	kuang4shui3
-(礦 ㊌)	kuang4shui3
 (礦 產)	kuang4chan3
 (礦 難)	kuang4nan4
 (礦 難)	kuang4nan4
@@ -53557,18 +51881,12 @@ $textmode
 (礼 法)	li3fa3
 (礼 法)	li3fa3
 (社 保)	she4bao3
-(㊓ 保)	she4bao3
 (社 保)	she4bao3
 (社 火)	she4huo3
-(社 ㊋)	she4huo3
-(㊓ 火)	she4huo3
 (社 火)	she4huo3
-(社 ㊋)	she4huo3
 (社 長)	she4zhang3
-(㊓ 長)	she4zhang3
 (社 長)	she4zhang3
 (社 长)	she4zhang3
-(㊓ 长)	she4zhang3
 (社 长)	she4zhang3
 (祇 讀)	zhi1du2
 (祇 讀)	zhi1du2
@@ -53592,10 +51910,8 @@ $textmode
 (祖 鸟)	zu3niao3
 (祖 鸟)	zu3niao3
 (祝 好)	zhu4hao3
-(㊗ 好)	zhu4hao3
 (祝 好)	zhu4hao3
 (祝 酒)	zhu4jiu3
-(㊗ 酒)	zhu4jiu3
 (祝 酒)	zhu4jiu3
 (神 仙)	shen2xian1
 (神 仙)	shen2xian1
@@ -53607,10 +51923,8 @@ $textmode
 (神 勇)	shen2yong3
 (神 勇)	shen2yong3
 (神 女)	shen2nv3
-(神 ㊛)	shen2nv3
 (神 女)	shen2nv3
 (神 女)	shen2nv3
-(神 ㊛)	shen2nv3
 (神 曲)	shen2qu3
 (神 曲)	shen2qu3
 (神 父)	shen2fu5
@@ -53689,7 +52003,6 @@ $textmode
 (福 鼎)	fu2ding3
 (禪 堂)	chan2tang2
 (禪 宗)	chan2zong1
-(禪 ㊪)	chan2zong1
 (禪 師)	chan2shi1
 (禪 房)	chan2fang2
 (禪 杖)	chan2zhang4
@@ -53726,7 +52039,6 @@ $textmode
 (秀 美)	xiu4mei3
 (私 地)	si1di4
 (私 有)	si1you3
-(私 ㊒)	si1you3
 (私 法)	si1fa3
 (私 語)	si1yu3
 (私 语)	si1yu3
@@ -53741,9 +52053,7 @@ $textmode
 (秋 瑾)	qiu1jin3
 (秋 雨)	qiu1yu3
 (种 上)	zhong4shang5
-(种 ㊤)	zhong4shang5
 (种 下)	zhong4xia4
-(种 ㊦)	zhong4xia4
 (种 地)	zhong4di4
 (种 差)	zhong3cha1
 (种 树)	zhong4shu4
@@ -53763,13 +52073,9 @@ $textmode
 (科 長)	ke1zhang3
 (科 长)	ke1zhang3
 (秘 本)	mi4ben3
-(㊙ 本)	mi4ben3
 (秘 魯)	bi4lu3
-(㊙ 魯)	bi4lu3
 (秘 魯)	bi4lu3
-(㊙ 魯)	bi4lu3
 (秘 鲁)	bi4lu3
-(㊙ 鲁)	bi4lu3
 (租 給)	zu1gei3
 (租 给)	zu1gei3
 (秤 杆)	cheng4gan3
@@ -53778,7 +52084,6 @@ $textmode
 (秦 嶺)	qin2ling3
 (秦 嶺)	qin2ling3
 (秦 火)	qin2huo3
-(秦 ㊋)	qin2huo3
 (秧 歌)	yang1ge5
 (积 攒)	ji1zan3
 (积 祖)	ji1zu3
@@ -53799,10 +52104,8 @@ $textmode
 (移 走)	yi2zou3
 (秽 迹)	hui4ji4
 (稀 土)	xi1tu3
-(稀 ㊏)	xi1tu3
 (稀 少)	xi1shao3
 (稀 有)	xi1you3
-(稀 ㊒)	xi1you3
 (稀 罕)	xi1han5
 (稅 務)	shui4wu4
 (稅 款)	shui4kuan3
@@ -53816,9 +52119,7 @@ $textmode
 (稜 角)	leng2jiao3
 (稜 角)	leng2jiao3
 (種 上)	zhong4shang5
-(種 ㊤)	zhong4shang5
 (種 下)	zhong4xia4
-(種 ㊦)	zhong4xia4
 (種 地)	zhong4di4
 (種 差)	zhong3cha1
 (種 植)	zhong4zhi2
@@ -53887,10 +52188,8 @@ $textmode
 (空 挡)	kong1dang4
 (空 擋)	kong1dang4
 (空 日)	kong4ri4
-(空 ㊐)	kong4ri4
 (空 暇)	kong4xia2
 (空 有)	kong1you3
-(空 ㊒)	kong1you3
 (空 格)	kong4ge2
 (空 當)	kong4dang1
 (空 白)	kong4bai2
@@ -53910,7 +52209,6 @@ $textmode
 (空 额)	kong4e2
 (空 餘)	kong4yu2
 (穿 上)	chuan1shang5
-(穿 ㊤)	chuan1shang5
 (穿 着)	chuan1zhuo2
 (穿 着)	chuan1zhuo2
 (穿 耳)	chuan1er3
@@ -53944,9 +52242,7 @@ $textmode
 (竄 改)	cuan4gai3
 (竊 取)	qie4qu3
 (立 下)	li4xia5
-(立 ㊦)	li4xia5
 (立 下)	li4xia5
-(立 ㊦)	li4xia5
 (立 体)	li4ti3
 (立 体)	li4ti3
 (立 场)	li4chang3
@@ -53977,7 +52273,6 @@ $textmode
 (竞 选)	jing4xuan3
 (竟 敢)	jing4gan3
 (童 女)	tong2nv3
-(童 ㊛)	tong2nv3
 (童 女)	tong2nv3
 (竭 盡)	jie2jin4
 (端 午)	duan1wu3
@@ -53986,7 +52281,6 @@ $textmode
 (競 走)	jing4zou3
 (競 選)	jing4xuan3
 (竹 北)	zhu2bei3
-(竹 🀃)	zhu2bei3
 (竹 北)	zhu2bei3
 (竹 岛)	zhu2dao3
 (竹 島)	zhu2dao3
@@ -54017,9 +52311,7 @@ $textmode
 (笛 手)	di2shou3
 (符 板)	fu2ban3
 (第 九)	di4jiu3
-(第 ㊈)	di4jiu3
 (第 五)	di4wu3
-(第 ㊄)	di4wu3
 (笼 头)	long2tou5
 (笼 槛)	long2jian4
 (笼 络)	long3luo4
@@ -54042,7 +52334,6 @@ $textmode
 (筋 斗)	jin1dou3
 (筋 骨)	jin1gu3
 (筑 土)	zhu4tu3
-(筑 ㊏)	zhu4tu3
 (筑 起)	zhu4qi3
 (答 允)	da1yun3
 (答 卷)	da2juan4
@@ -54073,7 +52364,6 @@ $textmode
 (签 署)	qian1shu3
 (简 体)	jian3ti3
 (简 写)	jian3xie3
-(简 ㊢)	jian3xie3
 (简 史)	jian3shi3
 (简 帖)	jian3tie3
 (简 朴)	jian3pu3
@@ -54098,11 +52388,8 @@ $textmode
 (節 氣)	jie2qi5
 (節 氣)	jie2qi5
 (節 水)	jie2shui3
-(節 ㊌)	jie2shui3
 (節 水)	jie2shui3
-(節 ㊌)	jie2shui3
 (節 水)	jie2shui3
-(節 ㊌)	jie2shui3
 (節 省)	jie2sheng3
 (節 省)	jie2sheng3
 (節 省)	jie2sheng3
@@ -54118,10 +52405,8 @@ $textmode
 (篆 體)	zhuan4ti3
 (篇 幅)	pian1fu5
 (築 土)	zhu4tu3
-(築 ㊏)	zhu4tu3
 (築 起)	zhu4qi3
 (篝 火)	gou1huo3
-(篝 ㊋)	gou1huo3
 (篡 改)	cuan4gai3
 (篤 守)	du3shou3
 (篩 檢)	shai1jian3
@@ -54173,7 +52458,6 @@ $textmode
 (类 比)	lei4bi3
 (籼 米)	xian1mi3
 (粉 土)	fen3tu3
-(粉 ㊏)	fen3tu3
 (粉 笔)	fen3bi3
 (粉 筆)	fen3bi3
 (粒 子)	li4zi3
@@ -54192,7 +52476,6 @@ $textmode
 (粗 魯)	cu1lu3
 (粗 鲁)	cu1lu3
 (粘 土)	nian2tu3
-(粘 ㊏)	nian2tu3
 (粘 度)	nian2du4
 (粘 度)	nian2du4
 (粘 性)	nian2xing4
@@ -54205,7 +52488,6 @@ $textmode
 (粘 菌)	nian2jun1
 (粤 语)	yue4yu3
 (粪 土)	fen4tu3
-(粪 ㊏)	fen4tu3
 (粮 草)	liang2cao3
 (粮 食)	liang2shi5
 (粮 饷)	liang2xiang3
@@ -54261,16 +52543,13 @@ $textmode
 (糖 果)	tang2guo3
 (糖 果)	tang2guo3
 (糖 水)	tang2shui3
-(糖 ㊌)	tang2shui3
 (糖 水)	tang2shui3
-(糖 ㊌)	tang2shui3
 (糖 酯)	tang2zhi3
 (糖 酯)	tang2zhi3
 (糜 烂)	mi2lan4
 (糜 爛)	mi2lan4
 (糜 爛)	mi2lan4
 (糞 土)	fen4tu3
-(糞 ㊏)	fen4tu3
 (糟 踏)	zao1ta5
 (糟 蹋)	zao1ta5
 (糢 糊)	mo2hu2
@@ -54282,7 +52561,6 @@ $textmode
 (糧 餉)	liang2xiang3
 (糯 米)	nuo4mi3
 (系 上)	ji4shang5
-(系 ㊤)	ji4shang5
 (系 囚)	ji4qiu2
 (系 小)	xi4xiao3
 (系 統)	xi4tong3
@@ -54297,7 +52575,6 @@ $textmode
 (約 緬)	yue1mian3
 (約 莫)	yue1mo5
 (約 西)	yue1xi1
-(約 🀂)	yue1xi1
 (約 請)	yue1qing3
 (約 請)	yue1qing3
 (紅 堡)	hong2bao3
@@ -54335,7 +52612,6 @@ $textmode
 (級 差)	ji2cha1
 (紜 苔)	yun2tai2
 (素 有)	su4you3
-(素 ㊒)	su4you3
 (索 取)	suo3qu3
 (索 取)	suo3qu3
 (索 尔)	suo3er3
@@ -54356,9 +52632,7 @@ $textmode
 (累 墜)	lei2zhui5
 (累 墜)	lei2zhui5
 (累 月)	lei3yue4
-(累 ㊊)	lei3yue4
 (累 月)	lei3yue4
-(累 ㊊)	lei3yue4
 (累 犯)	lei3fan4
 (累 犯)	lei3fan4
 (累 犯)	lei3fan4
@@ -54450,7 +52724,6 @@ $textmode
 (經 手)	jing1shou3
 (經 打)	jing1da3
 (經 水)	jing1shui3
-(經 ㊌)	jing1shui3
 (經 理)	jing1li3
 (經 理)	jing1li3
 (經 管)	jing1guan3
@@ -54519,7 +52792,6 @@ $textmode
 (緯 錦)	wei3jin3
 (縣 長)	xian4zhang3
 (縫 上)	feng2shang4
-(縫 ㊤)	feng2shang4
 (縫 口)	feng2kou3
 (縫 合)	feng2he2
 (縫 窮)	feng2qiong2
@@ -54533,21 +52805,17 @@ $textmode
 (縮 小)	suo1xiao3
 (縮 影)	suo1ying3
 (縮 水)	suo1shui3
-(縮 ㊌)	suo1shui3
 (縮 減)	suo1jian3
 (縮 短)	suo1duan3
 (縱 使)	zong4shi3
 (縱 有)	zong4you3
-(縱 ㊒)	zong4you3
 (縱 火)	zong4huo3
-(縱 ㊋)	zong4huo3
 (縱 覽)	zong4lan3
 (縱 酒)	zong4jiu3
 (縴 夫)	qian4fu1
 (總 務)	zong3wu4
 (總 得)	zong3dei3
 (總 有)	zong3you3
-(總 ㊒)	zong3you3
 (總 理)	zong3li3
 (總 理)	zong3li3
 (總 管)	zong3guan3
@@ -54577,7 +52845,6 @@ $textmode
 (繃 簧)	beng1huang2
 (織 品)	zhi1pin3
 (織 女)	zhi1nv3
-(織 ㊛)	zhi1nv3
 (織 女)	zhi1nv3
 (織 補)	zhi1bu3
 (織 錦)	zhi1jin3
@@ -54587,11 +52854,9 @@ $textmode
 (繩 索)	sheng2suo3
 (繩 索)	sheng2suo3
 (繫 上)	ji4shang5
-(繫 ㊤)	ji4shang5
 (繫 囚)	ji4qiu2
 (繳 還)	jiao3huan2
 (繼 女)	ji4nv3
-(繼 ㊛)	ji4nv3
 (繼 女)	ji4nv3
 (繼 母)	ji4mu3
 (續 假)	xu4jia4
@@ -54631,7 +52896,6 @@ $textmode
 (约 缅)	yue1mian3
 (约 莫)	yue1mo5
 (约 西)	yue1xi1
-(约 🀂)	yue1xi1
 (约 请)	yue1qing3
 (级 差)	ji2cha1
 (纬 锦)	wei3jin3
@@ -54648,9 +52912,7 @@ $textmode
 (纳 降)	na4xiang2
 (纵 使)	zong4shi3
 (纵 有)	zong4you3
-(纵 ㊒)	zong4you3
 (纵 火)	zong4huo3
-(纵 ㊋)	zong4huo3
 (纵 览)	zong4lan3
 (纵 酒)	zong4jiu3
 (纸 品)	zhi3pin3
@@ -54679,7 +52941,6 @@ $textmode
 (细 雨)	xi4yu3
 (织 品)	zhi1pin3
 (织 女)	zhi1nv3
-(织 ㊛)	zhi1nv3
 (织 女)	zhi1nv3
 (织 补)	zhi1bu3
 (织 锦)	zhi1jin3
@@ -54696,7 +52957,6 @@ $textmode
 (经 手)	jing1shou3
 (经 打)	jing1da3
 (经 水)	jing1shui3
-(经 ㊌)	jing1shui3
 (经 理)	jing1li3
 (经 理)	jing1li3
 (经 管)	jing1guan3
@@ -54749,7 +53009,6 @@ $textmode
 (统 考)	tong3kao3
 (统 领)	tong3ling3
 (继 女)	ji4nv3
-(继 ㊛)	ji4nv3
 (继 女)	ji4nv3
 (继 母)	ji4mu3
 (绩 效)	ji4xiao4
@@ -54781,7 +53040,6 @@ $textmode
 (缓 缓)	huan3huan3
 (缓 解)	huan3jie3
 (编 写)	bian1xie3
-(编 ㊢)	bian1xie3
 (编 审)	bian1shen3
 (编 导)	bian1dao3
 (编 曲)	bian1qu3
@@ -54802,7 +53060,6 @@ $textmode
 (缘 起)	yuan2qi3
 (缜 发)	zhen3fa4
 (缝 上)	feng2shang4
-(缝 ㊤)	feng2shang4
 (缝 制)	feng2zhi4
 (缝 口)	feng2kou3
 (缝 合)	feng2he2
@@ -54819,12 +53076,10 @@ $textmode
 (缠 累)	chan2lei3
 (缠 裹)	chan2guo3
 (缩 写)	suo1xie3
-(缩 ㊢)	suo1xie3
 (缩 减)	suo1jian3
 (缩 小)	suo1xiao3
 (缩 影)	suo1ying3
 (缩 水)	suo1shui3
-(缩 ㊌)	suo1shui3
 (缩 短)	suo1duan3
 (缰 绳)	jiang1sheng5
 (缴 还)	jiao3huan2
@@ -54835,7 +53090,6 @@ $textmode
 (缺 損)	que1sun3
 (缺 氧)	que1yang3
 (缺 水)	que1shui3
-(缺 ㊌)	que1shui3
 (缺 点)	que1dian3
 (缺 點)	que1dian3
 (罐 头)	guan4tou5
@@ -54851,7 +53105,6 @@ $textmode
 (网 眼)	wang3yan3
 (网 管)	wang3guan3
 (罕 有)	han3you3
-(罕 ㊒)	han3you3
 (罗 以)	luo2yi3
 (罗 刹)	luo2cha4
 (罗 口)	luo2kou3
@@ -54869,7 +53122,6 @@ $textmode
 (罢 了)	ba4le5
 (罢 了)	ba4le5
 (罢 休)	ba4xiu1
-(罢 ㊡)	ba4xiu1
 (罢 免)	ba4mian3
 (罢 免)	ba4mian3
 (罢 官)	ba4guan1
@@ -54889,7 +53141,6 @@ $textmode
 (罷 了)	ba4le5
 (罷 了)	ba4le5
 (罷 休)	ba4xiu1
-(罷 ㊡)	ba4xiu1
 (罷 免)	ba4mian3
 (罷 免)	ba4mian3
 (罷 官)	ba4guan1
@@ -54934,7 +53185,6 @@ $textmode
 (羊 圈)	yang2juan4
 (羊 奶)	yang2nai3
 (羊 水)	yang2shui3
-(羊 ㊌)	yang2shui3
 (羊 腿)	yang2tui3
 (羊 舍)	yang2she4
 (羊 角)	yang2jiao3
@@ -54942,7 +53192,6 @@ $textmode
 (羊 驼)	yang2tuo2
 (美 发)	mei3fa4
 (美 女)	mei3nv3
-(美 ㊛)	mei3nv3
 (美 女)	mei3nv3
 (美 好)	mei3hao3
 (美 景)	mei3jing3
@@ -54970,14 +53219,12 @@ $textmode
 (義 馬)	yi4ma3
 (羯 鼓)	jie2gu3
 (羼 水)	chan4shui3
-(羼 ㊌)	chan4shui3
 (羽 冠)	yu3guan1
 (羽 冠)	yu3guan1
 (翅 展)	chi4zhan3
 (翅 膀)	chi4bang3
 (習 得)	xi2de2
 (習 水)	xi2shui3
-(習 ㊌)	xi2shui3
 (翘 首)	qiao2shou3
 (翳 眼)	yi4yan3
 (翹 首)	qiao2shou3
@@ -55063,10 +53310,7 @@ $textmode
 (老 鼠)	lao3shu3
 (老 鼠)	lao3shu3
 (考 上)	kao3shang5
-(考 ㊤)	kao3shang5
 (考 中)	kao3zhong4
-(考 🀄)	kao3zhong4
-(考 ㊥)	kao3zhong4
 (考 卷)	kao3juan4
 (考 取)	kao3qu3
 (考 古)	kao3gu3
@@ -55081,10 +53325,8 @@ $textmode
 (而 已)	er2yi3
 (耐 久)	nai4jiu3
 (耐 水)	nai4shui3
-(耐 ㊌)	nai4shui3
 (耐 洗)	nai4xi3
 (耐 火)	nai4huo3
-(耐 ㊋)	nai4huo3
 (耐 碱)	nai4jian3
 (耐 鹼)	nai4jian3
 (耕 地)	geng1di4
@@ -55094,14 +53336,12 @@ $textmode
 (耗 損)	hao4sun3
 (耗 盡)	hao4jin4
 (耙 土)	ba4tu3
-(耙 ㊏)	ba4tu3
 (耳 屎)	er3shi3
 (耳 底)	er3di3
 (耳 片)	er3pian1
 (耳 語)	er3yu3
 (耳 语)	er3yu3
 (耶 西)	ye1xi1
-(耶 🀂)	ye1xi1
 (耶 魯)	ye1lu3
 (耶 魯)	ye1lu3
 (耶 鲁)	ye1lu3
@@ -55137,10 +53377,8 @@ $textmode
 (聖 旨)	sheng4zhi3
 (聖 母)	sheng4mu3
 (聖 水)	sheng4shui3
-(聖 ㊌)	sheng4shui3
 (聖 洗)	sheng4xi3
 (聖 火)	sheng4huo3
-(聖 ㊋)	sheng4huo3
 (聖 禮)	sheng4li3
 (聖 禮)	sheng4li3
 (聖 者)	sheng4zhe3
@@ -55248,15 +53486,12 @@ $textmode
 (肥 實)	fei2shi5
 (肥 美)	fei2mei3
 (肥 西)	fei2xi1
-(肥 🀂)	fei2xi1
 (肩 上)	jian1shang5
-(肩 ㊤)	jian1shang5
 (肩 胛)	jian1jia3
 (肩 膀)	jian1bang3
 (肮 脏)	ang1zang5
 (肱 骨)	gong1gu3
 (育 水)	yu4shui3
-(育 ㊌)	yu4shui3
 (肺 腑)	fei4fu3
 (胀 起)	zhang4qi3
 (胃 口)	wei4kou3
@@ -55264,7 +53499,6 @@ $textmode
 (胆 敢)	dan3gan3
 (胆 管)	dan3guan3
 (背 上)	bei4shang5
-(背 ㊤)	bei4shang5
 (背 包)	bei1bao1
 (背 带)	bei1dai4
 (背 帶)	bei1dai4
@@ -55300,7 +53534,6 @@ $textmode
 (胶 卷)	jiao1juan3
 (胶 子)	jiao1zi3
 (胶 水)	jiao1shui3
-(胶 ㊌)	jiao1shui3
 (胶 粘)	jiao1nian2
 (胸 口)	xiong1kou3
 (胸 椎)	xiong1zhui1
@@ -55338,11 +53571,9 @@ $textmode
 (脊 髓)	ji3sui3
 (脏 乱)	zang1luan4
 (脏 土)	zang1tu3
-(脏 ㊏)	zang1tu3
 (脏 字)	zang1zi4
 (脏 弹)	zang1dan4
 (脏 水)	zang1shui3
-(脏 ㊌)	zang1shui3
 (脏 污)	zang1wu1
 (脏 煤)	zang1mei2
 (脏 病)	zang1bing4
@@ -55373,7 +53604,6 @@ $textmode
 (脫 敏)	tuo1min3
 (脫 氧)	tuo1yang3
 (脫 水)	tuo1shui3
-(脫 ㊌)	tuo1shui3
 (脫 灑)	tuo1sa3
 (脫 產)	tuo1chan3
 (脫 稿)	tuo1gao3
@@ -55392,7 +53622,6 @@ $textmode
 (脱 敏)	tuo1min3
 (脱 氧)	tuo1yang3
 (脱 水)	tuo1shui3
-(脱 ㊌)	tuo1shui3
 (脱 洒)	tuo1sa3
 (脱 稿)	tuo1gao3
 (脱 羽)	tuo1yu3
@@ -55439,7 +53668,6 @@ $textmode
 (膠 卷)	jiao1juan3
 (膠 子)	jiao1zi3
 (膠 水)	jiao1shui3
-(膠 ㊌)	jiao1shui3
 (膠 粘)	jiao1nian2
 (膠 體)	jiao1ti3
 (膩 友)	ni4you3
@@ -55480,9 +53708,7 @@ $textmode
 (臨 產)	lin2chan3
 (臨 產)	lin2chan3
 (臨 西)	lin2xi1
-(臨 🀂)	lin2xi1
 (臨 西)	lin2xi1
-(臨 🀂)	lin2xi1
 (臨 難)	lin2nan4
 (臨 難)	lin2nan4
 (臨 難)	lin2nan4
@@ -55502,7 +53728,6 @@ $textmode
 (自 我)	zi4wo3
 (自 找)	zi4zhao3
 (自 有)	zi4you3
-(自 ㊒)	zi4you3
 (自 此)	zi4ci3
 (自 毀)	zi4hui3
 (自 毁)	zi4hui3
@@ -55540,7 +53765,6 @@ $textmode
 (致 使)	zhi4shi3
 (致 死)	zhi4si3
 (臺 北)	tai2bei3
-(臺 🀃)	tai2bei3
 (臺 北)	tai2bei3
 (臺 地)	tai2di4
 (臺 海)	tai2hai3
@@ -55548,7 +53772,6 @@ $textmode
 (臼 齒)	jiu4chi3
 (臼 齿)	jiu4chi3
 (舀 水)	yao3shui3
-(舀 ㊌)	yao3shui3
 (舅 嫂)	jiu4sao3
 (舅 母)	jiu4mu5
 (舅 舅)	jiu4jiu5
@@ -55601,7 +53824,6 @@ $textmode
 (舌 头)	she2tou5
 (舌 頭)	she2tou5
 (舍 下)	she4xia4
-(舍 ㊦)	she4xia4
 (舍 利)	she4li4
 (舍 利)	she4li4
 (舍 己)	she3ji3
@@ -55677,7 +53899,6 @@ $textmode
 (节 俭)	jie2jian3
 (节 气)	jie2qi5
 (节 水)	jie2shui3
-(节 ㊌)	jie2shui3
 (节 点)	jie2dian3
 (节 省)	jie2sheng3
 (节 省)	jie2sheng3
@@ -55744,7 +53965,6 @@ $textmode
 (苏 瓦)	su1wa3
 (苏 甲)	su1jia3
 (苏 西)	su1xi1
-(苏 🀂)	su1xi1
 (苏 醒)	su1xing3
 (苏 铁)	su1tie3
 (苔 草)	tai2cao3
@@ -55772,7 +53992,6 @@ $textmode
 (苦 果)	ku3guo3
 (苦 楚)	ku3chu3
 (苦 水)	ku3shui3
-(苦 ㊌)	ku3shui3
 (苦 海)	ku3hai3
 (苦 海)	ku3hai3
 (苦 胆)	ku3dan3
@@ -55844,9 +54063,7 @@ $textmode
 (草 草)	cao3cao3
 (草 菇)	cao3gu1
 (荒 土)	huang1tu3
-(荒 ㊏)	huang1tu3
 (荒 土)	huang1tu3
-(荒 ㊏)	huang1tu3
 (荒 地)	huang1di4
 (荒 地)	huang1di4
 (荒 岛)	huang1dao3
@@ -55864,7 +54081,6 @@ $textmode
 (药 品)	yao4pin3
 (药 检)	yao4jian3
 (药 水)	yao4shui3
-(药 ㊌)	yao4shui3
 (荳 角)	dou4jiao3
 (荷 馬)	he2ma3
 (荷 马)	he2ma3
@@ -55879,7 +54095,6 @@ $textmode
 (莫 講)	mo4jiang3
 (莫 讲)	mo4jiang3
 (莱 西)	lai2xi1
-(莱 🀂)	lai2xi1
 (莲 子)	lian2zi3
 (莴 笋)	wo1sun3
 (获 准)	huo4zhun3
@@ -55901,9 +54116,7 @@ $textmode
 (華 佗)	hua4tuo2
 (華 佗)	hua4tuo2
 (華 北)	hua2bei3
-(華 🀃)	hua2bei3
 (華 北)	hua2bei3
-(華 🀃)	hua2bei3
 (華 北)	hua2bei3
 (華 山)	hua4shan1
 (華 山)	hua4shan1
@@ -55933,13 +54146,10 @@ $textmode
 (萃 取)	cui4qu3
 (萇 楚)	chang2chu3
 (萊 西)	lai2xi1
-(萊 🀂)	lai2xi1
 (萎 靡)	wei3mi3
 (萝 北)	luo2bei3
-(萝 🀃)	luo2bei3
 (萝 北)	luo2bei3
 (萤 火)	ying2huo3
-(萤 ㊋)	ying2huo3
 (营 养)	ying2yang3
 (营 口)	ying2kou3
 (营 地)	ying2di4
@@ -55954,7 +54164,6 @@ $textmode
 (萨 里)	sa4li3
 (萬 古)	wan4gu3
 (萬 有)	wan4you3
-(萬 ㊒)	wan4you3
 (萬 里)	wan4li3
 (萬 里)	wan4li3
 (萵 筍)	wo1sun3
@@ -55965,9 +54174,7 @@ $textmode
 (落 榜)	luo4bang3
 (落 榜)	luo4bang3
 (落 水)	luo4shui3
-(落 ㊌)	luo4shui3
 (落 水)	luo4shui3
-(落 ㊌)	luo4shui3
 (落 笔)	luo4bi3
 (落 笔)	luo4bi3
 (落 筆)	luo4bi3
@@ -56008,9 +54215,7 @@ $textmode
 (著 吃)	zhao2chi1
 (著 吃)	zhao2chi1
 (著 名)	zhu4ming2
-(著 ㊔)	zhu4ming2
 (著 名)	zhu4ming2
-(著 ㊔)	zhu4ming2
 (著 墨)	zhuo2mo4
 (著 墨)	zhuo2mo4
 (著 墨)	zhuo2mo4
@@ -56043,9 +54248,7 @@ $textmode
 (著 涼)	zhao2liang2
 (著 涼)	zhao2liang2
 (著 火)	zhao2huo3
-(著 ㊋)	zhao2huo3
 (著 火)	zhao2huo3
-(著 ㊋)	zhao2huo3
 (著 用)	zhao2yong4
 (著 用)	zhao2yong4
 (著 眼)	zhuo2yan3
@@ -56101,7 +54304,6 @@ $textmode
 (葱 岭)	cong1ling3
 (葵 涌)	kui2yong3
 (蒙 医)	meng3yi1
-(蒙 ㊩)	meng3yi1
 (蒙 古)	meng3gu3
 (蒙 文)	meng3wen2
 (蒙 茸)	meng2rong2
@@ -56128,10 +54330,8 @@ $textmode
 (蒼 莽)	cang1mang3
 (蓄 养)	xu4yang3
 (蓄 水)	xu4shui3
-(蓄 ㊌)	xu4shui3
 (蓄 養)	xu4yang3
 (蓋 上)	gai4shang5
-(蓋 ㊤)	gai4shang5
 (蓋 好)	gai4hao3
 (蓋 爾)	gai4er3
 (蓓 蕾)	bei4lei3
@@ -56221,7 +54421,6 @@ $textmode
 (薩 裡)	sa4li3
 (薩 裡)	sa4li3
 (薪 水)	xin1shui5
-(薪 ㊌)	xin1shui5
 (薪 酬)	xin1chou2
 (薹 草)	tai2cao3
 (藉 口)	jie4kou3
@@ -56253,7 +54452,6 @@ $textmode
 (藥 品)	yao4pin3
 (藥 檢)	yao4jian3
 (藥 水)	yao4shui3
-(藥 ㊌)	yao4shui3
 (藹 藹)	ai3ai3
 (蘆 筍)	lu2sun3
 (蘆 筍)	lu2sun3
@@ -56268,7 +54466,6 @@ $textmode
 (蘇 瓦)	su1wa3
 (蘇 甲)	su1jia3
 (蘇 西)	su1xi1
-(蘇 🀂)	su1xi1
 (蘇 醒)	su1xing3
 (蘇 鐵)	su1tie3
 (蘊 藉)	yun4jie4
@@ -56279,15 +54476,11 @@ $textmode
 (蘭 考)	lan2kao3
 (蘭 考)	lan2kao3
 (蘭 西)	lan2xi1
-(蘭 🀂)	lan2xi1
 (蘭 西)	lan2xi1
-(蘭 🀂)	lan2xi1
 (蘭 譜)	lan2pu3
 (蘭 譜)	lan2pu3
 (蘿 北)	luo2bei3
-(蘿 🀃)	luo2bei3
 (蘿 北)	luo2bei3
-(蘿 🀃)	luo2bei3
 (蘿 北)	luo2bei3
 (虎 口)	hu3kou3
 (虎 骨)	hu3gu3
@@ -56297,7 +54490,6 @@ $textmode
 (處 在)	chu3zai4
 (處 境)	chu3jing4
 (處 女)	chu3nv3
-(處 ㊛)	chu3nv3
 (處 女)	chu3nv3
 (處 所)	chu4suo3
 (處 方)	chu3fang1
@@ -56310,7 +54502,6 @@ $textmode
 (處 理)	chu3li3
 (處 理)	chu3li3
 (處 男)	chu3nan2
-(處 ㊚)	chu3nan2
 (處 置)	chu3zhi4
 (處 罰)	chu3fa2
 (處 身)	chu3shen1
@@ -56394,7 +54585,6 @@ $textmode
 (螞 蚱)	ma4zha5
 (螞 蟻)	ma3yi3
 (螢 火)	ying2huo3
-(螢 ㊋)	ying2huo3
 (螺 杆)	luo2gan3
 (螺 杆)	luo2gan3
 (螺 桨)	luo2jiang3
@@ -56423,7 +54613,6 @@ $textmode
 (血 本)	xue4ben3
 (血 染)	xue4ran3
 (血 水)	xue4shui3
-(血 ㊌)	xue4shui3
 (血 洗)	xue4xi3
 (血 管)	xue4guan3
 (血 統)	xue4tong3
@@ -56500,7 +54689,6 @@ $textmode
 (行 驶)	xing2shi3
 (術 語)	shu4yu3
 (街 上)	jie1shang5
-(街 ㊤)	jie1shang5
 (衙 門)	ya2men5
 (衙 门)	ya2men5
 (衛 冕)	wei4mian3
@@ -56509,7 +54697,6 @@ $textmode
 (衝 著)	chong4zhe5
 (衝 著)	chong4zhe5
 (衡 水)	heng2shui3
-(衡 ㊌)	heng2shui3
 (衡 量)	heng2liang5
 (衡 量)	heng2liang5
 (衣 子)	yi1zi3
@@ -56538,7 +54725,6 @@ $textmode
 (补 语)	bu3yu3
 (补 选)	bu3xuan3
 (表 土)	biao3tu3
-(表 ㊏)	biao3tu3
 (表 姐)	biao3jie3
 (表 尺)	biao3chi3
 (表 徵)	biao3zheng1
@@ -56580,7 +54766,6 @@ $textmode
 (装 好)	zhuang1hao3
 (装 扮)	zhuang1ban4
 (装 有)	zhuang1you3
-(装 ㊒)	zhuang1you3
 (装 满)	zhuang1man3
 (装 甲)	zhuang1jia3
 (補 丁)	bu3ding5
@@ -56600,7 +54785,6 @@ $textmode
 (裝 好)	zhuang1hao3
 (裝 扮)	zhuang1ban4
 (裝 有)	zhuang1you3
-(裝 ㊒)	zhuang1you3
 (裝 滿)	zhuang1man3
 (裝 甲)	zhuang1jia3
 (裡 人)	li3ren2
@@ -56652,319 +54836,159 @@ $textmode
 (襯 裡)	chen4li3
 (襯 裡)	chen4li3
 (西 丁)	xi1ding1
-(🀂 丁)	xi1ding1
 (西 丰)	xi1feng1
-(🀂 丰)	xi1feng1
 (西 乃)	xi1nai3
-(🀂 乃)	xi1nai3
 (西 乡)	xi1xiang1
-(🀂 乡)	xi1xiang1
 (西 亚)	xi1ya4
-(🀂 亚)	xi1ya4
 (西 亞)	xi1ya4
-(🀂 亞)	xi1ya4
 (西 伯)	xi1bo2
-(🀂 伯)	xi1bo2
 (西 侧)	xi1ce4
-(🀂 侧)	xi1ce4
 (西 側)	xi1ce4
-(🀂 側)	xi1ce4
 (西 元)	xi1yuan2
-(🀂 元)	xi1yuan2
 (西 充)	xi1chong1
-(🀂 充)	xi1chong1
 (西 充)	xi1chong1
-(🀂 充)	xi1chong1
 (西 凉)	xi1liang2
-(🀂 凉)	xi1liang2
 (西 凉)	xi1liang2
-(🀂 凉)	xi1liang2
 (西 列)	xi1lie4
-(🀂 列)	xi1lie4
 (西 列)	xi1lie4
-(🀂 列)	xi1lie4
 (西 割)	xi1ge1
-(🀂 割)	xi1ge1
 (西 北)	xi1bei3
-(🀂 北)	xi1bei3
-(西 🀃)	xi1bei3
 (西 北)	xi1bei3
-(🀂 北)	xi1bei3
 (西 区)	xi1qu1
-(🀂 区)	xi1qu1
 (西 医)	xi1yi1
-(🀂 医)	xi1yi1
-(西 ㊩)	xi1yi1
-(🀂 ㊩)	xi1yi1
 (西 區)	xi1qu1
-(🀂 區)	xi1qu1
 (西 华)	xi1hua2
-(🀂 华)	xi1hua2
 (西 单)	xi1dan1
-(🀂 单)	xi1dan1
 (西 南)	xi1nan2
-(🀂 南)	xi1nan2
-(西 🀁)	xi1nan2
 (西 发)	xi1fa1
-(🀂 发)	xi1fa1
 (西 吉)	xi1ji2
-(🀂 吉)	xi1ji2
 (西 周)	xi1zhou1
-(🀂 周)	xi1zhou1
 (西 和)	xi1he2
-(🀂 和)	xi1he2
 (西 哈)	xi1ha1
-(🀂 哈)	xi1ha1
 (西 單)	xi1dan1
-(🀂 單)	xi1dan1
 (西 坡)	xi1po1
-(🀂 坡)	xi1po1
 (西 坦)	xi1tan3
-(🀂 坦)	xi1tan3
 (西 域)	xi1yu4
-(🀂 域)	xi1yu4
 (西 塔)	xi1ta3
-(🀂 塔)	xi1ta3
 (西 夏)	xi1xia4
-(🀂 夏)	xi1xia4
 (西 天)	xi1tian1
-(🀂 天)	xi1tian1
 (西 奇)	xi1qi2
-(🀂 奇)	xi1qi2
 (西 奈)	xi1nai4
-(🀂 奈)	xi1nai4
 (西 奈)	xi1nai4
-(🀂 奈)	xi1nai4
 (西 学)	xi1xue2
-(🀂 学)	xi1xue2
-(西 ㊫)	xi1xue2
-(🀂 ㊫)	xi1xue2
 (西 學)	xi1xue2
-(🀂 學)	xi1xue2
 (西 宁)	xi1ning2
-(🀂 宁)	xi1ning2
 (西 安)	xi1an1
-(🀂 安)	xi1an1
 (西 宏)	xi1hong2
-(🀂 宏)	xi1hong2
 (西 寧)	xi1ning2
-(🀂 寧)	xi1ning2
 (西 寧)	xi1ning2
-(🀂 寧)	xi1ning2
 (西 寧)	xi1ning2
-(🀂 寧)	xi1ning2
 (西 尼)	xi1ni2
-(🀂 尼)	xi1ni2
 (西 岳)	xi1yue4
-(🀂 岳)	xi1yue4
 (西 岸)	xi1an4
-(🀂 岸)	xi1an4
 (西 峡)	xi1xia2
-(🀂 峡)	xi1xia2
 (西 峰)	xi1feng1
-(🀂 峰)	xi1feng1
 (西 峽)	xi1xia2
-(🀂 峽)	xi1xia2
 (西 嶽)	xi1yue4
-(🀂 嶽)	xi1yue4
 (西 巴)	xi1ba1
-(🀂 巴)	xi1ba1
 (西 帖)	xi1tie1
-(🀂 帖)	xi1tie1
 (西 平)	xi1ping2
-(🀂 平)	xi1ping2
 (西 式)	xi1shi4
-(🀂 式)	xi1shi4
 (西 弗)	xi1fu2
-(🀂 弗)	xi1fu2
 (西 征)	xi1zheng1
-(🀂 征)	xi1zheng1
 (西 德)	xi1de2
-(🀂 德)	xi1de2
 (西 戎)	xi1rong2
-(🀂 戎)	xi1rong2
 (西 拉)	xi1la1
-(🀂 拉)	xi1la1
 (西 拉)	xi1la1
-(🀂 拉)	xi1la1
 (西 探)	xi1tan4
-(🀂 探)	xi1tan4
 (西 文)	xi1wen2
-(🀂 文)	xi1wen2
 (西 方)	xi1fang1
-(🀂 方)	xi1fang1
 (西 施)	xi1shi1
-(🀂 施)	xi1shi1
 (西 昌)	xi1chang1
-(🀂 昌)	xi1chang1
 (西 晉)	xi1jin4
-(🀂 晉)	xi1jin4
 (西 晋)	xi1jin4
-(🀂 晋)	xi1jin4
 (西 曷)	xi1he2
-(🀂 曷)	xi1he2
 (西 服)	xi1fu2
-(🀂 服)	xi1fu2
 (西 林)	xi1lin2
-(🀂 林)	xi1lin2
 (西 林)	xi1lin2
-(🀂 林)	xi1lin2
 (西 欧)	xi1ou1
-(🀂 欧)	xi1ou1
 (西 歐)	xi1ou1
-(🀂 歐)	xi1ou1
 (西 汉)	xi1han4
-(🀂 汉)	xi1han4
 (西 江)	xi1jiang1
-(🀂 江)	xi1jiang1
 (西 沽)	xi1gu1
-(🀂 沽)	xi1gu1
 (西 法)	xi1fa3
-(🀂 法)	xi1fa3
 (西 洋)	xi1yang2
-(🀂 洋)	xi1yang2
 (西 涼)	xi1liang2
-(🀂 涼)	xi1liang2
 (西 湖)	xi1hu2
-(🀂 湖)	xi1hu2
 (西 满)	xi1man3
-(🀂 满)	xi1man3
 (西 滿)	xi1man3
-(🀂 滿)	xi1man3
 (西 漢)	xi1han4
-(🀂 漢)	xi1han4
 (西 漢)	xi1han4
-(🀂 漢)	xi1han4
 (西 漢)	xi1han4
-(🀂 漢)	xi1han4
 (西 点)	xi1dian3
-(🀂 点)	xi1dian3
 (西 烈)	xi1lie4
-(🀂 烈)	xi1lie4
 (西 烈)	xi1lie4
-(🀂 烈)	xi1lie4
 (西 珥)	xi1er3
-(🀂 珥)	xi1er3
 (西 班)	xi1ban1
-(🀂 班)	xi1ban1
 (西 瓜)	xi1gua1
-(🀂 瓜)	xi1gua1
 (西 畴)	xi1chou2
-(🀂 畴)	xi1chou2
 (西 疇)	xi1chou2
-(🀂 疇)	xi1chou2
 (西 發)	xi1fa1
-(🀂 發)	xi1fa1
 (西 秦)	xi1qin2
-(🀂 秦)	xi1qin2
 (西 端)	xi1duan1
-(🀂 端)	xi1duan1
 (西 答)	xi1da2
-(🀂 答)	xi1da2
 (西 米)	xi1mi3
-(🀂 米)	xi1mi3
 (西 納)	xi1na4
-(🀂 納)	xi1na4
 (西 經)	xi1jing1
-(🀂 經)	xi1jing1
 (西 緬)	xi1mian3
-(🀂 緬)	xi1mian3
 (西 纳)	xi1na4
-(🀂 纳)	xi1na4
 (西 经)	xi1jing1
-(🀂 经)	xi1jing1
 (西 缅)	xi1mian3
-(🀂 缅)	xi1mian3
 (西 美)	xi1mei3
-(🀂 美)	xi1mei3
 (西 艺)	xi1yi4
-(🀂 艺)	xi1yi4
 (西 芹)	xi1qin2
-(🀂 芹)	xi1qin2
 (西 華)	xi1hua2
-(🀂 華)	xi1hua2
 (西 華)	xi1hua2
-(🀂 華)	xi1hua2
 (西 藏)	xi1zang4
-(🀂 藏)	xi1zang4
 (西 藝)	xi1yi4
-(🀂 藝)	xi1yi4
 (西 装)	xi1zhuang1
-(🀂 装)	xi1zhuang1
 (西 裝)	xi1zhuang1
-(🀂 裝)	xi1zhuang1
 (西 訂)	xi1ding4
-(🀂 訂)	xi1ding4
 (西 订)	xi1ding4
-(🀂 订)	xi1ding4
 (西 豐)	xi1feng1
-(🀂 豐)	xi1feng1
 (西 边)	xi1bian5
-(🀂 边)	xi1bian5
 (西 辽)	xi1liao2
-(🀂 辽)	xi1liao2
 (西 达)	xi1da2
-(🀂 达)	xi1da2
 (西 进)	xi1jin4
-(🀂 进)	xi1jin4
 (西 连)	xi1lian2
-(🀂 连)	xi1lian2
 (西 連)	xi1lian2
-(🀂 連)	xi1lian2
 (西 連)	xi1lian2
-(🀂 連)	xi1lian2
 (西 進)	xi1jin4
-(🀂 進)	xi1jin4
 (西 遍)	xi1bian4
-(🀂 遍)	xi1bian4
 (西 達)	xi1da2
-(🀂 達)	xi1da2
 (西 遼)	xi1liao2
-(🀂 遼)	xi1liao2
 (西 遼)	xi1liao2
-(🀂 遼)	xi1liao2
 (西 邊)	xi1bian5
-(🀂 邊)	xi1bian5
 (西 部)	xi1bu4
-(🀂 部)	xi1bu4
 (西 鄉)	xi1xiang1
-(🀂 鄉)	xi1xiang1
 (西 醫)	xi1yi1
-(🀂 醫)	xi1yi1
 (西 門)	xi1men2
-(🀂 門)	xi1men2
 (西 门)	xi1men2
-(🀂 门)	xi1men2
 (西 限)	xi1xian4
-(🀂 限)	xi1xian4
 (西 陲)	xi1chui2
-(🀂 陲)	xi1chui2
 (西 雅)	xi1ya3
-(🀂 雅)	xi1ya3
 (西 非)	xi1fei1
-(🀂 非)	xi1fei1
 (西 面)	xi1mian4
-(🀂 面)	xi1mian4
 (西 頓)	xi1dun4
-(🀂 頓)	xi1dun4
 (西 顿)	xi1dun4
-(🀂 顿)	xi1dun4
 (西 風)	xi1feng1
-(🀂 風)	xi1feng1
 (西 风)	xi1feng1
-(🀂 风)	xi1feng1
 (西 餐)	xi1can1
-(🀂 餐)	xi1can1
 (西 魏)	xi1wei4
-(🀂 魏)	xi1wei4
 (西 鹿)	xi1lu4
-(🀂 鹿)	xi1lu4
 (西 鹿)	xi1lu4
-(🀂 鹿)	xi1lu4
 (西 麓)	xi1lu4
-(🀂 麓)	xi1lu4
 (西 點)	xi1dian3
-(🀂 點)	xi1dian3
 (要 击)	yao1ji1
 (要 务)	yao4wu4
 (要 務)	yao4wu4
@@ -56986,7 +55010,6 @@ $textmode
 (要 暈)	yao1yun1
 (要 暈)	yao1yun1
 (要 有)	yao4you3
-(要 ㊒)	yao4you3
 (要 束)	yao1shu4
 (要 死)	yao4si3
 (要 求)	yao1qiu2
@@ -57050,7 +55073,6 @@ $textmode
 (觀 感)	guan1gan3
 (觀 止)	guan1zhi3
 (觀 火)	guan1huo3
-(觀 ㊋)	guan1huo3
 (觀 禮)	guan1li3
 (觀 禮)	guan1li3
 (觀 覽)	guan1lan3
@@ -57065,7 +55087,6 @@ $textmode
 (观 感)	guan1gan3
 (观 止)	guan1zhi3
 (观 火)	guan1huo3
-(观 ㊋)	guan1huo3
 (观 点)	guan1dian3
 (观 礼)	guan1li3
 (观 礼)	guan1li3
@@ -57115,7 +55136,6 @@ $textmode
 (言 语)	yan2yu3
 (計 劃)	ji4hua4
 (計 有)	ji4you3
-(計 ㊒)	ji4you3
 (計 都)	ji4du1
 (計 都)	ji4du1
 (訊 息)	xun4xi1
@@ -57147,7 +55167,6 @@ $textmode
 (設 想)	she4xiang3
 (設 斐)	she4fei3
 (設 有)	she4you3
-(設 ㊒)	she4you3
 (設 法)	she4fa3
 (許 久)	xu3jiu3
 (許 仙)	xu3xian1
@@ -57198,14 +55217,12 @@ $textmode
 (話 筒)	hua4tong3
 (話 語)	hua4yu3
 (該 上)	gai1shang5
-(該 ㊤)	gai1shang5
 (該 死)	gai1si3
 (該 隱)	gai1yin3
 (詳 盡)	xiang2jin4
 (誇 口)	kua1kou3
 (誇 獎)	kua1jiang3
 (誊 写)	teng2xie3
-(誊 ㊢)	teng2xie3
 (認 可)	ren4ke3
 (認 準)	ren4zhun3
 (認 為)	ren4wei2
@@ -57230,14 +55247,8 @@ $textmode
 (誤 差)	wu4cha1
 (誤 解)	wu4jie3
 (說 中)	shuo1zhong4
-(說 🀄)	shuo1zhong4
-(說 ㊥)	shuo1zhong4
 (說 中)	shuo1zhong4
-(說 🀄)	shuo1zhong4
-(說 ㊥)	shuo1zhong4
 (說 中)	shuo1zhong4
-(說 🀄)	shuo1zhong4
-(說 ㊥)	shuo1zhong4
 (說 和)	shuo1he5
 (說 和)	shuo1he5
 (說 和)	shuo1he5
@@ -57284,9 +55295,7 @@ $textmode
 (調 勻)	tiao2yun2
 (調 勻)	tiao2yun2
 (調 協)	tiao2xie2
-(調 ㊯)	tiao2xie2
 (調 協)	tiao2xie2
-(調 ㊯)	tiao2xie2
 (調 味)	tiao2wei4
 (調 味)	tiao2wei4
 (調 和)	tiao2he2
@@ -57342,17 +55351,13 @@ $textmode
 (調 變)	tiao2bian4
 (調 變)	tiao2bian4
 (調 資)	tiao2zi1
-(調 ㊮)	tiao2zi1
 (調 資)	tiao2zi1
-(調 ㊮)	tiao2zi1
 (調 轉)	diao4zhuan3
 (調 轉)	diao4zhuan3
 (調 速)	tiao2su4
 (調 速)	tiao2su4
 (調 適)	tiao2shi4
-(調 ㊜)	tiao2shi4
 (調 適)	tiao2shi4
-(調 ㊜)	tiao2shi4
 (調 音)	tiao2yin1
 (調 音)	tiao2yin1
 (調 頻)	tiao2pin2
@@ -57520,7 +55525,6 @@ $textmode
 (讚 賞)	zan4shang3
 (讚 赏)	zan4shang3
 (计 有)	ji4you3
-(计 ㊒)	ji4you3
 (计 都)	ji4du1
 (计 都)	ji4du1
 (认 为)	ren4wei2
@@ -57574,7 +55578,6 @@ $textmode
 (设 想)	she4xiang3
 (设 斐)	she4fei3
 (设 有)	she4you3
-(设 ㊒)	she4you3
 (设 法)	she4fa3
 (访 古)	fang3gu3
 (访 港)	fang3gang3
@@ -57643,7 +55646,6 @@ $textmode
 (话 语)	hua4yu3
 (诤 友)	zheng4you3
 (该 上)	gai1shang5
-(该 ㊤)	gai1shang5
 (该 死)	gai1si3
 (该 隐)	gai1yin3
 (语 感)	yu3gan3
@@ -57658,8 +55660,6 @@ $textmode
 (诱 饵)	you4er3
 (诳 语)	kuang2yu3
 (说 中)	shuo1zhong4
-(说 🀄)	shuo1zhong4
-(说 ㊥)	shuo1zhong4
 (说 和)	shuo1he5
 (说 好)	shuo1hao3
 (说 客)	shui4ke4
@@ -57679,7 +55679,6 @@ $textmode
 (诸 葛)	zhu1ge3
 (诺 尔)	nuo4er3
 (读 写)	du2xie3
-(读 ㊢)	du2xie3
 (读 懂)	du2dong3
 (读 本)	du2ben3
 (读 者)	du2zhe3
@@ -57758,7 +55757,6 @@ $textmode
 (谬 奖)	miu4jiang3
 (谬 种)	miu4zhong3
 (谱 写)	pu3xie3
-(谱 ㊢)	pu3xie3
 (谱 曲)	pu3qu3
 (谷 地)	gu3di4
 (谷 场)	gu3chang2
@@ -57776,7 +55774,6 @@ $textmode
 (豆 豉)	dou4chi3
 (豎 起)	shu4qi3
 (豐 水)	feng1shui3
-(豐 ㊌)	feng1shui3
 (豐 滿)	feng1man3
 (豐 產)	feng1chan3
 (豐 美)	feng1mei3
@@ -57797,22 +55794,15 @@ $textmode
 (貝 母)	bei4mu3
 (貝 爾)	bei4er3
 (負 有)	fu4you3
-(負 ㊒)	fu4you3
 (負 荷)	fu4he4
 (負 起)	fu4qi3
 (負 鼠)	fu4shu3
 (財 主)	cai2zhu3
-(㊖ 主)	cai2zhu3
 (財 務)	cai2wu4
-(㊖ 務)	cai2wu4
 (財 寶)	cai2bao3
-(㊖ 寶)	cai2bao3
 (財 會)	cai2kuai4
-(㊖ 會)	cai2kuai4
 (財 產)	cai2chan3
-(㊖ 產)	cai2chan3
 (財 長)	cai2zhang3
-(㊖ 長)	cai2zhang3
 (貢 品)	gong4pin3
 (貧 嘴)	pin2zui3
 (貧 氣)	pin2qi5
@@ -57837,19 +55827,14 @@ $textmode
 (費 解)	fei4jie3
 (貼 息)	tie1xi1
 (貼 水)	tie1shui3
-(貼 ㊌)	tie1shui3
 (賀 卡)	he4ka3
 (賀 得)	he4de2
 (賁 臨)	bi4lin2
 (賁 臨)	bi4lin2
 (資 本)	zi1ben3
-(㊮ 本)	zi1ben3
 (資 產)	zi1chan3
-(㊮ 產)	zi1chan3
 (資 給)	zi1ji3
-(㊮ 給)	zi1ji3
 (資 興)	zi1xing1
-(㊮ 興)	zi1xing1
 (賊 眼)	zei2yan3
 (賓 主)	bin1zhu3
 (賓 主)	bin1zhu3
@@ -57916,7 +55901,6 @@ $textmode
 (贝 尔)	bei4er3
 (贝 母)	bei4mu3
 (负 有)	fu4you3
-(负 ㊒)	fu4you3
 (负 荷)	fu4he4
 (负 起)	fu4qi3
 (负 鼠)	fu4shu3
@@ -57930,10 +55914,8 @@ $textmode
 (责 打)	ze2da3
 (责 难)	ze2nan4
 (败 北)	bai4bei3
-(败 🀃)	bai4bei3
 (败 北)	bai4bei3
 (败 火)	bai4huo3
-(败 ㊋)	bai4huo3
 (败 笔)	bai4bi3
 (败 绩)	bai4ji4
 (败 诉)	bai4su4
@@ -57962,7 +55944,6 @@ $textmode
 (贲 临)	bi4lin2
 (贴 息)	tie1xi1
 (贴 水)	tie1shui3
-(贴 ㊌)	tie1shui3
 (贵 屿)	gui4yu3
 (贵 港)	gui4gang3
 (贷 款)	dai4kuan3
@@ -58006,7 +55987,6 @@ $textmode
 (赢 得)	ying2de2
 (赤 手)	chi4shou3
 (赤 水)	chi4shui3
-(赤 ㊌)	chi4shui3
 (赤 脚)	chi4jiao3
 (赤 腳)	chi4jiao3
 (赤 裸)	chi4luo3
@@ -58024,7 +56004,6 @@ $textmode
 (走 好)	zou3hao3
 (走 子)	zou3zi3
 (走 水)	zou3shui3
-(走 ㊌)	zou3shui3
 (走 狗)	zou3gou3
 (走 相)	zou3xiang4
 (走 眼)	zou3yan3
@@ -58043,13 +56022,11 @@ $textmode
 (起 來)	qi3lai5
 (起 哄)	qi3hong4
 (起 土)	qi3tu3
-(起 ㊏)	qi3tu3
 (起 始)	qi3shi3
 (起 手)	qi3shou3
 (起 晚)	qi3wan3
 (起 来)	qi3lai5
 (起 火)	qi3huo3
-(起 ㊋)	qi3huo3
 (起 点)	qi3dian3
 (起 码)	qi3ma3
 (起 碼)	qi3ma3
@@ -58071,7 +56048,6 @@ $textmode
 (越 分)	yue4fen4
 (越 桔)	yue4jie2
 (越 西)	yue4xi1
-(越 🀂)	yue4xi1
 (越 軌)	yue4gui3
 (越 轨)	yue4gui3
 (越 野)	yue4ye3
@@ -58086,13 +56062,11 @@ $textmode
 (趨 於)	qu1yu2
 (足 以)	zu2yi3
 (足 有)	zu2you3
-(足 ㊒)	zu2you3
 (足 跡)	zu2ji4
 (足 迹)	zu2ji4
 (跃 马)	yue4ma3
 (跌 倒)	die1dao3
 (跌 水)	die1shui3
-(跌 ㊌)	die1shui3
 (跑 垒)	pao3lei3
 (跑 壘)	pao3lei3
 (跑 壘)	pao3lei3
@@ -58110,15 +56084,12 @@ $textmode
 (跟 頭)	gen1tou5
 (跡 象)	ji4xiang4
 (跪 下)	gui4xia5
-(跪 ㊦)	gui4xia5
 (跪 倒)	gui4dao3
 (跪 毯)	gui4tan3
 (跪 祷)	gui4dao3
 (跪 禱)	gui4dao3
 (路 上)	lu4shang5
-(路 ㊤)	lu4shang5
 (路 上)	lu4shang5
-(路 ㊤)	lu4shang5
 (路 口)	lu4kou3
 (路 口)	lu4kou3
 (路 得)	lu4de2
@@ -58127,7 +56098,6 @@ $textmode
 (跳 傘)	tiao4san3
 (跳 板)	tiao4ban3
 (跳 水)	tiao4shui3
-(跳 ㊌)	tiao4shui3
 (跳 脚)	tiao4jiao3
 (跳 腳)	tiao4jiao3
 (跳 舞)	tiao4wu3
@@ -58147,7 +56117,6 @@ $textmode
 (踝 骨)	huai2gu3
 (踩 死)	cai3si3
 (踩 水)	cai3shui3
-(踩 ㊌)	cai3shui3
 (踪 影)	zong1ying3
 (踪 迹)	zong1ji4
 (踮 脚)	dian3jiao3
@@ -58162,7 +56131,6 @@ $textmode
 (蹦 達)	beng4da5
 (躍 馬)	yue4ma3
 (身 上)	shen1shang5
-(身 ㊤)	shen1shang5
 (身 为)	shen1wei2
 (身 份)	shen1fen5
 (身 体)	shen1ti3
@@ -58192,7 +56160,6 @@ $textmode
 (躲 難)	duo3nan4
 (躲 難)	duo3nan4
 (躺 下)	tang3xia5
-(躺 ㊦)	tang3xia5
 (躺 椅)	tang3yi3
 (軀 殼)	qu1qiao4
 (軀 體)	qu1ti3
@@ -58223,7 +56190,6 @@ $textmode
 (軍 港)	jun1gang3
 (軍 演)	jun1yan3
 (軍 火)	jun1huo3
-(軍 ㊋)	jun1huo3
 (軍 長)	jun1zhang3
 (軒 檻)	xuan1jian4
 (軟 飲)	ruan3yin3
@@ -58249,7 +56215,6 @@ $textmode
 (輕 打)	qing1da3
 (輕 染)	qing1ran3
 (輕 水)	qing1shui3
-(輕 ㊌)	qing1shui3
 (輕 率)	qing1shuai4
 (輕 率)	qing1shuai4
 (輕 率)	qing1shuai4
@@ -58335,7 +56300,6 @@ $textmode
 (转 产)	zhuan3chan3
 (转 体)	zhuan3ti3
 (转 写)	zhuan3xie3
-(转 ㊢)	zhuan3xie3
 (转 口)	zhuan3kou3
 (转 台)	zhuan4tai2
 (转 圈)	zhuan4quan1
@@ -58387,7 +56351,6 @@ $textmode
 (轻 打)	qing1da3
 (轻 染)	qing1ran3
 (轻 水)	qing1shui3
-(轻 ㊌)	qing1shui3
 (轻 率)	qing1shuai4
 (轻 率)	qing1shuai4
 (轻 率)	qing1shuai4
@@ -58465,7 +56428,6 @@ $textmode
 (迁 往)	qian1wang3
 (迁 徙)	qian1xi3
 (迁 西)	qian1xi1
-(迁 🀂)	qian1xi1
 (迁 都)	qian1du1
 (迁 都)	qian1du1
 (迂 緩)	yu1huan3
@@ -58492,7 +56454,6 @@ $textmode
 (过 逾)	guo4yu5
 (迎 娶)	ying2qu3
 (迎 火)	ying2huo3
-(迎 ㊋)	ying2huo3
 (运 往)	yun4wang3
 (运 气)	yun4qi5
 (运 笔)	yun4bi3
@@ -58519,7 +56480,6 @@ $textmode
 (还 早)	hai2zao3
 (还 是)	hai2shi5
 (还 有)	hai2you3
-(还 ㊒)	hai2you3
 (还 本)	huan2ben3
 (还 清)	huan2qing1
 (还 礼)	huan2li3
@@ -58547,7 +56507,6 @@ $textmode
 (进 展)	jin4zhan3
 (进 来)	jin4lai5
 (进 水)	jin4shui3
-(进 ㊌)	jin4shui3
 (进 深)	jin4shen5
 (进 酒)	jin4jiu3
 (远 古)	yuan3gu3
@@ -58562,7 +56521,6 @@ $textmode
 (违 拗)	wei2ao4
 (违 法)	wei2fa3
 (连 写)	lian2xie3
-(连 ㊢)	lian2xie3
 (连 巹)	lian2jin3
 (连 手)	lian2shou3
 (连 理)	lian2li3
@@ -58652,19 +56610,15 @@ $textmode
 (逆 旅)	ni4lv3
 (逆 旅)	ni4lv3
 (逆 水)	ni4shui3
-(逆 ㊌)	ni4shui3
 (逆 產)	ni4chan3
 (逆 耳)	ni4er3
 (逆 轉)	ni4zhuan3
 (逆 转)	ni4zhuan3
 (选 中)	xuan3zhong4
-(选 🀄)	xuan3zhong4
-(选 ㊥)	xuan3zhong4
 (选 举)	xuan3ju3
 (选 取)	xuan3qu3
 (选 手)	xuan3shou3
 (透 水)	tou4shui3
-(透 ㊌)	tou4shui3
 (透 頂)	tou4ding3
 (透 顶)	tou4ding3
 (逐 行)	zhu2hang2
@@ -58706,7 +56660,6 @@ $textmode
 (通 许)	tong1xu3
 (通 识)	tong1shi2
 (速 写)	su4xie3
-(速 ㊢)	su4xie3
 (速 寫)	su4xie3
 (造 假)	zao4jia3
 (造 反)	zao4fan3
@@ -58735,7 +56688,6 @@ $textmode
 (連 鎖)	lian2suo3
 (逮 捕)	dai4bu3
 (週 五)	zhou1wu3
-(週 ㊄)	zhou1wu3
 (週 轉)	zhou1zhuan3
 (週 转)	zhou1zhuan3
 (進 來)	jin4lai5
@@ -58746,13 +56698,11 @@ $textmode
 (進 場)	jin4chang3
 (進 展)	jin4zhan3
 (進 水)	jin4shui3
-(進 ㊌)	jin4shui3
 (進 深)	jin4shen5
 (進 酒)	jin4jiu3
 (逼 供)	bi1gong4
 (逼 死)	bi1si3
 (遇 火)	yu4huo3
-(遇 ㊋)	yu4huo3
 (遇 险)	yu4xian3
 (遇 險)	yu4xian3
 (遇 难)	yu4nan4
@@ -58838,11 +56788,8 @@ $textmode
 (遥 感)	yao2gan3
 (遥 远)	yao2yuan3
 (適 宜)	shi4yi2
-(㊜ 宜)	shi4yi2
 (適 應)	shi4ying4
-(㊜ 應)	shi4ying4
 (適 當)	shi4dang4
-(㊜ 當)	shi4dang4
 (遭 打)	zao1da3
 (遭 难)	zao1nan4
 (遭 難)	zao1nan4
@@ -58863,12 +56810,9 @@ $textmode
 (遷 往)	qian1wang3
 (遷 徙)	qian1xi3
 (遷 西)	qian1xi1
-(遷 🀂)	qian1xi1
 (遷 都)	qian1du1
 (遷 都)	qian1du1
 (選 中)	xuan3zhong4
-(選 🀄)	xuan3zhong4
-(選 ㊥)	xuan3zhong4
 (選 取)	xuan3qu3
 (選 手)	xuan3shou3
 (選 舉)	xuan3ju3
@@ -58914,7 +56858,6 @@ $textmode
 (還 是)	hai2shi5
 (還 書)	huan2shu1
 (還 有)	hai2you3
-(還 ㊒)	hai2you3
 (還 本)	huan2ben3
 (還 清)	huan2qing1
 (還 禮)	huan2li3
@@ -58939,7 +56882,6 @@ $textmode
 (那 是)	na4shi5
 (那 曲)	na3qu1
 (那 有)	na3you3
-(那 ㊒)	na3you3
 (那 种)	na4zhong3
 (那 種)	na4zhong3
 (那 裏)	na4li3
@@ -58953,16 +56895,13 @@ $textmode
 (邮 筒)	you2tong3
 (邵 武)	shao4wu3
 (邻 水)	lin2shui3
-(邻 ㊌)	lin2shui3
 (邻 舍)	lin2she4
 (邻 里)	lin2li3
 (邻 里)	lin2li3
 (郊 野)	jiao1ye3
 (郑 码)	zheng4ma3
 (郧 西)	yun2xi1
-(郧 🀂)	yun2xi1
 (部 下)	bu4xia5
-(部 ㊦)	bu4xia5
 (部 分)	bu4fen5
 (部 委)	bu4wei3
 (部 属)	bu4shu3
@@ -58999,22 +56938,18 @@ $textmode
 (都 靈)	du1ling2
 (都 靈)	du1ling2
 (鄉 下)	xiang1xia5
-(鄉 ㊦)	xiang1xia5
 (鄉 土)	xiang1tu3
-(鄉 ㊏)	xiang1tu3
 (鄉 戚)	xiang1qi1
 (鄉 曲)	xiang1qu3
 (鄉 里)	xiang1li3
 (鄉 里)	xiang1li3
 (鄖 西)	yun2xi1
-(鄖 🀂)	yun2xi1
 (鄙 俚)	bi3li3
 (鄙 薄)	bi3bo2
 (鄧 拓)	deng4tuo4
 (鄧 拓)	deng4tuo4
 (鄭 碼)	zheng4ma3
 (鄰 水)	lin2shui3
-(鄰 ㊌)	lin2shui3
 (鄰 舍)	lin2she4
 (鄰 里)	lin2li3
 (鄰 里)	lin2li3
@@ -59052,7 +56987,6 @@ $textmode
 (酬 偿)	chou2chang2
 (酬 償)	chou2chang2
 (酬 劳)	chou2lao2
-(酬 ㊘)	chou2lao2
 (酬 勞)	chou2lao2
 (酬 勞)	chou2lao2
 (酬 和)	chou2he4
@@ -59069,7 +57003,6 @@ $textmode
 (酬 载)	chou2zai4
 (酬 酢)	chou2zuo4
 (酬 金)	chou2jin1
-(酬 ㊎)	chou2jin1
 (酬 金)	chou2jin1
 (酵 母)	jiao4mu3
 (酸 乳)	suan1ru3
@@ -59120,7 +57053,6 @@ $textmode
 (里 长)	li3zhang3
 (里 长)	li3zhang3
 (重 五)	chong2wu3
-(重 ㊄)	chong2wu3
 (重 启)	chong2qi3
 (重 试)	chong2shi4
 (重 估)	chong2gu1
@@ -59132,7 +57064,6 @@ $textmode
 (重 創)	zhong4chuang1
 (重 午)	chong2wu3
 (重 印)	chong2yin4
-(重 ㊞)	chong2yin4
 (重 又)	chong2you4
 (重 叠)	chong2die2
 (重 回)	chong2hui2
@@ -59167,7 +57098,6 @@ $textmode
 (重 樓)	chong2lou2
 (重 樓)	chong2lou2
 (重 水)	zhong4shui3
-(重 ㊌)	zhong4shui3
 (重 沓)	chong2ta4
 (重 洋)	chong2yang2
 (重 温)	chong2wen1
@@ -59207,7 +57137,6 @@ $textmode
 (野 史)	ye3shi3
 (野 地)	ye3di4
 (野 火)	ye3huo3
-(野 ㊋)	ye3huo3
 (野 狗)	ye3gou3
 (野 草)	ye3cao3
 (野 馬)	ye3ma3
@@ -59242,42 +57171,29 @@ $textmode
 (量 计)	liang2ji4
 (釐 米)	li2mi3
 (金 匠)	jin1jiang4
-(㊎ 匠)	jin1jiang4
 (金 匠)	jin1jiang4
 (金 发)	jin1fa4
-(㊎ 发)	jin1fa4
 (金 发)	jin1fa4
 (金 史)	jin1shi3
-(㊎ 史)	jin1shi3
 (金 史)	jin1shi3
 (金 塔)	jin1ta3
-(㊎ 塔)	jin1ta3
 (金 塔)	jin1ta3
 (金 属)	jin1shu3
-(㊎ 属)	jin1shu3
 (金 属)	jin1shu3
 (金 屬)	jin1shu3
-(㊎ 屬)	jin1shu3
 (金 屬)	jin1shu3
 (金 桔)	jin1jie2
-(㊎ 桔)	jin1jie2
 (金 桔)	jin1jie2
 (金 罕)	jin1han3
-(㊎ 罕)	jin1han3
 (金 罕)	jin1han3
 (金 菇)	jin1gu1
-(㊎ 菇)	jin1gu1
 (金 菇)	jin1gu1
 (金 酒)	jin1jiu3
-(㊎ 酒)	jin1jiu3
 (金 酒)	jin1jiu3
 (金 領)	jin1ling3
-(㊎ 領)	jin1ling3
 (金 領)	jin1ling3
 (金 領)	jin1ling3
-(㊎ 領)	jin1ling3
 (金 领)	jin1ling3
-(㊎ 领)	jin1ling3
 (金 领)	jin1ling3
 (釘 住)	ding4zhu4
 (釘 入)	ding4ru4
@@ -59309,7 +57225,6 @@ $textmode
 (銳 角)	rui4jiao3
 (銷 毀)	xiao1hui3
 (鋁 土)	lv3tu3
-(鋁 ㊏)	lv3tu3
 (鋤 地)	chu2di4
 (鋤 草)	chu2cao3
 (鋤 頭)	chu2tou5
@@ -59355,7 +57270,6 @@ $textmode
 (錄 取)	lu4qu3
 (錘 骨)	chui2gu3
 (錦 西)	jin3xi1
-(錦 🀂)	jin3xi1
 (錫 鑞)	xi1la5
 (錯 處)	cuo4chu5
 (鍋 底)	guo1di3
@@ -59392,12 +57306,10 @@ $textmode
 (鐵 板)	tie3ban3
 (鐵 桿)	tie3gan3
 (鐵 水)	tie3shui3
-(鐵 ㊌)	tie3shui3
 (鐵 法)	tie3fa3
 (鐵 甲)	tie3jia3
 (鐵 筆)	tie3bi3
 (鐵 西)	tie3xi1
-(鐵 🀂)	tie3xi1
 (鐵 軌)	tie3gui3
 (鐵 餅)	tie3bing3
 (鑄 鐵)	zhu4tie3
@@ -59448,12 +57360,10 @@ $textmode
 (铁 杆)	tie3gan3
 (铁 板)	tie3ban3
 (铁 水)	tie3shui3
-(铁 ㊌)	tie3shui3
 (铁 法)	tie3fa3
 (铁 甲)	tie3jia3
 (铁 笔)	tie3bi3
 (铁 西)	tie3xi1
-(铁 🀂)	tie3xi1
 (铁 轨)	tie3gui3
 (铁 饼)	tie3bing3
 (铃 鼓)	ling2gu3
@@ -59461,7 +57371,6 @@ $textmode
 (铜 板)	tong2ban3
 (铜 鼓)	tong2gu3
 (铝 土)	lv3tu3
-(铝 ㊏)	lv3tu3
 (铠 甲)	kai3jia3
 (银 两)	yin2liang3
 (银 匠)	yin2jiang4
@@ -59520,7 +57429,6 @@ $textmode
 (锣 鼓)	luo2gu3
 (锤 骨)	chui2gu3
 (锦 西)	jin3xi1
-(锦 🀂)	jin3xi1
 (锯 齿)	ju4chi3
 (锻 铁)	duan4tie3
 (镇 咳)	zhen4ke2
@@ -59539,7 +57447,6 @@ $textmode
 (镶 框)	xiang1kuang4
 (镶 满)	xiang1man3
 (長 上)	zhang3shang4
-(長 ㊤)	zhang3shang4
 (長 久)	chang2jiu3
 (長 假)	chang2jia4
 (長 像)	zhang3xiang4
@@ -59547,7 +57454,6 @@ $textmode
 (長 出)	zhang3chu1
 (長 大)	zhang3da4
 (長 女)	zhang3nv3
-(長 ㊛)	zhang3nv3
 (長 女)	zhang3nv3
 (長 姊)	zhang3zi3
 (長 子)	zhang3zi3
@@ -59583,7 +57489,6 @@ $textmode
 (長 釘)	chang2ding4
 (長 長)	zhang3chang2
 (长 上)	zhang3shang4
-(长 ㊤)	zhang3shang4
 (长 久)	chang2jiu3
 (长 假)	chang2jia4
 (长 像)	zhang3xiang4
@@ -59594,7 +57499,6 @@ $textmode
 (长 处)	chang2chu5
 (长 大)	zhang3da4
 (长 女)	zhang3nv3
-(长 ㊛)	zhang3nv3
 (长 女)	zhang3nv3
 (长 姊)	zhang3zi3
 (长 子)	zhang3zi3
@@ -59646,7 +57550,6 @@ $textmode
 (閃 開)	shan3kai5
 (閃 點)	shan3dian3
 (閉 上)	bi4shang5
-(閉 ㊤)	bi4shang5
 (閉 嘴)	bi4zui3
 (閉 塞)	bi4se4
 (閉 塞)	bi4se4
@@ -59671,11 +57574,9 @@ $textmode
 (開 朗)	kai1lang3
 (開 本)	kai1ben3
 (開 水)	kai1shui3
-(開 ㊌)	kai1shui3
 (開 滿)	kai1man3
 (開 演)	kai1yan3
 (開 火)	kai1huo3
-(開 ㊋)	kai1huo3
 (開 眼)	kai1yan3
 (開 筆)	kai1bi3
 (開 臉)	kai1lian3
@@ -59699,17 +57600,13 @@ $textmode
 (間 隔)	jian4ge2
 (間 隙)	jian4xi4
 (閨 女)	gui1nv5
-(閨 ㊛)	gui1nv5
 (閨 女)	gui1nv5
 (閬 中)	lang2zhong1
-(閬 🀄)	lang2zhong1
-(閬 ㊥)	lang2zhong1
 (閱 覽)	yue4lan3
 (閻 王)	yan2wang5
 (闊 氣)	kuo4qi5
 (闌 尾)	lan2wei3
 (關 上)	guan1shang5
-(關 ㊤)	guan1shang5
 (關 乎)	guan1hu1
 (關 係)	guan1xi5
 (關 卡)	guan1qia3
@@ -59721,7 +57618,6 @@ $textmode
 (關 羽)	guan1yu3
 (關 羽)	guan1yu3
 (關 西)	guan1xi1
-(關 🀂)	guan1xi1
 (门 口)	men2kou3
 (门 将)	men2jiang4
 (门 岗)	men2gang3
@@ -59742,7 +57638,6 @@ $textmode
 (闪 躲)	shan3duo3
 (闪 闪)	shan3shan3
 (闭 上)	bi4shang5
-(闭 ㊤)	bi4shang5
 (闭 嘴)	bi4zui3
 (闭 塞)	bi4se4
 (闭 塞)	bi4se4
@@ -59765,14 +57660,11 @@ $textmode
 (闷 热)	men1re4
 (闹 鬼)	nao4gui3
 (闺 女)	gui1nv5
-(闺 ㊛)	gui1nv5
 (闺 女)	gui1nv5
 (闻 喜)	wen2xi3
 (闻 得)	wen2de2
 (阅 览)	yue4lan3
 (阆 中)	lang2zhong1
-(阆 🀄)	lang2zhong1
-(阆 ㊥)	lang2zhong1
 (阎 王)	yan2wang5
 (阑 尾)	lan2wei3
 (阔 气)	kuo4qi5
@@ -59783,9 +57675,7 @@ $textmode
 (防 守)	fang2shou3
 (防 止)	fang2zhi3
 (防 水)	fang2shui3
-(防 ㊌)	fang2shui3
 (防 火)	fang2huo3
-(防 ㊋)	fang2huo3
 (防 腐)	fang2fu3
 (防 長)	fang2zhang3
 (防 长)	fang2zhang3
@@ -59793,7 +57683,6 @@ $textmode
 (阳 曲)	yang2qu3
 (阳 痿)	yang2wei3
 (阳 西)	yang2xi1
-(阳 🀂)	yang2xi1
 (阳 谷)	yang2gu3
 (阴 冷)	yin1leng3
 (阴 冷)	yin1leng3
@@ -59849,7 +57738,6 @@ $textmode
 (附 著)	fu4zhuo2
 (陆 地)	lu4di4
 (陇 西)	long3xi1
-(陇 🀂)	long3xi1
 (陈 米)	chen2mi3
 (陈 美)	chen2mei3
 (陈 腐)	chen2fu3
@@ -59861,28 +57749,19 @@ $textmode
 (降 旨)	jiang4zhi3
 (降 旨)	jiang4zhi3
 (降 水)	jiang4shui3
-(降 ㊌)	jiang4shui3
 (降 水)	jiang4shui3
-(降 ㊌)	jiang4shui3
 (降 火)	jiang4huo3
-(降 ㊋)	jiang4huo3
 (降 火)	jiang4huo3
-(降 ㊋)	jiang4huo3
 (降 雨)	jiang4yu3
 (降 雨)	jiang4yu3
 (限 於)	xian4yu2
 (陕 北)	shan3bei3
-(陕 🀃)	shan3bei3
 (陕 北)	shan3bei3
 (陕 西)	shan3xi1
-(陕 🀂)	shan3xi1
 (陜 西)	xia2xi1
-(陜 🀂)	xia2xi1
 (陝 北)	shan3bei3
-(陝 🀃)	shan3bei3
 (陝 北)	shan3bei3
 (陝 西)	shan3xi1
-(陝 🀂)	shan3xi1
 (院 裡)	yuan4li3
 (院 裡)	yuan4li3
 (院 里)	yuan4li3
@@ -59914,7 +57793,6 @@ $textmode
 (陶 冶)	tao2ye3
 (陶 匠)	tao2jiang4
 (陶 土)	tao2tu3
-(陶 ㊏)	tao2tu3
 (陷 於)	xian4yu2
 (陷 阱)	xian4jing3
 (陸 地)	lu4di4
@@ -59923,7 +57801,6 @@ $textmode
 (陽 曲)	yang2qu3
 (陽 痿)	yang2wei3
 (陽 西)	yang2xi1
-(陽 🀂)	yang2xi1
 (陽 谷)	yang2gu3
 (隆 子)	long2zi3
 (隆 子)	long2zi3
@@ -59937,7 +57814,6 @@ $textmode
 (随 手)	sui2shou3
 (随 笔)	sui2bi3
 (隐 土)	yin3tu3
-(隐 ㊏)	yin3tu3
 (隐 忍)	yin3ren3
 (隐 显)	yin3xian3
 (隐 没)	yin3mo4
@@ -59956,7 +57832,6 @@ $textmode
 (隨 筆)	sui2bi3
 (險 阻)	xian3zu3
 (隱 土)	yin3tu3
-(隱 ㊏)	yin3tu3
 (隱 忍)	yin3ren3
 (隱 沒)	yin3mo4
 (隱 語)	yin3yu3
@@ -59964,7 +57839,6 @@ $textmode
 (隱 隱)	yin3yin3
 (隱 顯)	yin3xian3
 (隴 西)	long3xi1
-(隴 🀂)	long3xi1
 (隶 属)	li4shu3
 (隸 屬)	li4shu3
 (隸 屬)	li4shu3
@@ -60019,7 +57893,6 @@ $textmode
 (雇 请)	gu4qing3
 (雌 蕊)	ci2rui3
 (雍 正)	yong1zheng1
-(雍 ㊣)	yong1zheng1
 (雏 儿)	chu2r5
 (雏 鸟)	chu2niao3
 (雕 版)	diao1ban3
@@ -60048,7 +57921,6 @@ $textmode
 (雞 眼)	ji1yan3
 (雞 腳)	ji1jiao3
 (雞 西)	ji1xi1
-(雞 🀂)	ji1xi1
 (離 地)	li2di4
 (離 地)	li2di4
 (離 子)	li2zi3
@@ -60099,13 +57971,11 @@ $textmode
 (雨 傘)	yu3san3
 (雨 果)	yu3guo3
 (雨 水)	yu3shui3
-(雨 ㊌)	yu3shui3
 (雨 点)	yu3dian3
 (雨 雪)	yu3xue3
 (雨 點)	yu3dian3
 (雪 板)	xue3ban3
 (雪 水)	xue3shui3
-(雪 ㊌)	xue3shui3
 (雲 彩)	yun2cai5
 (雲 彩)	yun2cai5
 (雲 影)	yun2ying3
@@ -60170,9 +58040,7 @@ $textmode
 (露 怯)	lou4qie4
 (露 怯)	lou4qie4
 (露 水)	lu4shui5
-(露 ㊌)	lu4shui5
 (露 水)	lu4shui5
-(露 ㊌)	lu4shui5
 (露 点)	lu4dian3
 (露 点)	lu4dian3
 (露 白)	lou4bai2
@@ -60188,9 +58056,7 @@ $textmode
 (露 茜)	lu4xi1
 (露 茜)	lu4xi1
 (露 西)	lu4xi1
-(露 🀂)	lu4xi1
 (露 西)	lu4xi1
-(露 🀂)	lu4xi1
 (露 醜)	lou4chou3
 (露 醜)	lou4chou3
 (露 面)	lou4mian4
@@ -60249,11 +58115,8 @@ $textmode
 (靖 宇)	jing4yu3
 (靖 宇)	jing4yu3
 (靖 西)	jing4xi1
-(靖 🀂)	jing4xi1
 (靖 西)	jing4xi1
-(靖 🀂)	jing4xi1
 (靖 西)	jing4xi1
-(靖 🀂)	jing4xi1
 (靖 远)	jing4yuan3
 (靖 远)	jing4yuan3
 (靖 远)	jing4yuan3
@@ -60290,7 +58153,6 @@ $textmode
 (靠 拢)	kao4long3
 (靠 攏)	kao4long3
 (面 上)	mian4shang5
-(面 ㊤)	mian4shang5
 (面 儿)	mian4r5
 (面 友)	mian4you3
 (面 孔)	mian4kong3
@@ -60348,11 +58210,8 @@ $textmode
 (響 應)	xiang3ying4
 (響 應)	xiang3ying4
 (響 水)	xiang3shui3
-(響 ㊌)	xiang3shui3
 (響 水)	xiang3shui3
-(響 ㊌)	xiang3shui3
 (響 水)	xiang3shui3
-(響 ㊌)	xiang3shui3
 (響 聲)	xiang3sheng5
 (響 聲)	xiang3sheng5
 (響 聲)	xiang3sheng5
@@ -60367,11 +58226,8 @@ $textmode
 (頂 骨)	ding3gu3
 (頂 點)	ding3dian3
 (項 羽)	xiang4yu3
-(㊠ 羽)	xiang4yu3
 (項 羽)	xiang4yu3
-(㊠ 羽)	xiang4yu3
 (項 頸)	xiang4jing3
-(㊠ 頸)	xiang4jing3
 (順 口)	shun4kou3
 (順 嘴)	shun4zui3
 (順 坦)	shun4tan3
@@ -60380,7 +58236,6 @@ $textmode
 (順 應)	shun4ying4
 (順 手)	shun4shou3
 (順 水)	shun4shui3
-(順 ㊌)	shun4shui3
 (順 溜)	shun4liu5
 (順 溜)	shun4liu5
 (順 當)	shun4dang5
@@ -60407,17 +58262,13 @@ $textmode
 (領 口)	ling3kou3
 (領 口)	ling3kou3
 (領 土)	ling3tu3
-(領 ㊏)	ling3tu3
 (領 土)	ling3tu3
-(領 ㊏)	ling3tu3
 (領 地)	ling3di4
 (領 地)	ling3di4
 (領 導)	ling3dao3
 (領 導)	ling3dao3
 (領 有)	ling3you3
-(領 ㊒)	ling3you3
 (領 有)	ling3you3
-(領 ㊒)	ling3you3
 (領 洗)	ling3xi3
 (領 洗)	ling3xi3
 (領 海)	ling3hai3
@@ -60503,7 +58354,6 @@ $textmode
 (顺 当)	shun4dang5
 (顺 手)	shun4shou3
 (顺 水)	shun4shui3
-(顺 ㊌)	shun4shui3
 (顺 溜)	shun4liu5
 (顺 溜)	shun4liu5
 (顺 眼)	shun4yan3
@@ -60528,12 +58378,10 @@ $textmode
 (领 取)	ling3qu3
 (领 口)	ling3kou3
 (领 土)	ling3tu3
-(领 ㊏)	ling3tu3
 (领 地)	ling3di4
 (领 奖)	ling3jiang3
 (领 导)	ling3dao3
 (领 有)	ling3you3
-(领 ㊒)	ling3you3
 (领 洗)	ling3xi3
 (领 海)	ling3hai3
 (领 海)	ling3hai3
@@ -60563,10 +58411,8 @@ $textmode
 (風 乾)	feng1gan1
 (風 口)	feng1kou3
 (風 土)	feng1tu3
-(風 ㊏)	feng1tu3
 (風 景)	feng1jing3
 (風 水)	feng1shui5
-(風 ㊌)	feng1shui5
 (風 箏)	feng1zheng5
 (風 采)	feng1cai3
 (風 鑽)	feng1zuan4
@@ -60586,11 +58432,9 @@ $textmode
 (飆 漲)	biao1zhang3
 (风 口)	feng1kou3
 (风 土)	feng1tu3
-(风 ㊏)	feng1tu3
 (风 头)	feng1tou5
 (风 景)	feng1jing3
 (风 水)	feng1shui5
-(风 ㊌)	feng1shui5
 (风 筝)	feng1zheng5
 (风 采)	feng1cai3
 (风 钻)	feng1zuan4
@@ -60645,7 +58489,6 @@ $textmode
 (飯 館)	fan4guan3
 (飲 品)	yin3pin3
 (飲 水)	yin3shui3
-(飲 ㊌)	yin3shui3
 (飲 酒)	yin3jiu3
 (飼 草)	si4cao3
 (飼 草)	si4cao3
@@ -60663,7 +58506,6 @@ $textmode
 (養 分)	yang3fen4
 (養 地)	yang3di4
 (養 女)	yang3nv3
-(養 ㊛)	yang3nv3
 (養 女)	yang3nv3
 (養 子)	yang3zi3
 (養 母)	yang3mu3
@@ -60702,7 +58544,6 @@ $textmode
 (饭 馆)	fan4guan3
 (饮 品)	yin3pin3
 (饮 水)	yin3shui3
-(饮 ㊌)	yin3shui3
 (饮 酒)	yin3jiu3
 (饰 品)	shi4pin3
 (饰 演)	shi4yan3
@@ -60745,10 +58586,8 @@ $textmode
 (香 槟)	xiang1bin1
 (香 檳)	xiang1bin1
 (香 水)	xiang1shui3
-(香 ㊌)	xiang1shui3
 (香 港)	xiang1gang3
 (香 火)	xiang1huo3
-(香 ㊋)	xiang1huo3
 (香 粉)	xiang1fen3
 (香 草)	xiang1cao3
 (香 荽)	xiang1sui5
@@ -60787,7 +58626,6 @@ $textmode
 (駱 馬)	luo4ma3
 (駿 馬)	jun4ma3
 (騎 土)	qi2tu3
-(騎 ㊏)	qi2tu3
 (騎 警)	qi2jing3
 (騎 馬)	qi2ma3
 (騖 遠)	wu4yuan3
@@ -60856,7 +58694,6 @@ $textmode
 (骈 体)	pian2ti3
 (骏 马)	jun4ma3
 (骑 土)	qi2tu3
-(骑 ㊏)	qi2tu3
 (骑 警)	qi2jing3
 (骑 马)	qi2ma3
 (骗 供)	pian4gong4
@@ -60882,9 +58719,7 @@ $textmode
 (髂 骨)	qia4gu3
 (髌 骨)	bin4gu3
 (髒 土)	zang1tu3
-(髒 ㊏)	zang1tu3
 (髒 水)	zang1shui3
-(髒 ㊌)	zang1shui3
 (髓 脑)	sui3nao3
 (髓 腦)	sui3nao3
 (體 己)	ti1ji5
@@ -60923,7 +58758,6 @@ $textmode
 (髮 給)	fa1gei3
 (髮 網)	fa4wang3
 (鬆 土)	song1tu3
-(鬆 ㊏)	song1tu3
 (鬆 快)	song1kuai5
 (鬆 散)	song1san5
 (鬆 泛)	song1fan5
@@ -60941,7 +58775,6 @@ $textmode
 (鬼 佬)	gui3lao3
 (鬼 扯)	gui3che3
 (鬼 火)	gui3huo3
-(鬼 ㊋)	gui3huo3
 (鬼 脸)	gui3lian3
 (鬼 臉)	gui3lian3
 (魁 伟)	kui2wei3
@@ -61036,7 +58869,6 @@ $textmode
 (鸡 眼)	ji1yan3
 (鸡 脚)	ji1jiao3
 (鸡 西)	ji1xi1
-(鸡 🀂)	ji1xi1
 (鸣 响)	ming2xiang3
 (鸣 鸟)	ming2niao3
 (鸨 母)	bao3mu3
@@ -61055,18 +58887,14 @@ $textmode
 (鹳 鸟)	guan4niao3
 (鹵 屬)	lu3shu3
 (鹵 水)	lu3shui3
-(鹵 ㊌)	lu3shui3
 (鹵 法)	lu3fa3
 (鹵 莽)	lu3mang3
 (鹹 水)	xian2shui3
-(鹹 ㊌)	xian2shui3
 (鹹 海)	xian2hai3
 (鹹 海)	xian2hai3
 (鹹 草)	xian2cao3
 (鹼 土)	jian3tu3
-(鹼 ㊏)	jian3tu3
 (鹼 水)	jian3shui3
-(鹼 ㊌)	jian3shui3
 (鹽 井)	yan2jing3
 (鹽 海)	yan2hai3
 (鹽 海)	yan2hai3
@@ -61074,9 +58902,7 @@ $textmode
 (鹽 鹵)	yan2lu3
 (鹽 鹼)	yan2jian3
 (麗 水)	li2shui3
-(麗 ㊌)	li2shui3
 (麗 水)	li2shui3
-(麗 ㊌)	li2shui3
 (麥 粉)	mai4fen3
 (麥 酒)	mai4jiu3
 (麥 餅)	mai4bing3
@@ -61093,11 +58919,9 @@ $textmode
 (麻 疹)	ma2zhen3
 (麻 秸)	ma2jie5
 (黃 土)	huang2tu3
-(黃 ㊏)	huang2tu3
 (黃 埔)	huang2pu3
 (黃 島)	huang2dao3
 (黃 水)	huang2shui3
-(黃 ㊌)	huang2shui3
 (黃 浦)	huang2pu3
 (黃 海)	huang2hai3
 (黃 海)	huang2hai3
@@ -61110,11 +58934,9 @@ $textmode
 (黄 体)	huang2ti3
 (黄 兴)	huang2xing1
 (黄 土)	huang2tu3
-(黄 ㊏)	huang2tu3
 (黄 埔)	huang2pu3
 (黄 岛)	huang2dao3
 (黄 水)	huang2shui3
-(黄 ㊌)	huang2shui3
 (黄 浦)	huang2pu3
 (黄 海)	huang2hai3
 (黄 海)	huang2hai3
@@ -61124,7 +58946,6 @@ $textmode
 (黄 饼)	huang2bing3
 (黏 儿)	nian2r5
 (黏 土)	nian2tu3
-(黏 ㊏)	nian2tu3
 (黏 涎)	nian2xian5
 (黏 着)	nian2zhuo2
 (黏 着)	nian2zhuo2
@@ -61135,7 +58956,6 @@ $textmode
 (黑 发)	hei1fa4
 (黑 板)	hei1ban3
 (黑 水)	hei1shui3
-(黑 ㊌)	hei1shui3
 (黑 海)	hei1hai3
 (黑 海)	hei1hai3
 (黑 馬)	hei1ma3
@@ -61143,9 +58963,7 @@ $textmode
 (黑 體)	hei1ti3
 (黑 鬼)	hei1gui3
 (黔 西)	qian2xi1
-(黔 🀂)	qian2xi1
 (默 写)	mo4xie3
-(默 ㊢)	mo4xie3
 (默 寫)	mo4xie3
 (默 想)	mo4xiang3
 (默 玛)	mo4ma3
@@ -61161,9 +58979,7 @@ $textmode
 (點 染)	dian3ran3
 (點 檢)	dian3jian3
 (點 水)	dian3shui3
-(點 ㊌)	dian3shui3
 (點 火)	dian3huo3
-(點 ㊋)	dian3huo3
 (點 睛)	dian3jing1
 (點 著)	dian3zhao2
 (點 著)	dian3zhao2
@@ -61256,814 +59072,401 @@ $textmode
 (Ｕ 盤)	yu4pan2
 (+ 個 樣)	yi1ge5yang4
 (一 丁 点)	yi4ding1dian3
-(㊀ 丁 点)	yi4ding1dian3
 (一 丁 點)	yi4ding1dian3
-(㊀ 丁 點)	yi4ding1dian3
 (一 上 來)	yi2shang4lai2
-(一 ㊤ 來)	yi2shang4lai2
-(㊀ 上 來)	yi2shang4lai2
 (一 上 來)	yi2shang4lai2
-(一 ㊤ 來)	yi2shang4lai2
-(㊀ 上 來)	yi2shang4lai2
 (一 上 来)	yi2shang4lai2
-(一 ㊤ 来)	yi2shang4lai2
-(㊀ 上 来)	yi2shang4lai2
 (一 下 儿)	yi2xia4r5
-(一 ㊦ 儿)	yi2xia4r5
-(㊀ 下 儿)	yi2xia4r5
 (一 不 溜)	yi2bu4liu1
-(㊀ 不 溜)	yi2bu4liu1
 (一 不 溜)	yi2bu4liu1
-(㊀ 不 溜)	yi2bu4liu1
 (一 不 溜)	yi2bu4liu1
-(㊀ 不 溜)	yi2bu4liu1
 (一 与 多)	yi4yu3duo1
-(㊀ 与 多)	yi4yu3duo1
 (一 世 界)	yi2shi4jie5
-(㊀ 世 界)	yi2shi4jie5
 (一 两 个)	yi4liang3ge5
-(㊀ 两 个)	yi4liang3ge5
 (一 两 個)	yi4liang3ge5
-(㊀ 两 個)	yi4liang3ge5
 (一 个 个)	yi2ge4ge4
-(㊀ 个 个)	yi2ge4ge4
 (一 个 劲)	yi2ge4jin4
-(㊀ 个 劲)	yi2ge4jin4
 (一 乐 也)	yi2le4ye3
-(㊀ 乐 也)	yi2le4ye3
 (一 些 个)	yi4xie1ge5
-(㊀ 些 个)	yi4xie1ge5
 (一 些 個)	yi4xie1ge5
-(㊀ 些 個)	yi4xie1ge5
 (一 些 儿)	yi4xie1r5
-(㊀ 些 儿)	yi4xie1r5
 (一 伙 儿)	yi4huo3r5
-(㊀ 伙 儿)	yi4huo3r5
 (一 会 儿)	yi2hui4r5
-(㊀ 会 儿)	yi2hui4r5
 (一 侧 化)	yi2ce4hua4
-(㊀ 侧 化)	yi2ce4hua4
 (一 個 個)	yi2ge4ge4
-(㊀ 個 個)	yi2ge4ge4
 (一 個 勁)	yi2ge4jin4
-(㊀ 個 勁)	yi2ge4jin4
 (一 側 化)	yi2ce4hua4
-(㊀ 側 化)	yi2ce4hua4
 (一 兩 个)	yi4liang3ge5
-(㊀ 兩 个)	yi4liang3ge5
 (一 兩 个)	yi4liang3ge5
-(㊀ 兩 个)	yi4liang3ge5
 (一 兩 個)	yi4liang3ge5
-(㊀ 兩 個)	yi4liang3ge5
 (一 兩 個)	yi4liang3ge5
-(㊀ 兩 個)	yi4liang3ge5
 (一 准 儿)	yi4zhun3r5
-(㊀ 准 儿)	yi4zhun3r5
 (一 刀 切)	yi4dao1qie1
-(㊀ 刀 切)	yi4dao1qie1
 (一 刀 切)	yi4dao1qie1
-(㊀ 刀 切)	yi4dao1qie1
 (一 分 子)	yi2fen4zi3
-(㊀ 分 子)	yi2fen4zi3
 (一 分 錢)	yi4fen1qian2
-(㊀ 分 錢)	yi4fen1qian2
 (一 分 钱)	yi4fen1qian2
-(㊀ 分 钱)	yi4fen1qian2
 (一 划 拉)	yi4hua2la5
-(㊀ 划 拉)	yi4hua2la5
 (一 划 拉)	yi4hua2la5
-(㊀ 划 拉)	yi4hua2la5
 (一 动 儿)	yi2dong4r5
-(㊀ 动 儿)	yi2dong4r5
 (一 劲 儿)	yi2jin4r5
-(㊀ 劲 儿)	yi2jin4r5
 (一 勁 兒)	yi2jin4r5
-(㊀ 勁 兒)	yi2jin4r5
 (一 勺 烩)	yi4shao2hui4
-(㊀ 勺 烩)	yi4shao2hui4
 (一 勺 烩)	yi4shao2hui4
-(㊀ 勺 烩)	yi4shao2hui4
 (一 勺 燴)	yi4shao2hui4
-(㊀ 勺 燴)	yi4shao2hui4
 (一 勺 燴)	yi4shao2hui4
-(㊀ 勺 燴)	yi4shao2hui4
 (一 半 儿)	yi2ban4r5
-(㊀ 半 儿)	yi2ban4r5
 (一 厚 块)	yi2hou4kuai4
-(㊀ 厚 块)	yi2hou4kuai4
 (一 厚 塊)	yi2hou4kuai4
-(㊀ 厚 塊)	yi2hou4kuai4
 (一 号 儿)	yi2hao4r5
-(㊀ 号 儿)	yi2hao4r5
 (一 后 晌)	yi2hou4shang3
-(㊀ 后 晌)	yi2hou4shang3
 (一 嘟 絡)	yi4du1luo4
-(㊀ 嘟 絡)	yi4du1luo4
 (一 嘟 络)	yi4du1luo4
-(㊀ 嘟 络)	yi4du1luo4
 (一 圪 堵)	yi4ge1du3
-(㊀ 圪 堵)	yi4ge1du3
 (一 地 区)	yi2di4qu1
-(㊀ 地 区)	yi2di4qu1
 (一 地 區)	yi2di4qu1
-(㊀ 地 區)	yi2di4qu1
 (一 地 址)	yi2di4zhi3
-(㊀ 地 址)	yi2di4zhi3
 (一 地 裡)	yi2di4li5
-(㊀ 地 裡)	yi2di4li5
 (一 地 裡)	yi2di4li5
-(㊀ 地 裡)	yi2di4li5
 (一 地 里)	yi2di4li5
-(㊀ 地 里)	yi2di4li5
 (一 地 里)	yi2di4li5
-(㊀ 地 里)	yi2di4li5
 (一 场 空)	yi4chang3kong1
-(㊀ 场 空)	yi4chang3kong1
 (一 场 雪)	yi4chang3xue3
-(㊀ 场 雪)	yi4chang3xue3
 (一 块 儿)	yi2kuai4r5
-(㊀ 块 儿)	yi2kuai4r5
 (一 場 空)	yi4chang3kong1
-(㊀ 場 空)	yi4chang3kong1
 (一 場 雪)	yi4chang3xue3
-(㊀ 場 雪)	yi4chang3xue3
 (一 处 儿)	yi2chu4r5
-(㊀ 处 儿)	yi2chu4r5
 (一 多 半)	yi4duo1ban4
-(㊀ 多 半)	yi4duo1ban4
 (一 夜 情)	yi2ye4qing2
-(一 ㊰ 情)	yi2ye4qing2
-(㊀ 夜 情)	yi2ye4qing2
 (一 大 些)	yi2da4xie1
-(㊀ 大 些)	yi2da4xie1
 (一 大 半)	yi2da4ban4
-(㊀ 大 半)	yi2da4ban4
 (一 大 天)	yi2da4tian1
-(㊀ 大 天)	yi2da4tian1
 (一 大 早)	yi2da4zao3
-(㊀ 大 早)	yi2da4zao3
 (一 大 晌)	yi2da4shang3
-(㊀ 大 晌)	yi2da4shang3
 (一 大 趟)	yi2da4tang4
-(㊀ 大 趟)	yi2da4tang4
 (一 天 价)	yi4tian1jia5
-(㊀ 天 价)	yi4tian1jia5
 (一 天 價)	yi4tian1jia5
-(㊀ 天 價)	yi4tian1jia5
 (一 头 儿)	yi4tou2r5
-(㊀ 头 儿)	yi4tou2r5
 (一 妻 制)	yi4qi1zhi4
-(㊀ 妻 制)	yi4qi1zhi4
 (一 子 儿)	yi4zi3r5
-(㊀ 子 儿)	yi4zi3r5
 (一 子 兒)	yi4zi3r5
-(㊀ 子 兒)	yi4zi3r5
 (一 字 儿)	yi2zi4r5
-(㊀ 字 儿)	yi2zi4r5
 (一 宗 儿)	yi4zong1r5
-(一 ㊪ 儿)	yi4zong1r5
-(㊀ 宗 儿)	yi4zong1r5
 (一 宠 性)	yi4chong3xing4
-(㊀ 宠 性)	yi4chong3xing4
 (一 家 儿)	yi4jia1r5
-(㊀ 家 儿)	yi4jia1r5
 (一 宿 儿)	yi4xiu3r5
-(㊀ 宿 儿)	yi4xiu3r5
 (一 寵 性)	yi4chong3xing4
-(㊀ 寵 性)	yi4chong3xing4
 (一 对 儿)	yi2dui4r5
-(㊀ 对 儿)	yi2dui4r5
 (一 小 儿)	yi4xiao3r5
-(㊀ 小 儿)	yi4xiao3r5
 (一 屁 股)	yi2pi4gu5
-(㊀ 屁 股)	yi2pi4gu5
 (一 巴 掌)	yi4ba1zhang5
-(㊀ 巴 掌)	yi4ba1zhang5
 (一 席 話)	yi4xi2hua4
-(㊀ 席 話)	yi4xi2hua4
 (一 席 談)	yi4xi2tan2
-(㊀ 席 談)	yi4xi2tan2
 (一 席 话)	yi4xi2hua4
-(㊀ 席 话)	yi4xi2hua4
 (一 席 谈)	yi4xi2tan2
-(㊀ 席 谈)	yi4xi2tan2
 (一 帮 人)	yi4bang1ren2
-(㊀ 帮 人)	yi4bang1ren2
 (一 幫 人)	yi4bang1ren2
-(㊀ 幫 人)	yi4bang1ren2
 (一 弄 儿)	yi2long4r5
-(㊀ 弄 儿)	yi2long4r5
 (一 弄 儿)	yi2long4r5
-(㊀ 弄 儿)	yi2long4r5
 (一 弄 兒)	yi2long4r5
-(㊀ 弄 兒)	yi2long4r5
 (一 弄 兒)	yi2long4r5
-(㊀ 弄 兒)	yi2long4r5
 (一 弦 琴)	yi4xian2qin2
-(㊀ 弦 琴)	yi4xian2qin2
 (一 弹 指)	yi4tan2zhi3
-(㊀ 弹 指)	yi4tan2zhi3
 (一 彈 指)	yi4tan2zhi3
-(㊀ 彈 指)	yi4tan2zhi3
 (一 当 儿)	yi2dang4r5
-(㊀ 当 儿)	yi2dang4r5
 (一 後 晌)	yi2hou4shang3
-(㊀ 後 晌)	yi2hou4shang3
 (一 忽 儿)	yi4hu1r5
-(㊀ 忽 儿)	yi4hu1r5
 (一 忽 兒)	yi4hu1r5
-(㊀ 忽 兒)	yi4hu1r5
 (一 忽 溜)	yi4hu1liu5
-(㊀ 忽 溜)	yi4hu1liu5
 (一 忽 溜)	yi4hu1liu5
-(㊀ 忽 溜)	yi4hu1liu5
 (一 忽 見)	yi4hu1jian4
-(㊀ 忽 見)	yi4hu1jian4
 (一 忽 見)	yi4hu1jian4
-(㊀ 忽 見)	yi4hu1jian4
 (一 忽 见)	yi4hu1jian4
-(㊀ 忽 见)	yi4hu1jian4
 (一 总 儿)	yi4zong3r5
-(㊀ 总 儿)	yi4zong3r5
 (一 愣 儿)	yi2leng4r5
-(㊀ 愣 儿)	yi2leng4r5
 (一 手 儿)	yi4shou3r5
-(㊀ 手 儿)	yi4shou3r5
 (一 抹 平)	yi4ma1ping2
-(㊀ 抹 平)	yi4ma1ping2
 (一 抿 子)	yi4min3zi5
-(㊀ 抿 子)	yi4min3zi5
 (一 拉 平)	yi4la1ping2
-(㊀ 拉 平)	yi4la1ping2
 (一 拉 平)	yi4la1ping2
-(㊀ 拉 平)	yi4la1ping2
 (一 招 儿)	yi4zhao1r5
-(㊀ 招 儿)	yi4zhao1r5
 (一 招 兒)	yi4zhao1r5
-(㊀ 招 兒)	yi4zhao1r5
 (一 拢 地)	yi4long3di4
-(㊀ 拢 地)	yi4long3di4
 (一 拧 头)	yi4ning3tou2
-(㊀ 拧 头)	yi4ning3tou2
 (一 拨 儿)	yi4bo1r5
-(㊀ 拨 儿)	yi4bo1r5
 (一 揽 子)	yi4lan3zi5
-(㊀ 揽 子)	yi4lan3zi5
 (一 摸 黑)	yi4mo1hei1
-(㊀ 摸 黑)	yi4mo1hei1
 (一 擰 頭)	yi4ning3tou2
-(㊀ 擰 頭)	yi4ning3tou2
 (一 攏 地)	yi4long3di4
-(㊀ 攏 地)	yi4long3di4
 (一 攬 子)	yi4lan3zi5
-(㊀ 攬 子)	yi4lan3zi5
 (一 整 列)	yi4zheng3lie4
-(㊀ 整 列)	yi4zheng3lie4
 (一 整 列)	yi4zheng3lie4
-(㊀ 整 列)	yi4zheng3lie4
 (一 整 天)	yi4zheng3tian1
-(㊀ 整 天)	yi4zheng3tian1
 (一 整 年)	yi4zheng3nian2
-(㊀ 整 年)	yi4zheng3nian2
 (一 整 年)	yi4zheng3nian2
-(㊀ 整 年)	yi4zheng3nian2
 (一 日 游)	yi2ri4you2
-(㊀ 日 游)	yi2ri4you2
-(一 ㊐ 游)	yi2ri4you2
 (一 日 热)	yi2ri4re4
-(㊀ 日 热)	yi2ri4re4
-(一 ㊐ 热)	yi2ri4re4
 (一 日 熱)	yi2ri4re4
-(㊀ 日 熱)	yi2ri4re4
-(一 ㊐ 熱)	yi2ri4re4
 (一 日 量)	yi2ri4liang4
-(㊀ 日 量)	yi2ri4liang4
-(一 ㊐ 量)	yi2ri4liang4
 (一 日 量)	yi2ri4liang4
-(㊀ 日 量)	yi2ri4liang4
-(一 ㊐ 量)	yi2ri4liang4
 (一 早 儿)	yi4zao3r5
-(㊀ 早 儿)	yi4zao3r5
 (一 早 晨)	yi4zao3chen2
-(㊀ 早 晨)	yi4zao3chen2
 (一 星 儿)	yi4xing1r5
-(㊀ 星 儿)	yi4xing1r5
 (一 晃 儿)	yi2huang4r5
-(㊀ 晃 儿)	yi2huang4r5
 (一 晌 儿)	yi4shang3r5
-(㊀ 晌 儿)	yi4shang3r5
 (一 朵 落)	yi4duo3luo5
-(㊀ 朵 落)	yi4duo3luo5
 (一 朵 落)	yi4duo3luo5
-(㊀ 朵 落)	yi4duo3luo5
 (一 样 儿)	yi2yang4r5
-(㊀ 样 儿)	yi2yang4r5
 (一 樂 也)	yi2le4ye3
-(㊀ 樂 也)	yi2le4ye3
 (一 樂 也)	yi2le4ye3
-(㊀ 樂 也)	yi2le4ye3
 (一 樂 也)	yi2le4ye3
-(㊀ 樂 也)	yi2le4ye3
 (一 樂 也)	yi2le4ye3
-(㊀ 樂 也)	yi2le4ye3
 (一 死 儿)	yi4si3r5
-(㊀ 死 儿)	yi4si3r5
 (一 死 兒)	yi4si3r5
-(㊀ 死 兒)	yi4si3r5
 (一 毫 儿)	yi4hao2r5
-(㊀ 毫 儿)	yi4hao2r5
 (一 气 儿)	yi2qi4r5
-(㊀ 气 儿)	yi2qi4r5
 (一 水 儿)	yi4shui3r5
-(一 ㊌ 儿)	yi4shui3r5
-(㊀ 水 儿)	yi4shui3r5
 (一 水 兒)	yi4shui3r5
-(一 ㊌ 兒)	yi4shui3r5
-(㊀ 水 兒)	yi4shui3r5
 (一 汤 匙)	yi4tang1chi2
-(㊀ 汤 匙)	yi4tang1chi2
 (一 汪 儿)	yi4wang1r5
-(㊀ 汪 儿)	yi4wang1r5
 (一 清 早)	yi4qing1zao3
-(㊀ 清 早)	yi4qing1zao3
 (一 湯 匙)	yi4tang1chi2
-(㊀ 湯 匙)	yi4tang1chi2
 (一 溜 儿)	yi2liu4r5
-(㊀ 溜 儿)	yi2liu4r5
 (一 溜 儿)	yi2liu4r5
-(㊀ 溜 儿)	yi2liu4r5
 (一 满 勺)	yi4man3shao2
-(㊀ 满 勺)	yi4man3shao2
 (一 满 勺)	yi4man3shao2
-(㊀ 满 勺)	yi4man3shao2
 (一 满 匙)	yi4man3chi2
-(㊀ 满 匙)	yi4man3chi2
 (一 满 盘)	yi4man3pan2
-(㊀ 满 盘)	yi4man3pan2
 (一 满 箱)	yi4man3xiang1
-(㊀ 满 箱)	yi4man3xiang1
 (一 滩 子)	yi4tan1zi5
-(㊀ 滩 子)	yi4tan1zi5
 (一 滩 泥)	yi4tan1ni2
-(㊀ 滩 泥)	yi4tan1ni2
 (一 滩 泥)	yi4tan1ni2
-(㊀ 滩 泥)	yi4tan1ni2
 (一 滩 滩)	yi4tan1tan1
-(㊀ 滩 滩)	yi4tan1tan1
 (一 滿 勺)	yi4man3shao2
-(㊀ 滿 勺)	yi4man3shao2
 (一 滿 勺)	yi4man3shao2
-(㊀ 滿 勺)	yi4man3shao2
 (一 滿 匙)	yi4man3chi2
-(㊀ 滿 匙)	yi4man3chi2
 (一 滿 盤)	yi4man3pan2
-(㊀ 滿 盤)	yi4man3pan2
 (一 滿 箱)	yi4man3xiang1
-(㊀ 滿 箱)	yi4man3xiang1
 (一 灘 子)	yi4tan1zi5
-(㊀ 灘 子)	yi4tan1zi5
 (一 灘 泥)	yi4tan1ni2
-(㊀ 灘 泥)	yi4tan1ni2
 (一 灘 泥)	yi4tan1ni2
-(㊀ 灘 泥)	yi4tan1ni2
 (一 灘 灘)	yi4tan1tan1
-(㊀ 灘 灘)	yi4tan1tan1
 (一 点 儿)	yi4dian3r5
-(㊀ 点 儿)	yi4dian3r5
 (一 熟 制)	yi4shu2zhi4
-(㊀ 熟 制)	yi4shu2zhi4
 (一 猛 子)	yi4meng3zi5
-(㊀ 猛 子)	yi4meng3zi5
 (一 甲 子)	yi4jia3zi5
-(㊀ 甲 子)	yi4jia3zi5
 (一 當 兒)	yi2dang4r5
-(㊀ 當 兒)	yi2dang4r5
 (一 疙 堆)	yi4ge1dui5
-(㊀ 疙 堆)	yi4ge1dui5
 (一 疙 瘩)	yi4ge1da5
-(㊀ 疙 瘩)	yi4ge1da5
 (一 眨 眼)	yi4zha3yan3
-(㊀ 眨 眼)	yi4zha3yan3
 (一 码 事)	yi4ma3shi4
-(㊀ 码 事)	yi4ma3shi4
 (一 码 子)	yi4ma3zi5
-(㊀ 码 子)	yi4ma3zi5
 (一 硫 化)	yi4liu2hua4
-(㊀ 硫 化)	yi4liu2hua4
 (一 硫 化)	yi4liu2hua4
-(㊀ 硫 化)	yi4liu2hua4
 (一 碼 事)	yi4ma3shi4
-(㊀ 碼 事)	yi4ma3shi4
 (一 碼 子)	yi4ma3zi5
-(㊀ 碼 子)	yi4ma3zi5
 (一 神 会)	yi4shen2hui4
-(㊀ 神 会)	yi4shen2hui4
 (一 神 会)	yi4shen2hui4
-(㊀ 神 会)	yi4shen2hui4
 (一 神 教)	yi4shen2jiao4
-(㊀ 神 教)	yi4shen2jiao4
 (一 神 教)	yi4shen2jiao4
-(㊀ 神 教)	yi4shen2jiao4
 (一 神 會)	yi4shen2hui4
-(㊀ 神 會)	yi4shen2hui4
 (一 神 會)	yi4shen2hui4
-(㊀ 神 會)	yi4shen2hui4
 (一 神 論)	yi4shen2lun4
-(㊀ 神 論)	yi4shen2lun4
 (一 神 論)	yi4shen2lun4
-(㊀ 神 論)	yi4shen2lun4
 (一 神 論)	yi4shen2lun4
-(㊀ 神 論)	yi4shen2lun4
 (一 神 论)	yi4shen2lun4
-(㊀ 神 论)	yi4shen2lun4
 (一 神 论)	yi4shen2lun4
-(㊀ 神 论)	yi4shen2lun4
 (一 穀 倉)	yi4gu3cang1
-(㊀ 穀 倉)	yi4gu3cang1
 (一 穀 倉)	yi4gu3cang1
-(㊀ 穀 倉)	yi4gu3cang1
 (一 窍 儿)	yi2qiao4r5
-(㊀ 窍 儿)	yi2qiao4r5
 (一 窝 子)	yi4wo1zi5
-(㊀ 窝 子)	yi4wo1zi5
 (一 窝 蜂)	yi4wo1feng1
-(㊀ 窝 蜂)	yi4wo1feng1
 (一 窩 子)	yi4wo1zi5
-(㊀ 窩 子)	yi4wo1zi5
 (一 窩 蜂)	yi4wo1feng1
-(㊀ 窩 蜂)	yi4wo1feng1
 (一 竅 兒)	yi2qiao4r5
-(㊀ 竅 兒)	yi2qiao4r5
 (一 管 笛)	yi4guan3di2
-(㊀ 管 笛)	yi4guan3di2
 (一 系 列)	yi2xi4lie4
-(㊀ 系 列)	yi2xi4lie4
 (一 系 列)	yi2xi4lie4
-(㊀ 系 列)	yi2xi4lie4
 (一 縷 子)	yi4lv3zi5
-(㊀ 縷 子)	yi4lv3zi5
 (一 縷 子)	yi4lv3zi5
-(㊀ 縷 子)	yi4lv3zi5
 (一 缕 子)	yi4lv3zi5
-(㊀ 缕 子)	yi4lv3zi5
 (一 罵 兒)	yi2ma4r5
-(㊀ 罵 兒)	yi2ma4r5
 (一 肘 子)	yi4zhou3zi5
-(㊀ 肘 子)	yi4zhou3zi5
 (一 肚 子)	yi2du4zi5
-(㊀ 肚 子)	yi2du4zi5
 (一 股 節)	yi4gu3jie5
-(㊀ 股 節)	yi4gu3jie5
 (一 股 節)	yi4gu3jie5
-(㊀ 股 節)	yi4gu3jie5
 (一 股 節)	yi4gu3jie5
-(㊀ 股 節)	yi4gu3jie5
 (一 股 节)	yi4gu3jie5
-(㊀ 股 节)	yi4gu3jie5
 (一 背 拉)	yi2bei4la5
-(㊀ 背 拉)	yi2bei4la5
 (一 背 拉)	yi2bei4la5
-(㊀ 背 拉)	yi2bei4la5
 (一 脑 子)	yi4nao3zi5
-(㊀ 脑 子)	yi4nao3zi5
 (一 脚 踢)	yi4jiao3ti1
-(㊀ 脚 踢)	yi4jiao3ti1
 (一 腦 子)	yi4nao3zi5
-(㊀ 腦 子)	yi4nao3zi5
 (一 腳 踢)	yi4jiao3ti1
-(㊀ 腳 踢)	yi4jiao3ti1
 (一 與 多)	yi4yu3duo1
-(㊀ 與 多)	yi4yu3duo1
 (一 色 儿)	yi4shai3r5
-(㊀ 色 儿)	yi4shai3r5
 (一 薄 层)	yi4bao2ceng2
-(㊀ 薄 层)	yi4bao2ceng2
 (一 薄 層)	yi4bao2ceng2
-(㊀ 薄 層)	yi4bao2ceng2
 (一 薄 層)	yi4bao2ceng2
-(㊀ 薄 層)	yi4bao2ceng2
 (一 行 儿)	yi4hang2r5
-(㊀ 行 儿)	yi4hang2r5
 (一 行 儿)	yi4hang2r5
-(㊀ 行 儿)	yi4hang2r5
 (一 行 兒)	yi4hang2r5
-(㊀ 行 兒)	yi4hang2r5
 (一 行 兒)	yi4hang2r5
-(㊀ 行 兒)	yi4hang2r5
 (一 谷 仓)	yi4gu3cang1
-(㊀ 谷 仓)	yi4gu3cang1
 (一 貼 藥)	yi4tie1yao4
-(㊀ 貼 藥)	yi4tie1yao4
 (一 贴 药)	yi4tie1yao4
-(㊀ 贴 药)	yi4tie1yao4
 (一 路 儿)	yi2lu4r5
-(㊀ 路 儿)	yi2lu4r5
 (一 路 儿)	yi2lu4r5
-(㊀ 路 儿)	yi2lu4r5
 (一 身 儿)	yi4shen1r5
-(㊀ 身 儿)	yi4shen1r5
 (一 輩 子)	yi2bei4zi5
-(㊀ 輩 子)	yi2bei4zi5
 (一 轉 眼)	yi4zhuan3yan3
-(㊀ 轉 眼)	yi4zhuan3yan3
 (一 转 眼)	yi4zhuan3yan3
-(㊀ 转 眼)	yi4zhuan3yan3
 (一 辈 子)	yi2bei4zi5
-(㊀ 辈 子)	yi2bei4zi5
 (一 边 倒)	yi4bian1dao3
-(㊀ 边 倒)	yi4bian1dao3
 (一 边 儿)	yi4bian1r5
-(㊀ 边 儿)	yi4bian1r5
 (一 遭 儿)	yi4zao1r5
-(㊀ 遭 儿)	yi4zao1r5
 (一 邊 倒)	yi4bian1dao3
-(㊀ 邊 倒)	yi4bian1dao3
 (一 部 分)	yi2bu4fen5
-(㊀ 部 分)	yi2bu4fen5
 (一 鋪 灘)	yi2pu4tan1
-(㊀ 鋪 灘)	yi2pu4tan1
 (一 鍋 煮)	yi4guo1zhu3
-(㊀ 鍋 煮)	yi4guo1zhu3
 (一 鍋 煮)	yi4guo1zhu3
-(㊀ 鍋 煮)	yi4guo1zhu3
 (一 鍋 煮)	yi4guo1zhu3
-(㊀ 鍋 煮)	yi4guo1zhu3
 (一 鍋 端)	yi4guo1duan1
-(㊀ 鍋 端)	yi4guo1duan1
 (一 鍋 粥)	yi4guo1zhou1
-(㊀ 鍋 粥)	yi4guo1zhou1
 (一 铺 滩)	yi2pu4tan1
-(㊀ 铺 滩)	yi2pu4tan1
 (一 锅 煮)	yi4guo1zhu3
-(㊀ 锅 煮)	yi4guo1zhu3
 (一 锅 煮)	yi4guo1zhu3
-(㊀ 锅 煮)	yi4guo1zhu3
 (一 锅 煮)	yi4guo1zhu3
-(㊀ 锅 煮)	yi4guo1zhu3
 (一 锅 端)	yi4guo1duan1
-(㊀ 锅 端)	yi4guo1duan1
 (一 锅 粥)	yi4guo1zhou1
-(㊀ 锅 粥)	yi4guo1zhou1
 (一 長 制)	yi4zhang3zhi4
-(㊀ 長 制)	yi4zhang3zhi4
 (一 长 制)	yi4zhang3zhi4
-(㊀ 长 制)	yi4zhang3zhi4
 (一 閃 念)	yi4shan3nian4
-(㊀ 閃 念)	yi4shan3nian4
 (一 閃 念)	yi4shan3nian4
-(㊀ 閃 念)	yi4shan3nian4
 (一 闪 念)	yi4shan3nian4
-(㊀ 闪 念)	yi4shan3nian4
 (一 闪 念)	yi4shan3nian4
-(㊀ 闪 念)	yi4shan3nian4
 (一 阵 儿)	yi2zhen4r5
-(㊀ 阵 儿)	yi2zhen4r5
 (一 阶 儿)	yi4jie1r5
-(㊀ 阶 儿)	yi4jie1r5
 (一 院 制)	yi2yuan4zhi4
-(㊀ 院 制)	yi2yuan4zhi4
 (一 零 儿)	yi4ling2r5
-(㊀ 零 儿)	yi4ling2r5
 (一 零 儿)	yi4ling2r5
-(㊀ 零 儿)	yi4ling2r5
 (一 零 兒)	yi4ling2r5
-(㊀ 零 兒)	yi4ling2r5
 (一 零 兒)	yi4ling2r5
-(㊀ 零 兒)	yi4ling2r5
 (一 面 倒)	yi2mian4dao3
-(㊀ 面 倒)	yi2mian4dao3
 (一 面 儿)	yi2mian4r5
-(㊀ 面 儿)	yi2mian4r5
 (一 顺 儿)	yi2shun4r5
-(㊀ 顺 儿)	yi2shun4r5
 (一 風 吹)	yi4feng1chui1
-(㊀ 風 吹)	yi4feng1chui1
 (一 风 吹)	yi4feng1chui1
-(㊀ 风 吹)	yi4feng1chui1
 (一 骂 儿)	yi2ma4r5
-(㊀ 骂 儿)	yi2ma4r5
 (一 骨 碌)	yi4gu1lu5
-(㊀ 骨 碌)	yi4gu1lu5
 (一 骨 碌)	yi4gu1lu5
-(㊀ 骨 碌)	yi4gu1lu5
 (一 骨 節)	yi4gu3jie2
-(㊀ 骨 節)	yi4gu3jie2
 (一 骨 節)	yi4gu3jie2
-(㊀ 骨 節)	yi4gu3jie2
 (一 骨 節)	yi4gu3jie2
-(㊀ 骨 節)	yi4gu3jie2
 (一 骨 节)	yi4gu3jie2
-(㊀ 骨 节)	yi4gu3jie2
 (一 骨 輪)	yi4gu3lun2
-(㊀ 骨 輪)	yi4gu3lun2
 (一 骨 輪)	yi4gu3lun2
-(㊀ 骨 輪)	yi4gu3lun2
 (一 骨 轮)	yi4gu3lun2
-(㊀ 骨 轮)	yi4gu3lun2
 (七 十 子)	qi1shi2zi3
-(七 ㊉ 子)	qi1shi2zi3
-(㊆ 十 子)	qi1shi2zi3
 (万 事 得)	wan4shi4de2
 (三 一 神)	san1yi4shen2
-(㊂ 一 神)	san1yi4shen2
-(三 ㊀ 神)	san1yi4shen2
 (三 一 神)	san1yi4shen2
-(㊂ 一 神)	san1yi4shen2
-(三 ㊀ 神)	san1yi4shen2
 (三 裡 屯)	san1li3tun2
-(㊂ 裡 屯)	san1li3tun2
 (三 裡 屯)	san1li3tun2
-(㊂ 裡 屯)	san1li3tun2
 (三 裡 河)	san1li3he2
-(㊂ 裡 河)	san1li3he2
 (三 裡 河)	san1li3he2
-(㊂ 裡 河)	san1li3he2
 (三 部 曲)	san1bu4qu3
-(㊂ 部 曲)	san1bu4qu3
 (上 一 頁)	shang4yi2ye4
-(㊤ 一 頁)	shang4yi2ye4
-(上 ㊀ 頁)	shang4yi2ye4
 (上 一 页)	shang4yi2ye4
-(㊤ 一 页)	shang4yi2ye4
-(上 ㊀ 页)	shang4yi2ye4
 (上 不 上)	shang4bu5shang4
-(㊤ 不 ㊤)	shang4bu5shang4
 (上 不 上)	shang4bu5shang4
-(㊤ 不 ㊤)	shang4bu5shang4
 (上 不 了)	shang4bu5liao3
-(㊤ 不 了)	shang4bu5liao3
 (上 不 了)	shang4bu5liao3
-(㊤ 不 了)	shang4bu5liao3
 (上 不 了)	shang4bu5liao3
-(㊤ 不 了)	shang4bu5liao3
 (上 不 來)	shang4bu5lai2
-(㊤ 不 來)	shang4bu5lai2
 (上 不 來)	shang4bu5lai2
-(㊤ 不 來)	shang4bu5lai2
 (上 不 來)	shang4bu5lai2
-(㊤ 不 來)	shang4bu5lai2
 (上 不 去)	shang4bu5qu4
-(㊤ 不 去)	shang4bu5qu4
 (上 不 去)	shang4bu5qu4
-(㊤ 不 去)	shang4bu5qu4
 (上 不 成)	shang4bu5cheng2
-(㊤ 不 成)	shang4bu5cheng2
 (上 不 成)	shang4bu5cheng2
-(㊤ 不 成)	shang4bu5cheng2
 (上 不 来)	shang4bu5lai2
-(㊤ 不 来)	shang4bu5lai2
 (上 不 来)	shang4bu5lai2
-(㊤ 不 来)	shang4bu5lai2
 (上 不 起)	shang4bu5qi3
-(㊤ 不 起)	shang4bu5qi3
 (上 不 起)	shang4bu5qi3
-(㊤ 不 起)	shang4bu5qi3
 (上 个 月)	shang4ge5yue4
-(㊤ 个 月)	shang4ge5yue4
-(上 个 ㊊)	shang4ge5yue4
 (上 個 月)	shang4ge5yue4
-(㊤ 個 月)	shang4ge5yue4
-(上 個 ㊊)	shang4ge5yue4
 (上 边 儿)	shang4bian5r5
-(㊤ 边 儿)	shang4bian5r5
 (下 一 頁)	xia4yi2ye4
-(㊦ 一 頁)	xia4yi2ye4
-(下 ㊀ 頁)	xia4yi2ye4
 (下 一 页)	xia4yi2ye4
-(㊦ 一 页)	xia4yi2ye4
-(下 ㊀ 页)	xia4yi2ye4
 (下 不 了)	xia4bu5liao3
-(㊦ 不 了)	xia4bu5liao3
 (下 不 了)	xia4bu5liao3
-(㊦ 不 了)	xia4bu5liao3
 (下 不 了)	xia4bu5liao3
-(㊦ 不 了)	xia4bu5liao3
 (下 不 來)	xia4bu5lai2
-(㊦ 不 來)	xia4bu5lai2
 (下 不 來)	xia4bu5lai2
-(㊦ 不 來)	xia4bu5lai2
 (下 不 來)	xia4bu5lai2
-(㊦ 不 來)	xia4bu5lai2
 (下 不 去)	xia4bu5qu4
-(㊦ 不 去)	xia4bu5qu4
 (下 不 去)	xia4bu5qu4
-(㊦ 不 去)	xia4bu5qu4
 (下 不 来)	xia4bu5lai2
-(㊦ 不 来)	xia4bu5lai2
 (下 不 来)	xia4bu5lai2
-(㊦ 不 来)	xia4bu5lai2
 (下 边 儿)	xia4bian5r5
-(㊦ 边 儿)	xia4bian5r5
 (不 万 个)	bu2wan4ge5
 (不 万 个)	bu2wan4ge5
 (不 万 個)	bu2wan4ge5
 (不 万 個)	bu2wan4ge5
 (不 上 來)	bu2shang4lai5
-(不 ㊤ 來)	bu2shang4lai5
 (不 上 來)	bu2shang4lai5
-(不 ㊤ 來)	bu2shang4lai5
 (不 上 來)	bu2shang4lai5
-(不 ㊤ 來)	bu2shang4lai5
 (不 上 去)	bu2shang4qu5
-(不 ㊤ 去)	bu2shang4qu5
 (不 上 去)	bu2shang4qu5
-(不 ㊤ 去)	bu2shang4qu5
 (不 上 司)	bu2shang4si5
-(不 ㊤ 司)	bu2shang4si5
 (不 上 司)	bu2shang4si5
-(不 ㊤ 司)	bu2shang4si5
 (不 上 头)	bu2shang4tou5
-(不 ㊤ 头)	bu2shang4tou5
 (不 上 头)	bu2shang4tou5
-(不 ㊤ 头)	bu2shang4tou5
 (不 上 将)	bu2shang4jiang4
-(不 ㊤ 将)	bu2shang4jiang4
 (不 上 将)	bu2shang4jiang4
-(不 ㊤ 将)	bu2shang4jiang4
 (不 上 將)	bu2shang4jiang4
-(不 ㊤ 將)	bu2shang4jiang4
 (不 上 將)	bu2shang4jiang4
-(不 ㊤ 將)	bu2shang4jiang4
 (不 上 当)	bu2shang4dang4
-(不 ㊤ 当)	bu2shang4dang4
 (不 上 当)	bu2shang4dang4
-(不 ㊤ 当)	bu2shang4dang4
 (不 上 杆)	bu2shang4gan3
-(不 ㊤ 杆)	bu2shang4gan3
 (不 上 杆)	bu2shang4gan3
-(不 ㊤ 杆)	bu2shang4gan3
 (不 上 来)	bu2shang4lai5
-(不 ㊤ 来)	bu2shang4lai5
 (不 上 来)	bu2shang4lai5
-(不 ㊤ 来)	bu2shang4lai5
 (不 上 當)	bu2shang4dang4
-(不 ㊤ 當)	bu2shang4dang4
 (不 上 當)	bu2shang4dang4
-(不 ㊤ 當)	bu2shang4dang4
 (不 上 訴)	bu2shang4su4
-(不 ㊤ 訴)	bu2shang4su4
 (不 上 訴)	bu2shang4su4
-(不 ㊤ 訴)	bu2shang4su4
 (不 上 調)	bu2shang4tiao2
-(不 ㊤ 調)	bu2shang4tiao2
 (不 上 調)	bu2shang4tiao2
-(不 ㊤ 調)	bu2shang4tiao2
 (不 上 調)	bu2shang4tiao2
-(不 ㊤ 調)	bu2shang4tiao2
 (不 上 诉)	bu2shang4su4
-(不 ㊤ 诉)	bu2shang4su4
 (不 上 诉)	bu2shang4su4
-(不 ㊤ 诉)	bu2shang4su4
 (不 上 调)	bu2shang4tiao2
-(不 ㊤ 调)	bu2shang4tiao2
 (不 上 调)	bu2shang4tiao2
-(不 ㊤ 调)	bu2shang4tiao2
 (不 上 边)	bu2shang4bian5
-(不 ㊤ 边)	bu2shang4bian5
 (不 上 边)	bu2shang4bian5
-(不 ㊤ 边)	bu2shang4bian5
 (不 上 邊)	bu2shang4bian5
-(不 ㊤ 邊)	bu2shang4bian5
 (不 上 邊)	bu2shang4bian5
-(不 ㊤ 邊)	bu2shang4bian5
 (不 上 面)	bu2shang4mian5
-(不 ㊤ 面)	bu2shang4mian5
 (不 上 面)	bu2shang4mian5
-(不 ㊤ 面)	bu2shang4mian5
 (不 上 頭)	bu2shang4tou5
-(不 ㊤ 頭)	bu2shang4tou5
 (不 上 頭)	bu2shang4tou5
-(不 ㊤ 頭)	bu2shang4tou5
 (不 下 來)	bu2xia4lai5
-(不 ㊦ 來)	bu2xia4lai5
 (不 下 來)	bu2xia4lai5
-(不 ㊦ 來)	bu2xia4lai5
 (不 下 來)	bu2xia4lai5
-(不 ㊦ 來)	bu2xia4lai5
 (不 下 去)	bu2xia4qu5
-(不 ㊦ 去)	bu2xia4qu5
 (不 下 去)	bu2xia4qu5
-(不 ㊦ 去)	bu2xia4qu5
 (不 下 於)	bu2xia4yu2
-(不 ㊦ 於)	bu2xia4yu2
 (不 下 於)	bu2xia4yu2
-(不 ㊦ 於)	bu2xia4yu2
 (不 下 来)	bu2xia4lai5
-(不 ㊦ 来)	bu2xia4lai5
 (不 下 来)	bu2xia4lai5
-(不 ㊦ 来)	bu2xia4lai5
 (不 下 边)	bu2xia4bian5
-(不 ㊦ 边)	bu2xia4bian5
 (不 下 边)	bu2xia4bian5
-(不 ㊦ 边)	bu2xia4bian5
 (不 下 邊)	bu2xia4bian5
-(不 ㊦ 邊)	bu2xia4bian5
 (不 下 邊)	bu2xia4bian5
-(不 ㊦ 邊)	bu2xia4bian5
 (不 下 面)	bu2xia4mian5
-(不 ㊦ 面)	bu2xia4mian5
 (不 下 面)	bu2xia4mian5
-(不 ㊦ 面)	bu2xia4mian5
 (不 与 会)	bu2yu4hui4
 (不 与 会)	bu2yu4hui4
 (不 业 务)	bu2ye4wu4
@@ -62075,173 +59478,61 @@ $textmode
 (不 个 儿)	bu2ge4r5
 (不 个 儿)	bu2ge4r5
 (不 中 举)	bu2zhong4ju3
-(不 🀄 举)	bu2zhong4ju3
-(不 ㊥ 举)	bu2zhong4ju3
 (不 中 举)	bu2zhong4ju3
-(不 🀄 举)	bu2zhong4ju3
-(不 ㊥ 举)	bu2zhong4ju3
 (不 中 伤)	bu2zhong4shang1
-(不 🀄 伤)	bu2zhong4shang1
-(不 ㊥ 伤)	bu2zhong4shang1
 (不 中 伤)	bu2zhong4shang1
-(不 🀄 伤)	bu2zhong4shang1
-(不 ㊥ 伤)	bu2zhong4shang1
 (不 中 傷)	bu2zhong4shang1
-(不 🀄 傷)	bu2zhong4shang1
-(不 ㊥ 傷)	bu2zhong4shang1
 (不 中 傷)	bu2zhong4shang1
-(不 🀄 傷)	bu2zhong4shang1
-(不 ㊥ 傷)	bu2zhong4shang1
 (不 中 奖)	bu2zhong4jiang3
-(不 🀄 奖)	bu2zhong4jiang3
-(不 ㊥ 奖)	bu2zhong4jiang3
 (不 中 奖)	bu2zhong4jiang3
-(不 🀄 奖)	bu2zhong4jiang3
-(不 ㊥ 奖)	bu2zhong4jiang3
 (不 中 弹)	bu2zhong4dan4
-(不 🀄 弹)	bu2zhong4dan4
-(不 ㊥ 弹)	bu2zhong4dan4
 (不 中 弹)	bu2zhong4dan4
-(不 🀄 弹)	bu2zhong4dan4
-(不 ㊥ 弹)	bu2zhong4dan4
 (不 中 彈)	bu2zhong4dan4
-(不 🀄 彈)	bu2zhong4dan4
-(不 ㊥ 彈)	bu2zhong4dan4
 (不 中 彈)	bu2zhong4dan4
-(不 🀄 彈)	bu2zhong4dan4
-(不 ㊥ 彈)	bu2zhong4dan4
 (不 中 彩)	bu2zhong4cai3
-(不 🀄 彩)	bu2zhong4cai3
-(不 ㊥ 彩)	bu2zhong4cai3
 (不 中 彩)	bu2zhong4cai3
-(不 🀄 彩)	bu2zhong4cai3
-(不 ㊥ 彩)	bu2zhong4cai3
 (不 中 彩)	bu2zhong4cai3
-(不 🀄 彩)	bu2zhong4cai3
-(不 ㊥ 彩)	bu2zhong4cai3
 (不 中 意)	bu2zhong4yi4
-(不 🀄 意)	bu2zhong4yi4
-(不 ㊥ 意)	bu2zhong4yi4
 (不 中 意)	bu2zhong4yi4
-(不 🀄 意)	bu2zhong4yi4
-(不 ㊥ 意)	bu2zhong4yi4
 (不 中 暑)	bu2zhong4shu3
-(不 🀄 暑)	bu2zhong4shu3
-(不 ㊥ 暑)	bu2zhong4shu3
 (不 中 暑)	bu2zhong4shu3
-(不 🀄 暑)	bu2zhong4shu3
-(不 ㊥ 暑)	bu2zhong4shu3
 (不 中 暑)	bu2zhong4shu3
-(不 🀄 暑)	bu2zhong4shu3
-(不 ㊥ 暑)	bu2zhong4shu3
 (不 中 枪)	bu2zhong4qiang1
-(不 🀄 枪)	bu2zhong4qiang1
-(不 ㊥ 枪)	bu2zhong4qiang1
 (不 中 枪)	bu2zhong4qiang1
-(不 🀄 枪)	bu2zhong4qiang1
-(不 ㊥ 枪)	bu2zhong4qiang1
 (不 中 标)	bu2zhong4biao1
-(不 🀄 标)	bu2zhong4biao1
-(不 ㊥ 标)	bu2zhong4biao1
 (不 中 标)	bu2zhong4biao1
-(不 🀄 标)	bu2zhong4biao1
-(不 ㊥ 标)	bu2zhong4biao1
 (不 中 槍)	bu2zhong4qiang1
-(不 🀄 槍)	bu2zhong4qiang1
-(不 ㊥ 槍)	bu2zhong4qiang1
 (不 中 槍)	bu2zhong4qiang1
-(不 🀄 槍)	bu2zhong4qiang1
-(不 ㊥ 槍)	bu2zhong4qiang1
 (不 中 標)	bu2zhong4biao1
-(不 🀄 標)	bu2zhong4biao1
-(不 ㊥ 標)	bu2zhong4biao1
 (不 中 標)	bu2zhong4biao1
-(不 🀄 標)	bu2zhong4biao1
-(不 ㊥ 標)	bu2zhong4biao1
 (不 中 毒)	bu2zhong4du2
-(不 🀄 毒)	bu2zhong4du2
-(不 ㊥ 毒)	bu2zhong4du2
 (不 中 毒)	bu2zhong4du2
-(不 🀄 毒)	bu2zhong4du2
-(不 ㊥ 毒)	bu2zhong4du2
 (不 中 獎)	bu2zhong4jiang3
-(不 🀄 獎)	bu2zhong4jiang3
-(不 ㊥ 獎)	bu2zhong4jiang3
 (不 中 獎)	bu2zhong4jiang3
-(不 🀄 獎)	bu2zhong4jiang3
-(不 ㊥ 獎)	bu2zhong4jiang3
 (不 中 签)	bu2zhong4qian1
-(不 🀄 签)	bu2zhong4qian1
-(不 ㊥ 签)	bu2zhong4qian1
 (不 中 签)	bu2zhong4qian1
-(不 🀄 签)	bu2zhong4qian1
-(不 ㊥ 签)	bu2zhong4qian1
 (不 中 簽)	bu2zhong4qian1
-(不 🀄 簽)	bu2zhong4qian1
-(不 ㊥ 簽)	bu2zhong4qian1
 (不 中 簽)	bu2zhong4qian1
-(不 🀄 簽)	bu2zhong4qian1
-(不 ㊥ 簽)	bu2zhong4qian1
 (不 中 肯)	bu2zhong4ken3
-(不 🀄 肯)	bu2zhong4ken3
-(不 ㊥ 肯)	bu2zhong4ken3
 (不 中 肯)	bu2zhong4ken3
-(不 🀄 肯)	bu2zhong4ken3
-(不 ㊥ 肯)	bu2zhong4ken3
 (不 中 舉)	bu2zhong4ju3
-(不 🀄 舉)	bu2zhong4ju3
-(不 ㊥ 舉)	bu2zhong4ju3
 (不 中 舉)	bu2zhong4ju3
-(不 🀄 舉)	bu2zhong4ju3
-(不 ㊥ 舉)	bu2zhong4ju3
 (不 中 計)	bu2zhong4ji4
-(不 🀄 計)	bu2zhong4ji4
-(不 ㊥ 計)	bu2zhong4ji4
 (不 中 計)	bu2zhong4ji4
-(不 🀄 計)	bu2zhong4ji4
-(不 ㊥ 計)	bu2zhong4ji4
 (不 中 计)	bu2zhong4ji4
-(不 🀄 计)	bu2zhong4ji4
-(不 ㊥ 计)	bu2zhong4ji4
 (不 中 计)	bu2zhong4ji4
-(不 🀄 计)	bu2zhong4ji4
-(不 ㊥ 计)	bu2zhong4ji4
 (不 中 选)	bu2zhong4xuan3
-(不 🀄 选)	bu2zhong4xuan3
-(不 ㊥ 选)	bu2zhong4xuan3
 (不 中 选)	bu2zhong4xuan3
-(不 🀄 选)	bu2zhong4xuan3
-(不 ㊥ 选)	bu2zhong4xuan3
 (不 中 選)	bu2zhong4xuan3
-(不 🀄 選)	bu2zhong4xuan3
-(不 ㊥ 選)	bu2zhong4xuan3
 (不 中 選)	bu2zhong4xuan3
-(不 🀄 選)	bu2zhong4xuan3
-(不 ㊥ 選)	bu2zhong4xuan3
 (不 中 邪)	bu2zhong4xie2
-(不 🀄 邪)	bu2zhong4xie2
-(不 ㊥ 邪)	bu2zhong4xie2
 (不 中 邪)	bu2zhong4xie2
-(不 🀄 邪)	bu2zhong4xie2
-(不 ㊥ 邪)	bu2zhong4xie2
 (不 中 風)	bu2zhong4feng1
-(不 🀄 風)	bu2zhong4feng1
-(不 ㊥ 風)	bu2zhong4feng1
 (不 中 風)	bu2zhong4feng1
-(不 🀄 風)	bu2zhong4feng1
-(不 ㊥ 風)	bu2zhong4feng1
 (不 中 风)	bu2zhong4feng1
-(不 🀄 风)	bu2zhong4feng1
-(不 ㊥ 风)	bu2zhong4feng1
 (不 中 风)	bu2zhong4feng1
-(不 🀄 风)	bu2zhong4feng1
-(不 ㊥ 风)	bu2zhong4feng1
 (不 中 魔)	bu2zhong4mo2
-(不 🀄 魔)	bu2zhong4mo2
-(不 ㊥ 魔)	bu2zhong4mo2
 (不 中 魔)	bu2zhong4mo2
-(不 🀄 魔)	bu2zhong4mo2
-(不 ㊥ 魔)	bu2zhong4mo2
 (不 串 供)	bu2chuan4gong4
 (不 串 供)	bu2chuan4gong4
 (不 串 供)	bu2chuan4gong4
@@ -62295,17 +59586,11 @@ $textmode
 (不 事 迹)	bu2shi4ji4
 (不 事 迹)	bu2shi4ji4
 (不 二 个)	bu2er4ge5
-(不 ㊁ 个)	bu2er4ge5
 (不 二 个)	bu2er4ge5
-(不 ㊁ 个)	bu2er4ge5
 (不 二 個)	bu2er4ge5
-(不 ㊁ 個)	bu2er4ge5
 (不 二 個)	bu2er4ge5
-(不 ㊁ 個)	bu2er4ge5
 (不 二 重)	bu2er4chong2
-(不 ㊁ 重)	bu2er4chong2
 (不 二 重)	bu2er4chong2
-(不 ㊁ 重)	bu2er4chong2
 (不 亞 於)	bu2ya4yu2
 (不 亞 於)	bu2ya4yu2
 (不 亮 相)	bu2liang4xiang4
@@ -62378,10 +59663,8 @@ $textmode
 (不 作 為)	bu2zuo4wei2
 (不 作 為)	bu2zuo4wei2
 (不 佣 金)	bu2yong4jin1
-(不 佣 ㊎)	bu2yong4jin1
 (不 佣 金)	bu2yong4jin1
 (不 佣 金)	bu2yong4jin1
-(不 佣 ㊎)	bu2yong4jin1
 (不 佩 服)	bu2pei4fu5
 (不 佩 服)	bu2pei4fu5
 (不 例 假)	bu2li4jia4
@@ -62444,9 +59727,7 @@ $textmode
 (不 债 务)	bu2zhai4wu4
 (不 债 务)	bu2zhai4wu4
 (不 假 日)	bu2jia4ri4
-(不 假 ㊐)	bu2jia4ri4
 (不 假 日)	bu2jia4ri4
-(不 假 ㊐)	bu2jia4ri4
 (不 假 期)	bu2jia4qi1
 (不 假 期)	bu2jia4qi1
 (不 假 条)	bu2jia4tiao2
@@ -62475,9 +59756,7 @@ $textmode
 (不 價 錢)	bu2jia4qian5
 (不 價 錢)	bu2jia4qian5
 (不 克 西)	bu2ke4xi1
-(不 克 🀂)	bu2ke4xi1
 (不 克 西)	bu2ke4xi1
-(不 克 🀂)	bu2ke4xi1
 (不 入 伍)	bu2ru4wu3
 (不 入 伍)	bu2ru4wu3
 (不 內 務)	bu2nei4wu4
@@ -62490,15 +59769,11 @@ $textmode
 (不 內 訌)	bu2nei4hong4
 (不 內 訌)	bu2nei4hong4
 (不 六 个)	bu2liu4ge5
-(不 ㊅ 个)	bu2liu4ge5
 (不 六 个)	bu2liu4ge5
 (不 六 个)	bu2liu4ge5
-(不 ㊅ 个)	bu2liu4ge5
 (不 六 個)	bu2liu4ge5
-(不 ㊅ 個)	bu2liu4ge5
 (不 六 個)	bu2liu4ge5
 (不 六 個)	bu2liu4ge5
-(不 ㊅ 個)	bu2liu4ge5
 (不 共 处)	bu2gong4chu3
 (不 共 处)	bu2gong4chu3
 (不 共 處)	bu2gong4chu3
@@ -62541,14 +59816,8 @@ $textmode
 (不 分 量)	bu2fen4liang4
 (不 分 量)	bu2fen4liang4
 (不 切 中)	bu2qie4zhong4
-(不 切 🀄)	bu2qie4zhong4
-(不 切 ㊥)	bu2qie4zhong4
 (不 切 中)	bu2qie4zhong4
-(不 切 🀄)	bu2qie4zhong4
-(不 切 ㊥)	bu2qie4zhong4
 (不 切 中)	bu2qie4zhong4
-(不 切 🀄)	bu2qie4zhong4
-(不 切 ㊥)	bu2qie4zhong4
 (不 划 算)	bu4hua2suan4
 (不 划 算)	bu4hua2suan4
 (不 列 为)	bu2lie4wei2
@@ -62626,13 +59895,9 @@ $textmode
 (不 剑 身)	bu2jian4shen1
 (不 剑 身)	bu2jian4shen1
 (不 剩 下)	bu2sheng4xia5
-(不 剩 ㊦)	bu2sheng4xia5
 (不 剩 下)	bu2sheng4xia5
-(不 剩 ㊦)	bu2sheng4xia5
 (不 劃 一)	bu2hua4yi1
-(不 劃 ㊀)	bu2hua4yi1
 (不 劃 一)	bu2hua4yi1
-(不 劃 ㊀)	bu2hua4yi1
 (不 劃 價)	bu2hua4jia4
 (不 劃 價)	bu2hua4jia4
 (不 劃 分)	bu2hua4fen1
@@ -62782,9 +60047,7 @@ $textmode
 (不 卧 倒)	bu2wo4dao3
 (不 卧 倒)	bu2wo4dao3
 (不 卷 宗)	bu2juan4zong1
-(不 卷 ㊪)	bu2juan4zong1
 (不 卷 宗)	bu2juan4zong1
-(不 卷 ㊪)	bu2juan4zong1
 (不 卷 軸)	bu2juan4zhou2
 (不 卷 軸)	bu2juan4zhou2
 (不 卷 轴)	bu2juan4zhou2
@@ -62869,13 +60132,9 @@ $textmode
 (不 叱 喝)	bu2chi4he4
 (不 叱 喝)	bu2chi4he4
 (不 右 边)	bu2you4bian5
-(不 ㊨ 边)	bu2you4bian5
 (不 右 边)	bu2you4bian5
-(不 ㊨ 边)	bu2you4bian5
 (不 右 邊)	bu2you4bian5
-(不 ㊨ 邊)	bu2you4bian5
 (不 右 邊)	bu2you4bian5
-(不 ㊨ 邊)	bu2you4bian5
 (不 叹 息)	bu2tan4xi1
 (不 叹 息)	bu2tan4xi1
 (不 各 地)	bu2ge4di4
@@ -62895,9 +60154,7 @@ $textmode
 (不 吐 根)	bu2tu4gen1
 (不 吐 根)	bu2tu4gen1
 (不 向 西)	bu2xiang4xi1
-(不 向 🀂)	bu2xiang4xi1
 (不 向 西)	bu2xiang4xi1
-(不 向 🀂)	bu2xiang4xi1
 (不 吓 倒)	bu2xia4dao3
 (不 吓 倒)	bu2xia4dao3
 (不 吓 声)	bu2he4sheng1
@@ -62984,13 +60241,9 @@ $textmode
 (不 囁 呫)	bu2nie4tie4
 (不 囁 呫)	bu2nie4tie4
 (不 四 个)	bu2si4ge5
-(不 ㊃ 个)	bu2si4ge5
 (不 四 个)	bu2si4ge5
-(不 ㊃ 个)	bu2si4ge5
 (不 四 個)	bu2si4ge5
-(不 ㊃ 個)	bu2si4ge5
 (不 四 個)	bu2si4ge5
-(不 ㊃ 個)	bu2si4ge5
 (不 困 难)	bu2kun4nan5
 (不 困 难)	bu2kun4nan5
 (不 困 難)	bu2kun4nan5
@@ -63004,13 +60257,9 @@ $textmode
 (不 在 於)	bu2zai4yu2
 (不 在 於)	bu2zai4yu2
 (不 地 上)	bu2di4shang5
-(不 地 ㊤)	bu2di4shang5
 (不 地 上)	bu2di4shang5
-(不 地 ㊤)	bu2di4shang5
 (不 地 下)	bu2di4xia4
-(不 地 ㊦)	bu2di4xia4
 (不 地 下)	bu2di4xia4
-(不 地 ㊦)	bu2di4xia4
 (不 地 主)	bu2di4zhu3
 (不 地 主)	bu2di4zhu3
 (不 地 产)	bu2di4chan3
@@ -63037,9 +60286,7 @@ $textmode
 (不 地 史)	bu2di4shi3
 (不 地 史)	bu2di4shi3
 (不 地 名)	bu2di4ming2
-(不 地 ㊔)	bu2di4ming2
 (不 地 名)	bu2di4ming2
-(不 地 ㊔)	bu2di4ming2
 (不 地 图)	bu2di4tu2
 (不 地 图)	bu2di4tu2
 (不 地 圖)	bu2di4tu2
@@ -63207,9 +60454,7 @@ $textmode
 (不 坏 处)	bu2huai4chu5
 (不 坏 处)	bu2huai4chu5
 (不 坐 下)	bu2zuo4xia5
-(不 坐 ㊦)	bu2zuo4xia5
 (不 坐 下)	bu2zuo4xia5
-(不 坐 ㊦)	bu2zuo4xia5
 (不 坐 禪)	bu2zuo4chan2
 (不 坐 禪)	bu2zuo4chan2
 (不 块 菌)	bu2kuai4jun4
@@ -63311,19 +60556,12 @@ $textmode
 (不 外 頭)	bu2wai4tou5
 (不 外 頭)	bu2wai4tou5
 (不 夜 叉)	bu2ye4cha5
-(不 ㊰ 叉)	bu2ye4cha5
 (不 夜 叉)	bu2ye4cha5
-(不 ㊰ 叉)	bu2ye4cha5
 (不 夜 曲)	bu2ye4qu3
-(不 ㊰ 曲)	bu2ye4qu3
 (不 夜 曲)	bu2ye4qu3
-(不 ㊰ 曲)	bu2ye4qu3
 (不 夜 里)	bu2ye4li5
-(不 ㊰ 里)	bu2ye4li5
 (不 夜 里)	bu2ye4li5
-(不 ㊰ 里)	bu2ye4li5
 (不 夜 里)	bu2ye4li5
-(不 ㊰ 里)	bu2ye4li5
 (不 夢 見)	bu2meng4jian5
 (不 夢 見)	bu2meng4jian5
 (不 夢 見)	bu2meng4jian5
@@ -63396,9 +60634,7 @@ $textmode
 (不 好 奇)	bu2hao4qi2
 (不 好 奇)	bu2hao4qi2
 (不 好 学)	bu2hao4xue2
-(不 好 ㊫)	bu2hao4xue2
 (不 好 学)	bu2hao4xue2
-(不 好 ㊫)	bu2hao4xue2
 (不 好 學)	bu2hao4xue2
 (不 好 學)	bu2hao4xue2
 (不 好 客)	bu2hao4ke4
@@ -63561,11 +60797,7 @@ $textmode
 (不 寿 面)	bu2shou4mian4
 (不 寿 面)	bu2shou4mian4
 (不 射 中)	bu2she4zhong4
-(不 射 🀄)	bu2she4zhong4
-(不 射 ㊥)	bu2she4zhong4
 (不 射 中)	bu2she4zhong4
-(不 射 🀄)	bu2she4zhong4
-(不 射 ㊥)	bu2she4zhong4
 (不 将 士)	bu2jiang4shi4
 (不 将 士)	bu2jiang4shi4
 (不 将 帅)	bu2jiang4shuai4
@@ -63600,10 +60832,8 @@ $textmode
 (不 少 兒)	bu2shao4er2
 (不 少 兒)	bu2shao4er2
 (不 少 女)	bu2shao4nv3
-(不 少 ㊛)	bu2shao4nv3
 (不 少 女)	bu2shao4nv3
 (不 少 女)	bu2shao4nv3
-(不 少 ㊛)	bu2shao4nv3
 (不 少 将)	bu2shao4jiang4
 (不 少 将)	bu2shao4jiang4
 (不 少 將)	bu2shao4jiang4
@@ -63627,9 +60857,7 @@ $textmode
 (不 岁 数)	bu2sui4shu5
 (不 岁 数)	bu2sui4shu5
 (不 岸 上)	bu2an4shang5
-(不 岸 ㊤)	bu2an4shang5
 (不 岸 上)	bu2an4shang5
-(不 岸 ㊤)	bu2an4shang5
 (不 巨 匠)	bu2ju4jiang4
 (不 巨 匠)	bu2ju4jiang4
 (不 巨 著)	bu2ju4zhu4
@@ -63912,15 +61140,10 @@ $textmode
 (不 戰 地)	bu2zhan4di4
 (不 戰 地)	bu2zhan4di4
 (不 戴 上)	bu2dai4shang5
-(不 戴 ㊤)	bu2dai4shang5
 (不 戴 上)	bu2dai4shang5
-(不 戴 ㊤)	bu2dai4shang5
 (不 戴 上)	bu2dai4shang5
-(不 戴 ㊤)	bu2dai4shang5
 (不 扣 上)	bu2kou4shang5
-(不 扣 ㊤)	bu2kou4shang5
 (不 扣 上)	bu2kou4shang5
-(不 扣 ㊤)	bu2kou4shang5
 (不 扫 帚)	bu2sao4zhou5
 (不 扫 帚)	bu2sao4zhou5
 (不 扫 把)	bu2sao4ba3
@@ -63979,9 +61202,7 @@ $textmode
 (不 拜 倒)	bu2bai4dao3
 (不 拜 倒)	bu2bai4dao3
 (不 按 下)	bu2an4xia5
-(不 按 ㊦)	bu2an4xia5
 (不 按 下)	bu2an4xia5
-(不 按 ㊦)	bu2an4xia5
 (不 挚 友)	bu2zhi4you3
 (不 挚 友)	bu2zhi4you3
 (不 挣 脱)	bu2zheng4tuo1
@@ -64015,9 +61236,7 @@ $textmode
 (不 擔 子)	bu2dan4zi5
 (不 擔 子)	bu2dan4zi5
 (不 放 下)	bu2fang4xia5
-(不 放 ㊦)	bu2fang4xia5
 (不 放 下)	bu2fang4xia5
-(不 放 ㊦)	bu2fang4xia5
 (不 放 假)	bu2fang4jia4
 (不 放 假)	bu2fang4jia4
 (不 政 务)	bu2zheng4wu4
@@ -64075,9 +61294,7 @@ $textmode
 (不 旋 床)	bu2xuan4chuang2
 (不 旋 床)	bu2xuan4chuang2
 (不 旋 木)	bu2xuan4mu4
-(不 旋 ㊍)	bu2xuan4mu4
 (不 旋 木)	bu2xuan4mu4
-(不 旋 ㊍)	bu2xuan4mu4
 (不 旋 風)	bu2xuan4feng1
 (不 旋 風)	bu2xuan4feng1
 (不 旋 风)	bu2xuan4feng1
@@ -64199,47 +61416,27 @@ $textmode
 (不 會 長)	bu2hui4zhang3
 (不 會 長)	bu2hui4zhang3
 (不 月 亮)	bu2yue4liang5
-(不 ㊊ 亮)	bu2yue4liang5
 (不 月 亮)	bu2yue4liang5
-(不 ㊊ 亮)	bu2yue4liang5
 (不 月 亮)	bu2yue4liang5
-(不 ㊊ 亮)	bu2yue4liang5
 (不 月 晕)	bu2yue4yun4
-(不 ㊊ 晕)	bu2yue4yun4
 (不 月 晕)	bu2yue4yun4
-(不 ㊊ 晕)	bu2yue4yun4
 (不 月 暈)	bu2yue4yun4
-(不 ㊊ 暈)	bu2yue4yun4
 (不 月 暈)	bu2yue4yun4
-(不 ㊊ 暈)	bu2yue4yun4
 (不 月 暈)	bu2yue4yun4
-(不 ㊊ 暈)	bu2yue4yun4
 (不 月 相)	bu2yue4xiang4
-(不 ㊊ 相)	bu2yue4xiang4
 (不 月 相)	bu2yue4xiang4
-(不 ㊊ 相)	bu2yue4xiang4
 (不 服 服)	bu2fu4fu5
 (不 服 服)	bu2fu4fu5
 (不 木 头)	bu2mu4tou5
-(不 ㊍ 头)	bu2mu4tou5
 (不 木 头)	bu2mu4tou5
-(不 ㊍ 头)	bu2mu4tou5
 (不 木 杆)	bu2mu4gan3
-(不 ㊍ 杆)	bu2mu4gan3
 (不 木 杆)	bu2mu4gan3
-(不 ㊍ 杆)	bu2mu4gan3
 (不 木 框)	bu2mu4kuang4
-(不 ㊍ 框)	bu2mu4kuang4
 (不 木 框)	bu2mu4kuang4
-(不 ㊍ 框)	bu2mu4kuang4
 (不 木 犀)	bu2mu4xi5
-(不 ㊍ 犀)	bu2mu4xi5
 (不 木 犀)	bu2mu4xi5
-(不 ㊍ 犀)	bu2mu4xi5
 (不 木 頭)	bu2mu4tou5
-(不 ㊍ 頭)	bu2mu4tou5
 (不 木 頭)	bu2mu4tou5
-(不 ㊍ 頭)	bu2mu4tou5
 (不 未 了)	bu2wei4liao3
 (不 未 了)	bu2wei4liao3
 (不 未 了)	bu2wei4liao3
@@ -64285,9 +61482,7 @@ $textmode
 (不 校 對)	bu2jiao4dui4
 (不 校 對)	bu2jiao4dui4
 (不 校 正)	bu2jiao4zheng4
-(不 校 ㊣)	bu2jiao4zheng4
 (不 校 正)	bu2jiao4zheng4
-(不 校 ㊣)	bu2jiao4zheng4
 (不 校 準)	bu2jiao4zhun3
 (不 校 準)	bu2jiao4zhun3
 (不 校 稿)	bu2jiao4gao3
@@ -64403,9 +61598,7 @@ $textmode
 (不 橫 死)	bu2heng4si3
 (不 橫 死)	bu2heng4si3
 (不 橫 財)	bu2heng4cai2
-(不 橫 ㊖)	bu2heng4cai2
 (不 橫 財)	bu2heng4cai2
-(不 橫 ㊖)	bu2heng4cai2
 (不 檻 車)	bu2jian4che1
 (不 檻 車)	bu2jian4che1
 (不 檻 車)	bu2jian4che1
@@ -64420,11 +61613,8 @@ $textmode
 (不 歎 息)	bu2tan4xi1
 (不 歎 息)	bu2tan4xi1
 (不 正 切)	bu2zheng4qie1
-(不 ㊣ 切)	bu2zheng4qie1
 (不 正 切)	bu2zheng4qie1
-(不 ㊣ 切)	bu2zheng4qie1
 (不 正 切)	bu2zheng4qie1
-(不 ㊣ 切)	bu2zheng4qie1
 (不 歲 差)	bu2sui4cha1
 (不 歲 差)	bu2sui4cha1
 (不 歲 數)	bu2sui4shu5
@@ -64518,11 +61708,8 @@ $textmode
 (不 溺 愛)	bu2ni4ai4
 (不 溺 愛)	bu2ni4ai4
 (不 溺 水)	bu2ni4shui3
-(不 溺 ㊌)	bu2ni4shui3
 (不 溺 水)	bu2ni4shui3
-(不 溺 ㊌)	bu2ni4shui3
 (不 溺 水)	bu2ni4shui3
-(不 溺 ㊌)	bu2ni4shui3
 (不 溺 爱)	bu2ni4ai4
 (不 溺 爱)	bu2ni4ai4
 (不 溺 爱)	bu2ni4ai4
@@ -64569,46 +61756,29 @@ $textmode
 (不 牧 師)	bu2mu4shi5
 (不 牧 師)	bu2mu4shi5
 (不 特 地)	bu2te4di4
-(不 ㊕ 地)	bu2te4di4
 (不 特 地)	bu2te4di4
-(不 ㊕ 地)	bu2te4di4
 (不 特 徵)	bu2te4zheng1
-(不 ㊕ 徵)	bu2te4zheng1
 (不 特 徵)	bu2te4zheng1
-(不 ㊕ 徵)	bu2te4zheng1
 (不 特 調)	bu2te4tiao2
-(不 ㊕ 調)	bu2te4tiao2
 (不 特 調)	bu2te4tiao2
-(不 ㊕ 調)	bu2te4tiao2
 (不 特 調)	bu2te4tiao2
-(不 ㊕ 調)	bu2te4tiao2
 (不 特 调)	bu2te4tiao2
-(不 ㊕ 调)	bu2te4tiao2
 (不 特 调)	bu2te4tiao2
-(不 ㊕ 调)	bu2te4tiao2
 (不 特 輯)	bu2te4ji2
-(不 ㊕ 輯)	bu2te4ji2
 (不 特 輯)	bu2te4ji2
-(不 ㊕ 輯)	bu2te4ji2
 (不 特 辑)	bu2te4ji2
-(不 ㊕ 辑)	bu2te4ji2
 (不 特 辑)	bu2te4ji2
-(不 ㊕ 辑)	bu2te4ji2
 (不 状 元)	bu2zhuang4yuan5
 (不 状 元)	bu2zhuang4yuan5
 (不 狀 元)	bu2zhuang4yuan5
 (不 狀 元)	bu2zhuang4yuan5
 (不 狀 元)	bu2zhuang4yuan5
 (不 献 上)	bu2xian4shang5
-(不 献 ㊤)	bu2xian4shang5
 (不 献 上)	bu2xian4shang5
-(不 献 ㊤)	bu2xian4shang5
 (不 獲 得)	bu2huo4de2
 (不 獲 得)	bu2huo4de2
 (不 獻 上)	bu2xian4shang5
-(不 獻 ㊤)	bu2xian4shang5
 (不 獻 上)	bu2xian4shang5
-(不 獻 ㊤)	bu2xian4shang5
 (不 率 先)	bu2shuai4xian1
 (不 率 先)	bu2shuai4xian1
 (不 率 先)	bu2shuai4xian1
@@ -64763,11 +61933,7 @@ $textmode
 (不 相 面)	bu2xiang4mian4
 (不 相 面)	bu2xiang4mian4
 (不 看 中)	bu2kan4zhong4
-(不 看 🀄)	bu2kan4zhong4
-(不 看 ㊥)	bu2kan4zhong4
 (不 看 中)	bu2kan4zhong4
-(不 看 🀄)	bu2kan4zhong4
-(不 看 ㊥)	bu2kan4zhong4
 (不 看 來)	bu2kan4lai5
 (不 看 來)	bu2kan4lai5
 (不 看 來)	bu2kan4lai5
@@ -64852,15 +62018,11 @@ $textmode
 (不 礦 難)	bu2kuang4nan4
 (不 礦 難)	bu2kuang4nan4
 (不 社 長)	bu2she4zhang3
-(不 ㊓ 長)	bu2she4zhang3
 (不 社 長)	bu2she4zhang3
 (不 社 長)	bu2she4zhang3
-(不 ㊓ 長)	bu2she4zhang3
 (不 社 长)	bu2she4zhang3
-(不 ㊓ 长)	bu2she4zhang3
 (不 社 长)	bu2she4zhang3
 (不 社 长)	bu2she4zhang3
-(不 ㊓ 长)	bu2she4zhang3
 (不 禁 令)	bu2jin4ling4
 (不 禁 令)	bu2jin4ling4
 (不 禁 令)	bu2jin4ling4
@@ -64971,9 +62133,7 @@ $textmode
 (不 空 当)	bu2kong4dang1
 (不 空 当)	bu2kong4dang1
 (不 空 日)	bu2kong4ri4
-(不 空 ㊐)	bu2kong4ri4
 (不 空 日)	bu2kong4ri4
-(不 空 ㊐)	bu2kong4ri4
 (不 空 暇)	bu2kong4xia2
 (不 空 暇)	bu2kong4xia2
 (不 空 格)	bu2kong4ge2
@@ -65021,9 +62181,7 @@ $textmode
 (不 糊 弄)	bu2hu4nong5
 (不 糊 弄)	bu2hu4nong5
 (不 系 上)	bu2ji4shang5
-(不 系 ㊤)	bu2ji4shang5
 (不 系 上)	bu2ji4shang5
-(不 系 ㊤)	bu2ji4shang5
 (不 系 囚)	bu2ji4qiu2
 (不 系 囚)	bu2ji4qiu2
 (不 納 降)	bu2na4xiang2
@@ -65053,9 +62211,7 @@ $textmode
 (不 繞 地)	bu2rao4di4
 (不 繞 地)	bu2rao4di4
 (不 繫 上)	bu2ji4shang5
-(不 繫 ㊤)	bu2ji4shang5
 (不 繫 上)	bu2ji4shang5
-(不 繫 ㊤)	bu2ji4shang5
 (不 繫 囚)	bu2ji4qiu2
 (不 繫 囚)	bu2ji4qiu2
 (不 續 假)	bu2xu4jia4
@@ -65086,9 +62242,7 @@ $textmode
 (不 罐 頭)	bu2guan4tou5
 (不 罐 頭)	bu2guan4tou5
 (不 罢 休)	bu2ba4xiu1
-(不 罢 ㊡)	bu2ba4xiu1
 (不 罢 休)	bu2ba4xiu1
-(不 罢 ㊡)	bu2ba4xiu1
 (不 罢 免)	bu2ba4mian3
 (不 罢 免)	bu2ba4mian3
 (不 罢 免)	bu2ba4mian3
@@ -65115,9 +62269,7 @@ $textmode
 (不 置 於)	bu2zhi4yu2
 (不 置 於)	bu2zhi4yu2
 (不 罷 休)	bu2ba4xiu1
-(不 罷 ㊡)	bu2ba4xiu1
 (不 罷 休)	bu2ba4xiu1
-(不 罷 ㊡)	bu2ba4xiu1
 (不 罷 免)	bu2ba4mian3
 (不 罷 免)	bu2ba4mian3
 (不 罷 免)	bu2ba4mian3
@@ -65226,9 +62378,7 @@ $textmode
 (不 舊 都)	bu2jiu4du1
 (不 舊 都)	bu2jiu4du1
 (不 舍 下)	bu2she4xia4
-(不 舍 ㊦)	bu2she4xia4
 (不 舍 下)	bu2she4xia4
-(不 舍 ㊦)	bu2she4xia4
 (不 舍 利)	bu2she4li4
 (不 舍 利)	bu2she4li4
 (不 舍 利)	bu2she4li4
@@ -65287,11 +62437,8 @@ $textmode
 (不 著 作)	bu2zhu4zuo4
 (不 著 作)	bu2zhu4zuo4
 (不 著 名)	bu2zhu4ming2
-(不 著 ㊔)	bu2zhu4ming2
 (不 著 名)	bu2zhu4ming2
-(不 著 ㊔)	bu2zhu4ming2
 (不 著 名)	bu2zhu4ming2
-(不 著 ㊔)	bu2zhu4ming2
 (不 著 录)	bu2zhu4lu4
 (不 著 录)	bu2zhu4lu4
 (不 著 录)	bu2zhu4lu4
@@ -65594,17 +62741,12 @@ $textmode
 (不 跡 象)	bu2ji4xiang4
 (不 跡 象)	bu2ji4xiang4
 (不 跪 下)	bu2gui4xia5
-(不 跪 ㊦)	bu2gui4xia5
 (不 跪 下)	bu2gui4xia5
-(不 跪 ㊦)	bu2gui4xia5
 (不 跪 倒)	bu2gui4dao3
 (不 跪 倒)	bu2gui4dao3
 (不 路 上)	bu2lu4shang5
-(不 路 ㊤)	bu2lu4shang5
 (不 路 上)	bu2lu4shang5
-(不 路 ㊤)	bu2lu4shang5
 (不 路 上)	bu2lu4shang5
-(不 路 ㊤)	bu2lu4shang5
 (不 跳 蚤)	bu2tiao4zao5
 (不 跳 蚤)	bu2tiao4zao5
 (不 踉 跄)	bu2liang4qiang4
@@ -65831,17 +62973,11 @@ $textmode
 (不 遞 解)	bu2di4jie4
 (不 遞 解)	bu2di4jie4
 (不 適 宜)	bu2shi4yi2
-(不 ㊜ 宜)	bu2shi4yi2
 (不 適 宜)	bu2shi4yi2
-(不 ㊜ 宜)	bu2shi4yi2
 (不 適 應)	bu2shi4ying4
-(不 ㊜ 應)	bu2shi4ying4
 (不 適 應)	bu2shi4ying4
-(不 ㊜ 應)	bu2shi4ying4
 (不 適 當)	bu2shi4dang4
-(不 ㊜ 當)	bu2shi4dang4
 (不 適 當)	bu2shi4dang4
-(不 ㊜ 當)	bu2shi4dang4
 (不 避 难)	bu2bi4nan4
 (不 避 难)	bu2bi4nan4
 (不 避 難)	bu2bi4nan4
@@ -65868,9 +63004,7 @@ $textmode
 (不 郑 重)	bu2zheng4zhong4
 (不 郑 重)	bu2zheng4zhong4
 (不 部 下)	bu2bu4xia5
-(不 部 ㊦)	bu2bu4xia5
 (不 部 下)	bu2bu4xia5
-(不 部 ㊦)	bu2bu4xia5
 (不 部 分)	bu2bu4fen5
 (不 部 分)	bu2bu4fen5
 (不 部 長)	bu2bu4zhang3
@@ -65950,9 +63084,7 @@ $textmode
 (不 镇 长)	bu2zhen4zhang3
 (不 镇 长)	bu2zhen4zhang3
 (不 閉 上)	bu2bi4shang5
-(不 閉 ㊤)	bu2bi4shang5
 (不 閉 上)	bu2bi4shang5
-(不 閉 ㊤)	bu2bi4shang5
 (不 閉 塞)	bu2bi4se4
 (不 閉 塞)	bu2bi4se4
 (不 閉 塞)	bu2bi4se4
@@ -65973,9 +63105,7 @@ $textmode
 (不 闊 氣)	bu2kuo4qi5
 (不 闊 氣)	bu2kuo4qi5
 (不 闭 上)	bu2bi4shang5
-(不 闭 ㊤)	bu2bi4shang5
 (不 闭 上)	bu2bi4shang5
-(不 闭 ㊤)	bu2bi4shang5
 (不 闭 塞)	bu2bi4se4
 (不 闭 塞)	bu2bi4se4
 (不 闭 塞)	bu2bi4se4
@@ -66059,11 +63189,8 @@ $textmode
 (不 露 怯)	bu2lou4qie4
 (不 露 怯)	bu2lou4qie4
 (不 露 水)	bu2lu4shui5
-(不 露 ㊌)	bu2lu4shui5
 (不 露 水)	bu2lu4shui5
-(不 露 ㊌)	bu2lu4shui5
 (不 露 水)	bu2lu4shui5
-(不 露 ㊌)	bu2lu4shui5
 (不 露 白)	bu2lou4bai2
 (不 露 白)	bu2lou4bai2
 (不 露 白)	bu2lou4bai2
@@ -66196,9 +63323,7 @@ $textmode
 (不 Ｕ 盤)	bu2yu4pan2
 (不 Ｕ 盤)	bu2yu4pan2
 (专 一 性)	zhuan1yi2xing4
-(专 ㊀ 性)	zhuan1yi2xing4
 (东 边 儿)	dong1bian1r5
-(🀀 边 儿)	dong1bian1r5
 (丟 不 了)	diu1bu5liao3
 (丟 不 了)	diu1bu5liao3
 (丟 不 了)	diu1bu5liao3
@@ -66213,42 +63338,17 @@ $textmode
 (丫 巴 儿)	ya1ba1r5
 (丫 巴 兒)	ya1ba1r5
 (中 不 溜)	zhong1bu5liu1
-(🀄 不 溜)	zhong1bu5liu1
-(㊥ 不 溜)	zhong1bu5liu1
 (中 不 溜)	zhong1bu5liu1
-(🀄 不 溜)	zhong1bu5liu1
-(㊥ 不 溜)	zhong1bu5liu1
 (中 不 溜)	zhong1bu5liu1
-(🀄 不 溜)	zhong1bu5liu1
-(㊥ 不 溜)	zhong1bu5liu1
 (中 圈 套)	zhong4quan1tao4
-(🀄 圈 套)	zhong4quan1tao4
-(㊥ 圈 套)	zhong4quan1tao4
 (中 埔 乡)	zhong1bu4xiang1
-(🀄 埔 乡)	zhong1bu4xiang1
-(㊥ 埔 乡)	zhong1bu4xiang1
 (中 埔 鄉)	zhong1bu4xiang1
-(🀄 埔 鄉)	zhong1bu4xiang1
-(㊥ 埔 鄉)	zhong1bu4xiang1
 (中 学 生)	zhong1xue2sheng1
-(🀄 学 生)	zhong1xue2sheng1
-(中 ㊫ 生)	zhong1xue2sheng1
-(🀄 ㊫ 生)	zhong1xue2sheng1
-(㊥ 学 生)	zhong1xue2sheng1
 (中 學 生)	zhong1xue2sheng1
-(🀄 學 生)	zhong1xue2sheng1
-(㊥ 學 生)	zhong1xue2sheng1
 (中 微 子)	zhong1wei1zi3
-(🀄 微 子)	zhong1wei1zi3
-(㊥ 微 子)	zhong1wei1zi3
 (中 心 矩)	zhong1xin1ju3
-(🀄 心 矩)	zhong1xin1ju3
-(㊥ 心 矩)	zhong1xin1ju3
 (中 洋 脊)	zhong1yang2ji2
-(🀄 洋 脊)	zhong1yang2ji2
-(㊥ 洋 脊)	zhong1yang2ji2
 (临 月 儿)	lin2yue4r5
-(临 ㊊ 儿)	lin2yue4r5
 (主 不 了)	zhu3bu5liao3
 (主 不 了)	zhu3bu5liao3
 (主 不 了)	zhu3bu5liao3
@@ -66264,37 +63364,23 @@ $textmode
 (乌 黎 雅)	wu1li1ya3
 (乌 黎 雅)	wu1li1ya3
 (乐 学 者)	yue4xue2zhe3
-(乐 ㊫ 者)	yue4xue2zhe3
 (乐 学 者)	yue4xue2zhe3
-(乐 ㊫ 者)	yue4xue2zhe3
 (乐 学 者)	yue4xue2zhe3
-(乐 ㊫ 者)	yue4xue2zhe3
 (乔 冠 华)	qiao2guan1hua4
 (乔 答 摩)	qiao2da1mo2
 (乘 务 员)	cheng2wu4yuan2
 (乘 務 員)	cheng2wu4yuan2
 (九 一 八)	jiu3yi4ba1
-(㊈ 一 八)	jiu3yi4ba1
-(九 ㊀ 八)	jiu3yi4ba1
-(九 一 ㊇)	jiu3yi4ba1
 (九 一 四)	jiu3yi2si4
-(㊈ 一 四)	jiu3yi2si4
-(九 一 ㊃)	jiu3yi2si4
-(九 ㊀ 四)	jiu3yi2si4
 (书 不 尽)	shu1bu5jin4
 (书 不 尽)	shu1bu5jin4
 (书 巴 业)	shu1ba1ye4
 (书 馆 儿)	shu1guan3r5
 (买 下 来)	mai3xia4lai2
-(买 ㊦ 来)	mai3xia4lai2
 (买 不 上)	mai3bu5shang4
-(买 不 ㊤)	mai3bu5shang4
 (买 不 上)	mai3bu5shang4
-(买 不 ㊤)	mai3bu5shang4
 (买 不 下)	mai3bu5xia4
-(买 不 ㊦)	mai3bu5xia4
 (买 不 下)	mai3bu5xia4
-(买 不 ㊦)	mai3bu5xia4
 (买 不 到)	mai3bu5dao4
 (买 不 到)	mai3bu5dao4
 (买 不 成)	mai3bu5cheng2
@@ -66329,24 +63415,15 @@ $textmode
 (争 不 来)	zheng1bu5lai2
 (争 不 来)	zheng1bu5lai2
 (二 噁 英)	er4e4ying1
-(㊁ 噁 英)	er4e4ying1
 (二 把 手)	er4ba3shou3
-(㊁ 把 手)	er4ba3shou3
 (二 節 棍)	er2jie2gun4
-(㊁ 節 棍)	er2jie2gun4
 (二 節 棍)	er2jie2gun4
-(㊁ 節 棍)	er2jie2gun4
 (二 節 棍)	er2jie2gun4
-(㊁ 節 棍)	er2jie2gun4
 (二 节 棍)	er2jie2gun4
-(㊁ 节 棍)	er2jie2gun4
 (互 操 性)	hu4cao4xing5
 (五 子 棋)	wu3zi3qi2
-(㊄ 子 棋)	wu3zi3qi2
 (五 虎 将)	wu3hu3jiang4
-(㊄ 虎 将)	wu3hu3jiang4
 (五 虎 將)	wu3hu3jiang4
-(㊄ 虎 將)	wu3hu3jiang4
 (亚 哈 拉)	ya4ha1la1
 (亚 哈 拉)	ya4ha1la1
 (亚 喀 巴)	ya4ka1ba1
@@ -66358,11 +63435,8 @@ $textmode
 (亚 舍 拉)	ya4she4la1
 (亚 舍 拉)	ya4she4la1
 (亚 西 加)	ya4xi1jia1
-(亚 🀂 加)	ya4xi1jia1
 (亚 西 娜)	ya4xi1na4
-(亚 🀂 娜)	ya4xi1na4
 (亚 西 撒)	ya4xi1sa1
-(亚 🀂 撒)	ya4xi1sa1
 (亚 都 悯)	ya4du1min3
 (亚 都 悯)	ya4du1min3
 (亞 哈 拉)	ya4ha1la1
@@ -66376,21 +63450,14 @@ $textmode
 (亞 舍 拉)	ya4she4la1
 (亞 舍 拉)	ya4she4la1
 (亞 西 加)	ya4xi1jia1
-(亞 🀂 加)	ya4xi1jia1
 (亞 西 娜)	ya4xi1na4
-(亞 🀂 娜)	ya4xi1na4
 (亞 西 撒)	ya4xi1sa1
-(亞 🀂 撒)	ya4xi1sa1
 (亞 都 憫)	ya4du1min3
 (亞 都 憫)	ya4du1min3
 (交 不 上)	jiao1bu5shang4
-(交 不 ㊤)	jiao1bu5shang4
 (交 不 上)	jiao1bu5shang4
-(交 不 ㊤)	jiao1bu5shang4
 (交 不 下)	jiao1bu5xia4
-(交 不 ㊦)	jiao1bu5xia4
 (交 不 下)	jiao1bu5xia4
-(交 不 ㊦)	jiao1bu5xia4
 (交 不 了)	jiao1bu5liao3
 (交 不 了)	jiao1bu5liao3
 (交 不 了)	jiao1bu5liao3
@@ -66399,7 +63466,6 @@ $textmode
 (交 响 乐)	jiao1xiang3yue4
 (交 响 曲)	jiao1xiang3qu3
 (交 得 上)	jiao1de5shang4
-(交 得 ㊤)	jiao1de5shang4
 (交 響 曲)	jiao1xiang3qu3
 (交 響 曲)	jiao1xiang3qu3
 (交 響 曲)	jiao1xiang3qu3
@@ -66419,10 +63485,7 @@ $textmode
 (什 剎 海)	shi2cha4hai3
 (什 剎 海)	shi2cha4hai3
 (他 得 上)	ta1de2shang4
-(他 得 ㊤)	ta1de2shang4
 (他 得 中)	ta1de2zhong4
-(他 得 🀄)	ta1de2zhong4
-(他 得 ㊥)	ta1de2zhong4
 (他 得 主)	ta1de2zhu3
 (他 得 了)	ta1de2le5
 (他 得 了)	ta1de2le5
@@ -66447,7 +63510,6 @@ $textmode
 (他 得 勝)	ta1de2sheng4
 (他 得 勢)	ta1de2shi4
 (他 得 名)	ta1de2ming2
-(他 得 ㊔)	ta1de2ming2
 (他 得 君)	ta1de2jun1
 (他 得 听)	ta1de2ting1
 (他 得 味)	ta1de2wei4
@@ -66554,10 +63616,7 @@ $textmode
 (以 拉 都)	yi3la1du1
 (以 拉 都)	yi3la1du1
 (们 得 上)	men5de2shang4
-(们 得 ㊤)	men5de2shang4
 (们 得 中)	men5de2zhong4
-(们 得 🀄)	men5de2zhong4
-(们 得 ㊥)	men5de2zhong4
 (们 得 主)	men5de2zhu3
 (们 得 了)	men5de2le5
 (们 得 了)	men5de2le5
@@ -66582,7 +63641,6 @@ $textmode
 (们 得 勝)	men5de2sheng4
 (们 得 勢)	men5de2shi4
 (们 得 名)	men5de2ming2
-(们 得 ㊔)	men5de2ming2
 (们 得 君)	men5de2jun1
 (们 得 听)	men5de2ting1
 (们 得 味)	men5de2wei4
@@ -66674,9 +63732,7 @@ $textmode
 (们 得 非)	men5de2fei1
 (们 得 體)	men5de2ti3
 (任 一 个)	ren4yi2ge4
-(任 ㊀ 个)	ren4yi2ge4
 (任 一 個)	ren4yi2ge4
-(任 ㊀ 個)	ren4yi2ge4
 (伊 妹 儿)	yi1mei4er5
 (伊 妹 兒)	yi1mei4er5
 (伊 施 巴)	yi1shi1ba1
@@ -66696,17 +63752,11 @@ $textmode
 (伽 羅 華)	jia1luo2hua4
 (低 能 兒)	di1neng2er2
 (住 下 來)	zhu4xia4lai5
-(住 ㊦ 來)	zhu4xia4lai5
 (住 下 來)	zhu4xia4lai5
-(住 ㊦ 來)	zhu4xia4lai5
 (住 下 去)	zhu4xia4qu5
-(住 ㊦ 去)	zhu4xia4qu5
 (住 下 来)	zhu4xia4lai5
-(住 ㊦ 来)	zhu4xia4lai5
 (住 不 下)	zhu4bu5xia4
-(住 不 ㊦)	zhu4bu5xia4
 (住 不 下)	zhu4bu5xia4
-(住 不 ㊦)	zhu4bu5xia4
 (住 不 了)	zhu4bu5liao3
 (住 不 了)	zhu4bu5liao3
 (住 不 了)	zhu4bu5liao3
@@ -66721,9 +63771,7 @@ $textmode
 (佔 便 宜)	zhan4pian2yi5
 (佔 便 宜)	zhan4pian2yi5
 (何 西 阿)	he2xi1a1
-(何 🀂 阿)	he2xi1a1
 (余 下 来)	yu2xia4lai2
-(余 ㊦ 来)	yu2xia4lai2
 (佛 得 角)	fo2de2jiao3
 (佛 手 瓜)	fo2shou3gua1
 (佛 朗 哥)	fo2lang3ge1
@@ -66739,10 +63787,7 @@ $textmode
 (作 不 来)	zuo4bu5lai2
 (作 不 来)	zuo4bu5lai2
 (你 得 上)	ni3de2shang4
-(你 得 ㊤)	ni3de2shang4
 (你 得 中)	ni3de2zhong4
-(你 得 🀄)	ni3de2zhong4
-(你 得 ㊥)	ni3de2zhong4
 (你 得 主)	ni3de2zhu3
 (你 得 了)	ni3de2le5
 (你 得 了)	ni3de2le5
@@ -66767,7 +63812,6 @@ $textmode
 (你 得 勝)	ni3de2sheng4
 (你 得 勢)	ni3de2shi4
 (你 得 名)	ni3de2ming2
-(你 得 ㊔)	ni3de2ming2
 (你 得 君)	ni3de2jun1
 (你 得 听)	ni3de2ting1
 (你 得 味)	ni3de2wei4
@@ -66859,17 +63903,13 @@ $textmode
 (你 得 非)	ni3de2fei1
 (你 得 體)	ni3de2ti3
 (佩 洛 西)	pei4luo4xi1
-(佩 洛 🀂)	pei4luo4xi1
 (佩 洛 西)	pei4luo4xi1
-(佩 洛 🀂)	pei4luo4xi1
 (佩 魯 賈)	pei4lu3jia3
 (佩 魯 賈)	pei4lu3jia3
 (佩 魯 賈)	pei4lu3jia3
 (佩 鲁 贾)	pei4lu3jia3
 (使 不 上)	shi3bu5shang4
-(使 不 ㊤)	shi3bu5shang4
 (使 不 上)	shi3bu5shang4
-(使 不 ㊤)	shi3bu5shang4
 (使 不 了)	shi3bu5liao3
 (使 不 了)	shi3bu5liao3
 (使 不 了)	shi3bu5liao3
@@ -66880,11 +63920,9 @@ $textmode
 (使 不 慣)	shi3bu5guan4
 (使 不 慣)	shi3bu5guan4
 (使 得 上)	shi3de5shang4
-(使 得 ㊤)	shi3de5shang4
 (使 溺 死)	shi3ni4si3
 (使 溺 死)	shi3ni4si3
 (侄 女 婿)	zhi2nv3xu5
-(侄 ㊛ 婿)	zhi2nv3xu5
 (侄 女 婿)	zhi2nv3xu5
 (侄 媳 妇)	zhi2xi2fu5
 (侄 媳 婦)	zhi2xi2fu5
@@ -66935,10 +63973,7 @@ $textmode
 (修 補 匠)	xiu1bu3jiang4
 (修 鞋 匠)	xiu1xie2jiang4
 (們 得 上)	men5de2shang4
-(們 得 ㊤)	men5de2shang4
 (們 得 中)	men5de2zhong4
-(們 得 🀄)	men5de2zhong4
-(們 得 ㊥)	men5de2zhong4
 (們 得 主)	men5de2zhu3
 (們 得 了)	men5de2le5
 (們 得 了)	men5de2le5
@@ -66963,7 +63998,6 @@ $textmode
 (們 得 勝)	men5de2sheng4
 (們 得 勢)	men5de2shi4
 (們 得 名)	men5de2ming2
-(們 得 ㊔)	men5de2ming2
 (們 得 君)	men5de2jun1
 (們 得 听)	men5de2ting1
 (們 得 味)	men5de2wei4
@@ -67083,9 +64117,7 @@ $textmode
 (值 不 當)	zhi2bu5dang4
 (值 不 當)	zhi2bu5dang4
 (做 不 下)	zuo4bu5xia4
-(做 不 ㊦)	zuo4bu5xia4
 (做 不 下)	zuo4bu5xia4
-(做 不 ㊦)	zuo4bu5xia4
 (做 不 了)	zuo4bu5liao3
 (做 不 了)	zuo4bu5liao3
 (做 不 了)	zuo4bu5liao3
@@ -67106,11 +64138,8 @@ $textmode
 (做 得 完)	zuo4de5wan2
 (做 買 賣)	zuo4mai3mai5
 (停 下 來)	ting2xia4lai2
-(停 ㊦ 來)	ting2xia4lai2
 (停 下 來)	ting2xia4lai2
-(停 ㊦ 來)	ting2xia4lai2
 (停 下 来)	ting2xia4lai2
-(停 ㊦ 来)	ting2xia4lai2
 (傅 作 义)	fu4zuo4yi4
 (傅 作 義)	fu4zuo4yi4
 (傅 佳 敏)	fu4jia1min3
@@ -67163,33 +64192,20 @@ $textmode
 (內 賈 德)	nei4jia3de2
 (內 賈 德)	nei4jia3de2
 (八 一 五)	ba1yi4wu3
-(八 ㊀ 五)	ba1yi4wu3
-(㊇ 一 五)	ba1yi4wu3
-(八 一 ㊄)	ba1yi4wu3
 (八 一 厂)	ba1yi4chang3
-(八 ㊀ 厂)	ba1yi4chang3
-(㊇ 一 厂)	ba1yi4chang3
 (八 一 廠)	ba1yi4chang3
-(八 ㊀ 廠)	ba1yi4chang3
-(㊇ 一 廠)	ba1yi4chang3
 (八 行 书)	ba1hang2shu1
-(㊇ 行 书)	ba1hang2shu1
 (八 行 书)	ba1hang2shu1
-(㊇ 行 书)	ba1hang2shu1
 (八 行 書)	ba1hang2shu1
-(㊇ 行 書)	ba1hang2shu1
 (八 行 書)	ba1hang2shu1
-(㊇ 行 書)	ba1hang2shu1
 (公 倍 数)	gong1bei4shu5
 (公 倍 數)	gong1bei4shu5
 (公 倍 數)	gong1bei4shu5
 (公 羊 传)	gong1yang2zhuan4
 (公 羊 傳)	gong1yang2zhuan4
 (六 合 区)	lu4he2qu1
-(㊅ 合 区)	lu4he2qu1
 (六 合 区)	lu4he2qu1
 (六 合 區)	lu4he2qu1
-(㊅ 合 區)	lu4he2qu1
 (六 合 區)	lu4he2qu1
 (关 不 严)	guan1bu5yan2
 (关 不 严)	guan1bu5yan2
@@ -67201,8 +64217,6 @@ $textmode
 (兴 不 开)	xing1bu5kai1
 (兴 不 开)	xing1bu5kai1
 (兴 中 会)	xing1zhong1hui4
-(兴 🀄 会)	xing1zhong1hui4
-(兴 ㊥ 会)	xing1zhong1hui4
 (典 狱 长)	dian3yu4zhang3
 (典 獄 長)	dian3yu4zhang3
 (内 切 球)	nei4qie1qiu2
@@ -67212,30 +64226,15 @@ $textmode
 (内 比 都)	nei4bi3du1
 (内 贾 德)	nei4jia3de2
 (写 下 来)	xie3xia4lai2
-(㊢ 下 来)	xie3xia4lai2
-(写 ㊦ 来)	xie3xia4lai2
 (写 不 上)	xie3bu5shang4
-(㊢ 不 上)	xie3bu5shang4
-(写 不 ㊤)	xie3bu5shang4
 (写 不 上)	xie3bu5shang4
-(㊢ 不 上)	xie3bu5shang4
-(写 不 ㊤)	xie3bu5shang4
 (写 不 下)	xie3bu5xia4
-(㊢ 不 下)	xie3bu5xia4
-(写 不 ㊦)	xie3bu5xia4
 (写 不 下)	xie3bu5xia4
-(㊢ 不 下)	xie3bu5xia4
-(写 不 ㊦)	xie3bu5xia4
 (写 不 出)	xie3bu5chu1
-(㊢ 不 出)	xie3bu5chu1
 (写 不 出)	xie3bu5chu1
-(㊢ 不 出)	xie3bu5chu1
 (写 不 通)	xie3bu5tong1
-(㊢ 不 通)	xie3bu5tong1
 (写 不 通)	xie3bu5tong1
-(㊢ 不 通)	xie3bu5tong1
 (写 出 来)	xie3chu1lai2
-(㊢ 出 来)	xie3chu1lai2
 (冠 心 病)	guan1xin1bing4
 (冰 棍 儿)	bing1gun4r5
 (冰 淇 淋)	bing1qi5lin2
@@ -67257,9 +64256,7 @@ $textmode
 (凍 不 著)	dong4bu5zhao2
 (凍 不 著)	dong4bu5zhao2
 (凑 不 上)	cou4bu5shang4
-(凑 不 ㊤)	cou4bu5shang4
 (凑 不 上)	cou4bu5shang4
-(凑 不 ㊤)	cou4bu5shang4
 (几 点 了)	ji3dian3le5
 (几 点 了)	ji3dian3le5
 (凤 仙 花)	feng4xian1hua1
@@ -67311,15 +64308,11 @@ $textmode
 (切 叶 蚁)	qie1ye4yi3
 (切 叶 蚁)	qie1ye4yi3
 (切 尔 西)	qie4er3xi1
-(切 尔 🀂)	qie4er3xi1
 (切 尔 西)	qie4er3xi1
-(切 尔 🀂)	qie4er3xi1
 (切 平 面)	qie1ping2mian4
 (切 平 面)	qie1ping2mian4
 (切 爾 西)	qie4er3xi1
-(切 爾 🀂)	qie4er3xi1
 (切 爾 西)	qie4er3xi1
-(切 爾 🀂)	qie4er3xi1
 (切 空 間)	qie1kong1jian1
 (切 空 間)	qie1kong1jian1
 (切 空 间)	qie1kong1jian1
@@ -67345,7 +64338,6 @@ $textmode
 (创 造 出)	chuang1zao4chu1
 (別 / 彆)	bie4bu5guo5
 (別 西 卜)	bie2xi1bu3
-(別 🀂 卜)	bie2xi1bu3
 (刨 根 儿)	pao2gen1r5
 (利 息 率)	li4xi5lv4
 (利 息 率)	li4xi5lv4
@@ -67361,7 +64353,6 @@ $textmode
 (别 不 过)	bie4bu5guo5
 (别 不 过)	bie4bu5guo5
 (别 西 卜)	bie2xi1bu3
-(别 🀂 卜)	bie2xi1bu3
 (刮 地 風)	gua1di4feng1
 (刮 地 风)	gua1di4feng1
 (到 不 了)	dao4bu5liao3
@@ -67380,21 +64371,13 @@ $textmode
 (前 奏 曲)	qian2zou4qu3
 (前 边 儿)	qian2bian5r5
 (剩 下 來)	sheng4xia4lai2
-(剩 ㊦ 來)	sheng4xia4lai2
 (剩 下 來)	sheng4xia4lai2
-(剩 ㊦ 來)	sheng4xia4lai2
 (剩 下 来)	sheng4xia4lai2
-(剩 ㊦ 来)	sheng4xia4lai2
 (剩 不 下)	sheng4bu5xia4
-(剩 不 ㊦)	sheng4bu5xia4
 (剩 不 下)	sheng4bu5xia4
-(剩 不 ㊦)	sheng4bu5xia4
 (剪 下 來)	jian3xia4lai2
-(剪 ㊦ 來)	jian3xia4lai2
 (剪 下 來)	jian3xia4lai2
-(剪 ㊦ 來)	jian3xia4lai2
 (剪 下 来)	jian3xia4lai2
-(剪 ㊦ 来)	jian3xia4lai2
 (剪 刀 差)	jian3dao1cha1
 (創 可 貼)	chuang1ke3tie1
 (創 造 出)	chuang1zao4chu1
@@ -67404,9 +64387,7 @@ $textmode
 (劉 涓 子)	liu2juan1zi3
 (劉 涓 子)	liu2juan1zi3
 (办 不 下)	ban4bu5xia4
-(办 不 ㊦)	ban4bu5xia4
 (办 不 下)	ban4bu5xia4
-(办 不 ㊦)	ban4bu5xia4
 (办 不 了)	ban4bu5liao3
 (办 不 了)	ban4bu5liao3
 (办 不 了)	ban4bu5liao3
@@ -67463,44 +64444,25 @@ $textmode
 (包 圆 儿)	bao1yuan2r5
 (包 干 儿)	bao1gan1r5
 (北 埔 乡)	bei3bu4xiang1
-(🀃 埔 乡)	bei3bu4xiang1
 (北 埔 乡)	bei3bu4xiang1
 (北 埔 鄉)	bei3bu4xiang1
-(🀃 埔 鄉)	bei3bu4xiang1
 (北 埔 鄉)	bei3bu4xiang1
 (北 边 儿)	bei3bian1r5
-(🀃 边 儿)	bei3bian1r5
 (北 边 儿)	bei3bian1r5
 (匯 出 行)	hui4chu1hang2
 (匯 出 行)	hui4chu1hang2
 (十 一 号)	shi2yi1hao4
-(㊉ 一 号)	shi2yi1hao4
-(十 ㊀ 号)	shi2yi1hao4
 (十 一 年)	shi2yi1nian2
-(㊉ 一 年)	shi2yi1nian2
-(十 ㊀ 年)	shi2yi1nian2
 (十 一 年)	shi2yi1nian2
-(㊉ 一 年)	shi2yi1nian2
-(十 ㊀ 年)	shi2yi1nian2
 (十 一 號)	shi2yi1hao4
-(㊉ 一 號)	shi2yi1hao4
-(十 ㊀ 號)	shi2yi1hao4
 (十 一 路)	shi2yi1lu4
-(㊉ 一 路)	shi2yi1lu4
-(十 ㊀ 路)	shi2yi1lu4
 (十 一 路)	shi2yi1lu4
-(㊉ 一 路)	shi2yi1lu4
-(十 ㊀ 路)	shi2yi1lu4
 (十 字 形)	shi2zi5xing2
-(㊉ 字 形)	shi2zi5xing2
 (千 佛 洞)	qian1fo2dong4
 (千 佛 洞)	qian1fo2dong4
 (升 上 來)	sheng1shang4lai2
-(升 ㊤ 來)	sheng1shang4lai2
 (升 上 來)	sheng1shang4lai2
-(升 ㊤ 來)	sheng1shang4lai2
 (升 上 来)	sheng1shang4lai2
-(升 ㊤ 来)	sheng1shang4lai2
 (升 不 了)	sheng1bu5liao3
 (升 不 了)	sheng1bu5liao3
 (升 不 了)	sheng1bu5liao3
@@ -67509,11 +64471,8 @@ $textmode
 (华 罗 庚)	hua4luo2geng1
 (协 奏 曲)	xie2zou4qu3
 (協 奏 曲)	xie2zou4qu3
-(㊯ 奏 曲)	xie2zou4qu3
 (单 一 码)	dan1yi4ma3
-(单 ㊀ 码)	dan1yi4ma3
 (单 一 税)	dan1yi2shui4
-(单 ㊀ 税)	dan1yi2shui4
 (单 峰 驼)	dan1feng1tuo2
 (单 相 思)	dan1xiang1si1
 (单 行 本)	dan1xing2ben3
@@ -67523,9 +64482,7 @@ $textmode
 (单 行 道)	dan1xing2dao4
 (单 行 道)	dan1xing2dao4
 (卖 不 上)	mai4bu5shang4
-(卖 不 ㊤)	mai4bu5shang4
 (卖 不 上)	mai4bu5shang4
-(卖 不 ㊤)	mai4bu5shang4
 (卖 不 了)	mai4bu5liao3
 (卖 不 了)	mai4bu5liao3
 (卖 不 了)	mai4bu5liao3
@@ -67539,9 +64496,7 @@ $textmode
 (卖 不 过)	mai4bu5guo4
 (卖 得 出)	mai4de5chu1
 (南 边 儿)	nan2bian5r5
-(🀁 边 儿)	nan2bian5r5
 (博 伊 西)	bo2yi1xi1
-(博 伊 🀂)	bo2yi1xi1
 (占 便 宜)	zhan4pian2yi5
 (占 便 宜)	zhan4pian2yi5
 (卡 仙 尼)	ka3xian1ni2
@@ -67550,20 +64505,15 @@ $textmode
 (卡 山 得)	ka3shan1de2
 (卧 果 儿)	wo4guo3r5
 (印 古 什)	yin4gu3shi2
-(㊞ 古 什)	yin4gu3shi2
 (印 古 什)	yin4gu3shi2
-(㊞ 古 什)	yin4gu3shi2
 (印 地 語)	yin4di4yu3
-(㊞ 地 語)	yin4di4yu3
 (印 地 语)	yin4di4yu3
-(㊞ 地 语)	yin4di4yu3
 (卷 起 來)	juan3qi3lai5
 (卷 起 來)	juan3qi3lai5
 (卷 起 来)	juan3qi3lai5
 (卷 铺 盖)	juan3pu1gai5
 (卸 肩 儿)	xie4jian1r5
 (历 史 上)	li4shi3shang5
-(历 史 ㊤)	li4shi3shang5
 (压 不 住)	ya1bu5zhu4
 (压 不 住)	ya1bu5zhu4
 (压 不 过)	ya1bu5guo4
@@ -67585,7 +64535,6 @@ $textmode
 (參 謀 長)	can1mou2zhang3
 (參 謀 長)	can1mou2zhang3
 (叉 一 叉)	cha3yi4cha3
-(叉 ㊀ 叉)	cha3yi4cha3
 (友 妮 基)	you3ni1ji1
 (友 布 罗)	you3bu4luo2
 (友 布 羅)	you3bu4luo2
@@ -67607,9 +64556,7 @@ $textmode
 (发 祥 地)	fa1xiang2di4
 (发 祥 地)	fa1xiang2di4
 (取 不 上)	qu3bu5shang4
-(取 不 ㊤)	qu3bu5shang4
 (取 不 上)	qu3bu5shang4
-(取 不 ㊤)	qu3bu5shang4
 (取 出 來)	qu3chu1lai2
 (取 出 來)	qu3chu1lai2
 (取 出 来)	qu3chu1lai2
@@ -67649,23 +64596,16 @@ $textmode
 (只 不 過)	zhi3bu5guo4
 (只 不 過)	zhi3bu5guo4
 (叫 不 上)	jiao4bu5shang4
-(叫 不 ㊤)	jiao4bu5shang4
 (叫 不 上)	jiao4bu5shang4
-(叫 不 ㊤)	jiao4bu5shang4
 (叫 不 醒)	jiao4bu5xing3
 (叫 不 醒)	jiao4bu5xing3
 (叭 啦 狗)	ba1la1gou3
 (史 蒂 夫)	shi3di4fu1
 (右 边 儿)	you4bian5r5
-(㊨ 边 儿)	you4bian5r5
 (吃 不 上)	chi1bu5shang4
-(吃 不 ㊤)	chi1bu5shang4
 (吃 不 上)	chi1bu5shang4
-(吃 不 ㊤)	chi1bu5shang4
 (吃 不 下)	chi1bu5xia4
-(吃 不 ㊦)	chi1bu5xia4
 (吃 不 下)	chi1bu5xia4
-(吃 不 ㊦)	chi1bu5xia4
 (吃 不 了)	chi1bu5liao3
 (吃 不 了)	chi1bu5liao3
 (吃 不 了)	chi1bu5liao3
@@ -67711,16 +64651,13 @@ $textmode
 (吃 不 饱)	chi1bu5bao3
 (吃 不 饱)	chi1bu5bao3
 (吃 得 上)	chi1de5shang4
-(吃 得 ㊤)	chi1de5shang4
 (吃 得 來)	chi1de5lai2
 (吃 得 來)	chi1de5lai2
 (吃 得 来)	chi1de5lai2
 (吃 苦 头)	chi1ku3tou5
 (吃 苦 頭)	chi1ku3tou5
 (合 不 上)	he2bu5shang4
-(合 不 ㊤)	he2bu5shang4
 (合 不 上)	he2bu5shang4
-(合 不 ㊤)	he2bu5shang4
 (合 不 了)	he2bu5liao3
 (合 不 了)	he2bu5liao3
 (合 不 了)	he2bu5liao3
@@ -67753,28 +64690,20 @@ $textmode
 (吉 卜 赛)	ji2bu3sai4
 (吉 娃 娃)	ji2wa2wa2
 (同 一 性)	tong2yi2xing4
-(同 ㊀ 性)	tong2yi2xing4
 (同 样 是)	tong2yang4shi5
 (同 樣 是)	tong2yang4shi5
 (名 义 上)	ming2yi4shang5
-(名 义 ㊤)	ming2yi4shang5
-(㊔ 义 上)	ming2yi4shang5
 (名 義 上)	ming2yi4shang5
-(名 義 ㊤)	ming2yi4shang5
-(㊔ 義 上)	ming2yi4shang5
 (名 角 儿)	ming2jue2r5
-(㊔ 角 儿)	ming2jue2r5
 (吐 不 出)	tu3bu5chu1
 (吐 不 出)	tu3bu5chu1
 (吐 出 來)	tu3chu1lai2
 (吐 出 來)	tu3chu1lai2
 (吐 出 来)	tu3chu1lai2
 (吐 苦 水)	tu4ku3shui3
-(吐 苦 ㊌)	tu4ku3shui3
 (吐 谷 浑)	tu3yu4hun2
 (吐 谷 渾)	tu3yu4hun2
 (向 北 地)	xiang4bei3di4
-(向 🀃 地)	xiang4bei3di4
 (向 北 地)	xiang4bei3di4
 (听 不 到)	ting1bu5dao4
 (听 不 到)	ting1bu5dao4
@@ -67802,9 +64731,7 @@ $textmode
 (吹 管 樂)	chui1guan3yue4
 (呛 得 慌)	qiang1de5huang1
 (周 一 岳)	zhou1yi2yue4
-(周 ㊀ 岳)	zhou1yi2yue4
 (周 一 嶽)	zhou1yi2yue4
-(周 ㊀ 嶽)	zhou1yi2yue4
 (和 散 那)	he2san3na4
 (咔 哒 声)	ka1da1sheng1
 (咔 噠 聲)	ka1da1sheng1
@@ -67820,11 +64747,8 @@ $textmode
 (咬 不 著)	yao3bu5zhao2
 (咬 不 著)	yao3bu5zhao2
 (咽 不 下)	yan4bu5xia4
-(咽 不 ㊦)	yan4bu5xia4
 (咽 不 下)	yan4bu5xia4
-(咽 不 ㊦)	yan4bu5xia4
 (咽 不 下)	yan4bu5xia4
-(咽 不 ㊦)	yan4bu5xia4
 (咽 鼓 管)	yan1gu3guan3
 (咽 鼓 管)	yan1gu3guan3
 (哄 不 过)	hong3bu5guo4
@@ -67856,15 +64780,10 @@ $textmode
 (唬 不 住)	hu3bu5zhu4
 (唬 不 住)	hu3bu5zhu4
 (唯 一 性)	wei2yi2xing4
-(唯 ㊀ 性)	wei2yi2xing4
 (唯 一 解)	wei2yi4jie3
-(唯 ㊀ 解)	wei2yi4jie3
 (唯 一 論)	wei2yi2lun4
-(唯 ㊀ 論)	wei2yi2lun4
 (唯 一 論)	wei2yi2lun4
-(唯 ㊀ 論)	wei2yi2lun4
 (唯 一 论)	wei2yi2lun4
-(唯 ㊀ 论)	wei2yi2lun4
 (唱 起 來)	chang4qi3lai5
 (唱 起 來)	chang4qi3lai5
 (唱 起 来)	chang4qi3lai5
@@ -67883,21 +64802,15 @@ $textmode
 (喉 塞 音)	hou2se4yin1
 (喉 塞 音)	hou2se4yin1
 (喘 不 上)	chuan3bu5shang4
-(喘 不 ㊤)	chuan3bu5shang4
 (喘 不 上)	chuan3bu5shang4
-(喘 不 ㊤)	chuan3bu5shang4
 (喘 不 过)	chuan3bu5guo4
 (喘 不 过)	chuan3bu5guo4
 (喘 不 過)	chuan3bu5guo4
 (喘 不 過)	chuan3bu5guo4
 (喝 不 上)	he1bu5shang4
-(喝 不 ㊤)	he1bu5shang4
 (喝 不 上)	he1bu5shang4
-(喝 不 ㊤)	he1bu5shang4
 (喝 不 上)	he1bu5shang4
-(喝 不 ㊤)	he1bu5shang4
 (喝 不 上)	he1bu5shang4
-(喝 不 ㊤)	he1bu5shang4
 (喝 不 到)	he1bu5dao4
 (喝 不 到)	he1bu5dao4
 (喝 不 到)	he1bu5dao4
@@ -67925,9 +64838,7 @@ $textmode
 (喬 冠 華)	qiao2guan1hua4
 (喬 答 摩)	qiao2da1mo2
 (單 一 碼)	dan1yi4ma3
-(單 ㊀ 碼)	dan1yi4ma3
 (單 一 稅)	dan1yi2shui4
-(單 ㊀ 稅)	dan1yi2shui4
 (單 峰 駝)	dan1feng1tuo2
 (單 相 思)	dan1xiang1si1
 (單 行 本)	dan1xing2ben3
@@ -67938,7 +64849,6 @@ $textmode
 (單 行 道)	dan1xing2dao4
 (嗆 得 慌)	qiang1de5huang1
 (嘗 一 嘗)	chang2yi4chang2
-(嘗 ㊀ 嘗)	chang2yi4chang2
 (嘩 啦 啦)	hua1la1la1
 (嘬 不 住)	zuo1bu5zhu4
 (嘬 不 住)	zuo1bu5zhu4
@@ -67960,7 +64870,6 @@ $textmode
 (嚼 得 动)	jiao2de5dong4
 (嚼 得 動)	jiao2de5dong4
 (四 部 曲)	si4bu4qu3
-(㊃ 部 曲)	si4bu4qu3
 (回 不 來)	hui2bu5lai2
 (回 不 來)	hui2bu5lai2
 (回 不 來)	hui2bu5lai2
@@ -67977,22 +64886,13 @@ $textmode
 (國 務 卿)	guo2wu4qing1
 (國 務 院)	guo2wu4yuan4
 (國 子 監)	guo2zi3jian4
-(國 子 ㊬)	guo2zi3jian4
 (團 團 轉)	tuan2tuan2zhuan4
 (圣 荷 西)	sheng4he2xi1
-(圣 荷 🀂)	sheng4he2xi1
 (在 一 达)	zai4yi4da2
-(在 ㊀ 达)	zai4yi4da2
 (在 一 達)	zai4yi4da2
-(在 ㊀ 達)	zai4yi4da2
 (在 下 面)	zai4xia4mian4
-(在 ㊦ 面)	zai4xia4mian4
 (地 中 海)	di4zhong1hai3
-(地 🀄 海)	di4zhong1hai3
-(地 ㊥ 海)	di4zhong1hai3
 (地 中 海)	di4zhong1hai3
-(地 🀄 海)	di4zhong1hai3
-(地 ㊥ 海)	di4zhong1hai3
 (地 平 線)	di4ping2xian4
 (地 平 线)	di4ping2xian4
 (地 心 說)	di4xin1shuo1
@@ -68006,29 +64906,20 @@ $textmode
 (地 磁 场)	di4ci2chang3
 (地 磁 場)	di4ci2chang3
 (地 西 泮)	di4xi1pan4
-(地 🀂 泮)	di4xi1pan4
 (地 躺 拳)	di4tang3quan2
 (均 一 性)	jun1yi2xing4
-(均 ㊀ 性)	jun1yi2xing4
 (坊 子 区)	fang1zi3qu1
 (坊 子 區)	fang1zi3qu1
 (坎 肩 儿)	kan3jian1r5
 (坏 主 意)	huai4zhu3yi4
 (坏 包 儿)	huai4bao1r5
 (坐 下 來)	zuo4xia4lai2
-(坐 ㊦ 來)	zuo4xia4lai2
 (坐 下 來)	zuo4xia4lai2
-(坐 ㊦ 來)	zuo4xia4lai2
 (坐 下 来)	zuo4xia4lai2
-(坐 ㊦ 来)	zuo4xia4lai2
 (坐 不 上)	zuo4bu5shang4
-(坐 不 ㊤)	zuo4bu5shang4
 (坐 不 上)	zuo4bu5shang4
-(坐 不 ㊤)	zuo4bu5shang4
 (坐 不 下)	zuo4bu5xia4
-(坐 不 ㊦)	zuo4bu5xia4
 (坐 不 下)	zuo4bu5xia4
-(坐 不 ㊦)	zuo4bu5xia4
 (坐 不 住)	zuo4bu5zhu4
 (坐 不 住)	zuo4bu5zhu4
 (坐 不 开)	zuo4bu5kai1
@@ -68062,17 +64953,13 @@ $textmode
 (執 行 長)	zhi2xing2zhang3
 (執 行 長)	zhi2xing2zhang3
 (基 哈 西)	ji1ha1xi1
-(基 哈 🀂)	ji1ha1xi1
 (基 巴 珥)	ji1ba1er3
 (基 本 上)	ji1ben3shang5
-(基 本 ㊤)	ji1ben3shang5
 (堆 起 來)	dui1qi3lai5
 (堆 起 來)	dui1qi3lai5
 (堆 起 来)	dui1qi3lai5
 (報 不 下)	bao4bu5xia4
-(報 不 ㊦)	bao4bu5xia4
 (報 不 下)	bao4bu5xia4
-(報 不 ㊦)	bao4bu5xia4
 (報 務 員)	bao4wu4yuan2
 (堵 不 住)	du3bu5zhu4
 (堵 不 住)	du3bu5zhu4
@@ -68082,16 +64969,12 @@ $textmode
 (塔 塔 儿)	ta3ta3r5
 (塗 油 於)	tu2you2yu2
 (塞 尔 南)	sai4er3nan2
-(塞 尔 🀁)	sai4er3nan2
 (塞 尔 南)	sai4er3nan2
-(塞 尔 🀁)	sai4er3nan2
 (塞 拉 凡)	sai4la1fan2
 (塞 拉 凡)	sai4la1fan2
 (塞 拉 凡)	sai4la1fan2
 (塞 爾 南)	sai4er3nan2
-(塞 爾 🀁)	sai4er3nan2
 (塞 爾 南)	sai4er3nan2
-(塞 爾 🀁)	sai4er3nan2
 (塞 琉 古)	sai4liu2gu3
 (塞 琉 古)	sai4liu2gu3
 (塞 琉 古)	sai4liu2gu3
@@ -68103,26 +64986,18 @@ $textmode
 (墊 不 起)	dian4bu5qi3
 (墊 腳 石)	dian4jiao3shi2
 (墨 水 儿)	mo4shui3r5
-(墨 ㊌ 儿)	mo4shui3r5
 (墨 水 儿)	mo4shui3r5
-(墨 ㊌ 儿)	mo4shui3r5
 (墨 西 哥)	mo4xi1ge1
-(墨 🀂 哥)	mo4xi1ge1
 (墨 西 哥)	mo4xi1ge1
-(墨 🀂 哥)	mo4xi1ge1
 (墨 西 拿)	mo4xi1na2
-(墨 🀂 拿)	mo4xi1na2
 (墨 西 拿)	mo4xi1na2
-(墨 🀂 拿)	mo4xi1na2
 (壓 不 住)	ya1bu5zhu4
 (壓 不 住)	ya1bu5zhu4
 (壓 不 過)	ya1bu5guo4
 (壓 不 過)	ya1bu5guo4
 (壞 主 意)	huai4zhu3yi4
 (处 不 下)	chu4bu5xia4
-(处 不 ㊦)	chu4bu5xia4
 (处 不 下)	chu4bu5xia4
-(处 不 ㊦)	chu4bu5xia4
 (处 不 来)	chu3bu5lai2
 (处 不 来)	chu3bu5lai2
 (处 得 来)	chu3de5lai2
@@ -68132,21 +65007,14 @@ $textmode
 (多 巴 胺)	duo1ba1an4
 (多 重 性)	duo1chong2xing4
 (夜 宵 儿)	ye4xiao1r5
-(㊰ 宵 儿)	ye4xiao1r5
 (够 不 上)	gou4bu5shang4
-(够 不 ㊤)	gou4bu5shang4
 (够 不 上)	gou4bu5shang4
-(够 不 ㊤)	gou4bu5shang4
 (够 得 上)	gou4de5shang4
-(够 得 ㊤)	gou4de5shang4
 (够 得 着)	gou4de5zhao2
 (够 得 着)	gou4de5zhao2
 (夠 不 上)	gou4bu5shang4
-(夠 不 ㊤)	gou4bu5shang4
 (夠 不 上)	gou4bu5shang4
-(夠 不 ㊤)	gou4bu5shang4
 (夠 得 上)	gou4de5shang4
-(夠 得 ㊤)	gou4de5shang4
 (夠 得 著)	gou4de5zhao2
 (夠 得 著)	gou4de5zhao2
 (大 不 了)	da4bu5liao3
@@ -68155,18 +65023,14 @@ $textmode
 (大 人 物)	da4ren2wu4
 (大 伙 儿)	da4huo3r5
 (大 体 上)	da4ti3shang5
-(大 体 ㊤)	da4ti3shang5
 (大 分 县)	da4fen4xian4
 (大 分 子)	da4fen1zi3
 (大 分 縣)	da4fen4xian4
 (大 女 儿)	da4nv3r5
-(大 ㊛ 儿)	da4nv3r5
 (大 女 儿)	da4nv3r5
 (大 女 兒)	da4nv3r5
-(大 ㊛ 兒)	da4nv3r5
 (大 女 兒)	da4nv3r5
 (大 学 生)	da4xue2sheng1
-(大 ㊫ 生)	da4xue2sheng1
 (大 學 生)	da4xue2sheng1
 (大 拇 指)	da4mu5zhi3
 (大 方 县)	da4fang1xian4
@@ -68176,16 +65040,13 @@ $textmode
 (大 融 爐)	rong2lu2da4
 (大 融 爐)	rong2lu2da4
 (大 西 国)	da4xi1guo2
-(大 🀂 国)	da4xi1guo2
 (大 西 國)	da4xi1guo2
-(大 🀂 國)	da4xi1guo2
 (大 部 份)	da4bu4fen5
 (大 都 会)	da4du1hui4
 (大 都 会)	da4du1hui4
 (大 都 會)	da4du1hui4
 (大 都 會)	da4du1hui4
 (大 體 上)	da4ti3shang5
-(大 體 ㊤)	da4ti3shang5
 (大 麥 地)	da4mai4di4
 (大 麦 地)	da4mai4di4
 (大 黃 蜂)	da4huang2feng1
@@ -68198,7 +65059,6 @@ $textmode
 (太 行 山)	tai4hang2shan1
 (太 行 山)	tai4hang2shan1
 (头 一 摸)	tou2yi4mo1
-(头 ㊀ 摸)	tou2yi4mo1
 (头 脸 儿)	tou2lian3r5
 (夹 塞 儿)	jia1sai1r5
 (夹 塞 儿)	jia1sai1r5
@@ -68249,23 +65109,15 @@ $textmode
 (奪 不 過)	duo2bu5guo4
 (奪 不 過)	duo2bu5guo4
 (女 孩 儿)	nv3hai2r5
-(㊛ 孩 儿)	nv3hai2r5
 (女 孩 儿)	nv3hai2r5
 (女 舍 监)	nv3she4jian1
-(㊛ 舍 监)	nv3she4jian1
 (女 舍 监)	nv3she4jian1
 (女 舍 監)	nv3she4jian1
-(女 舍 ㊬)	nv3she4jian1
-(㊛ 舍 監)	nv3she4jian1
 (女 舍 監)	nv3she4jian1
-(女 舍 ㊬)	nv3she4jian1
 (奴 兒 干)	nu2er2gan1
 (奶 嘴 儿)	nai3zui3r5
 (她 得 上)	ta1de2shang4
-(她 得 ㊤)	ta1de2shang4
 (她 得 中)	ta1de2zhong4
-(她 得 🀄)	ta1de2zhong4
-(她 得 ㊥)	ta1de2zhong4
 (她 得 主)	ta1de2zhu3
 (她 得 了)	ta1de2le5
 (她 得 了)	ta1de2le5
@@ -68290,7 +65142,6 @@ $textmode
 (她 得 勝)	ta1de2sheng4
 (她 得 勢)	ta1de2shi4
 (她 得 名)	ta1de2ming2
-(她 得 ㊔)	ta1de2ming2
 (她 得 君)	ta1de2jun1
 (她 得 听)	ta1de2ting1
 (她 得 味)	ta1de2wei4
@@ -68382,9 +65233,7 @@ $textmode
 (她 得 非)	ta1de2fei1
 (她 得 體)	ta1de2ti3
 (好 一 个)	hao3yi2ge4
-(好 ㊀ 个)	hao3yi2ge4
 (好 一 個)	hao3yi2ge4
-(好 ㊀ 個)	hao3yi2ge4
 (好 不 了)	hao3bu5liao3
 (好 不 了)	hao3bu5liao3
 (好 不 了)	hao3bu5liao3
@@ -68397,13 +65246,10 @@ $textmode
 (好 玩 儿)	hao3wan2er5
 (好 玩 兒)	hao3wan2er5
 (如 一 日)	ru2yi2ri4
-(如 ㊀ 日)	ru2yi2ri4
-(如 一 ㊐)	ru2yi2ri4
 (委 员 长)	wei3yuan2zhang3
 (委 員 長)	wei3yuan2zhang3
 (姜 子 牙)	jiang1zi3ya2
 (姪 女 婿)	zhi2nv3xu5
-(姪 ㊛ 婿)	zhi2nv3xu5
 (姪 女 婿)	zhi2nv3xu5
 (婆 囉 洲)	po2luo2zhou1
 (媳 妇 儿)	xi2fu5r5
@@ -68423,7 +65269,6 @@ $textmode
 (孔 丛 子)	kong3cong2zi3
 (孔 叢 子)	kong3cong2zi3
 (孙 女 儿)	sun1nv3r5
-(孙 ㊛ 儿)	sun1nv3r5
 (孙 女 儿)	sun1nv3r5
 (孙 武 子)	sun1wu3zi3
 (孙 逸 仙)	sun1yi4xian1
@@ -68434,19 +65279,12 @@ $textmode
 (孤 零 零)	gu1ling1ling1
 (孤 零 零)	gu1ling1ling1
 (学 不 了)	xue2bu5liao3
-(㊫ 不 了)	xue2bu5liao3
 (学 不 了)	xue2bu5liao3
-(㊫ 不 了)	xue2bu5liao3
 (学 不 了)	xue2bu5liao3
-(㊫ 不 了)	xue2bu5liao3
 (学 不 会)	xue2bu5hui4
-(㊫ 不 会)	xue2bu5hui4
 (学 不 会)	xue2bu5hui4
-(㊫ 不 会)	xue2bu5hui4
 (学 不 来)	xue2bu5lai2
-(㊫ 不 来)	xue2bu5lai2
 (学 不 来)	xue2bu5lai2
-(㊫ 不 来)	xue2bu5lai2
 (孫 武 子)	sun1wu3zi3
 (孫 逸 仙)	sun1yi4xian1
 (孫 逸 仙)	sun1yi4xian1
@@ -68463,9 +65301,7 @@ $textmode
 (守 不 住)	shou3bu5zhu4
 (守 空 房)	shou3kong4fang2
 (安 不 下)	an1bu5xia4
-(安 不 ㊦)	an1bu5xia4
 (安 不 下)	an1bu5xia4
-(安 不 ㊦)	an1bu5xia4
 (安 地 斯)	an1di4si1
 (宋 楚 瑜)	song4chu3yu2
 (完 不 了)	wan2bu5liao3
@@ -68478,11 +65314,8 @@ $textmode
 (官 老 爺)	guan1lao3ye2
 (官 老 爺)	guan1lao3ye2
 (定 下 來)	ding4xia4lai2
-(定 ㊦ 來)	ding4xia4lai2
 (定 下 來)	ding4xia4lai2
-(定 ㊦ 來)	ding4xia4lai2
 (定 下 来)	ding4xia4lai2
-(定 ㊦ 来)	ding4xia4lai2
 (定 场 白)	ding4chang2bai2
 (定 場 白)	ding4chang2bai2
 (宝 生 佛)	bao3sheng1fo2
@@ -68490,7 +65323,6 @@ $textmode
 (宝 贝 儿)	bao3bei4r5
 (实 分 析)	shi2fen1xi1
 (实 际 上)	shi2ji4shang5
-(实 际 ㊤)	shi2ji4shang5
 (审 判 长)	shen3pan4zhang3
 (审 计 长)	shen3ji4zhang3
 (室 內 樂)	shi4nei4yue4
@@ -68502,9 +65334,7 @@ $textmode
 (害 不 了)	hai4bu5liao3
 (害 不 了)	hai4bu5liao3
 (容 不 下)	rong2bu5xia4
-(容 不 ㊦)	rong2bu5xia4
 (容 不 下)	rong2bu5xia4
-(容 不 ㊦)	rong2bu5xia4
 (容 不 开)	rong2bu5kai1
 (容 不 开)	rong2bu5kai1
 (容 不 得)	rong2bu5de2
@@ -68514,28 +65344,19 @@ $textmode
 (寄 存 处)	ji4cun2chu3
 (寄 存 處)	ji4cun2chu3
 (密 西 莱)	mi4xi1lai2
-(密 🀂 莱)	mi4xi1lai2
 (密 西 萊)	mi4xi1lai2
-(密 🀂 萊)	mi4xi1lai2
 (察 合 台)	cha2ge3tai2
 (察 合 臺)	cha2ge3tai2
 (實 分 析)	shi2fen1xi1
 (實 際 上)	shi2ji4shang5
-(實 際 ㊤)	shi2ji4shang5
 (審 判 長)	shen3pan4zhang3
 (審 計 長)	shen3ji4zhang3
 (寫 下 來)	xie3xia4lai2
-(寫 ㊦ 來)	xie3xia4lai2
 (寫 下 來)	xie3xia4lai2
-(寫 ㊦ 來)	xie3xia4lai2
 (寫 不 上)	xie3bu5shang4
-(寫 不 ㊤)	xie3bu5shang4
 (寫 不 上)	xie3bu5shang4
-(寫 不 ㊤)	xie3bu5shang4
 (寫 不 下)	xie3bu5xia4
-(寫 不 ㊦)	xie3bu5xia4
 (寫 不 下)	xie3bu5xia4
-(寫 不 ㊦)	xie3bu5xia4
 (寫 不 出)	xie3bu5chu1
 (寫 不 出)	xie3bu5chu1
 (寫 不 通)	xie3bu5tong1
@@ -68545,9 +65366,7 @@ $textmode
 (寶 生 佛)	bao3sheng1fo2
 (寶 石 匠)	bao3shi2jiang4
 (对 不 上)	dui4bu5shang4
-(对 不 ㊤)	dui4bu5shang4
 (对 不 上)	dui4bu5shang4
-(对 不 ㊤)	dui4bu5shang4
 (对 不 住)	dui4bu5zhu4
 (对 不 住)	dui4bu5zhu4
 (对 不 起)	dui4bu5qi3
@@ -68563,14 +65382,11 @@ $textmode
 (寻 不 着)	xun2bu5zhao2
 (寻 不 着)	xun2bu5zhao2
 (專 一 性)	zhuan1yi2xing4
-(專 ㊀ 性)	zhuan1yi2xing4
 (尋 不 著)	xun2bu5zhao2
 (尋 不 著)	xun2bu5zhao2
 (尋 不 著)	xun2bu5zhao2
 (對 不 上)	dui4bu5shang4
-(對 不 ㊤)	dui4bu5shang4
 (對 不 上)	dui4bu5shang4
-(對 不 ㊤)	dui4bu5shang4
 (對 不 住)	dui4bu5zhu4
 (對 不 住)	dui4bu5zhu4
 (對 不 起)	dui4bu5qi3
@@ -68583,11 +65399,9 @@ $textmode
 (小 不 點)	xiao3bu5dian3
 (小 不 點)	xiao3bu5dian3
 (小 女 兒)	xiao3nv3er2
-(小 ㊛ 兒)	xiao3nv3er2
 (小 女 兒)	xiao3nv3er2
 (小 妹 妹)	xiao3mei4mei4
 (小 学 生)	xiao3xue2sheng1
-(小 ㊫ 生)	xiao3xue2sheng1
 (小 孩 儿)	xiao3hai2r5
 (小 學 生)	xiao3xue2sheng1
 (小 指 头)	xiao3zhi3tou5
@@ -68611,7 +65425,6 @@ $textmode
 (少 得 了)	shao3de5liao3
 (少 得 了)	shao3de5liao3
 (尝 一 尝)	chang2yi4chang2
-(尝 ㊀ 尝)	chang2yi4chang2
 (尼 泊 尔)	ni2bo2er3
 (尼 泊 爾)	ni2bo2er3
 (尽 可 能)	jin3ke3neng2
@@ -68629,23 +65442,14 @@ $textmode
 (川 黨 參)	chuan1dang3shen1
 (川 黨 參)	chuan1dang3shen1
 (左 不 是)	zuo3bu5shi5
-(㊧ 不 是)	zuo3bu5shi5
 (左 不 是)	zuo3bu5shi5
-(㊧ 不 是)	zuo3bu5shi5
 (左 不 过)	zuo3bu5guo4
-(㊧ 不 过)	zuo3bu5guo4
 (左 不 过)	zuo3bu5guo4
-(㊧ 不 过)	zuo3bu5guo4
 (左 不 過)	zuo3bu5guo4
-(㊧ 不 過)	zuo3bu5guo4
 (左 不 過)	zuo3bu5guo4
-(㊧ 不 過)	zuo3bu5guo4
 (左 边 儿)	zuo3bian5r5
-(㊧ 边 儿)	zuo3bian5r5
 (差 一 点)	cha1yi4dian3
-(差 ㊀ 点)	cha1yi4dian3
 (差 一 點)	cha1yi4dian3
-(差 ㊀ 點)	cha1yi4dian3
 (差 不 了)	cha4bu5liao3
 (差 不 了)	cha4bu5liao3
 (差 不 了)	cha4bu5liao3
@@ -68722,7 +65526,6 @@ $textmode
 (巴 耶 稣)	ba1ye1su1
 (巴 耶 穌)	ba1ye1su1
 (巴 菲 特)	ba1fei1te4
-(巴 菲 ㊕)	ba1fei1te4
 (巴 頌 管)	ba1song4guan3
 (巴 颂 管)	ba1song4guan3
 (巴 馬 科)	ba1ma3ke1
@@ -68737,14 +65540,11 @@ $textmode
 (希 拉 裡)	xi1la1li3
 (希 拉 裡)	xi1la1li3
 (希 西 基)	xi1xi1ji1
-(希 🀂 基)	xi1xi1ji1
 (希 西 家)	xi1xi1jia1
-(希 🀂 家)	xi1xi1jia1
 (帕 罗 巴)	pa4luo2ba1
 (帕 羅 巴)	pa4luo2ba1
 (帕 羅 巴)	pa4luo2ba1
 (帖 木 兒)	tie1mu4er2
-(帖 ㊍ 兒)	tie1mu4er2
 (带 不 到)	dai4bu5dao5
 (带 不 到)	dai4bu5dao5
 (带 不 走)	dai4bu5zou3
@@ -68752,9 +65552,7 @@ $textmode
 (带 出 去)	dai4chu1qu4
 (帧 太 长)	zheng4tai4chang2
 (帮 不 上)	bang1bu5shang4
-(帮 不 ㊤)	bang1bu5shang4
 (帮 不 上)	bang1bu5shang4
-(帮 不 ㊤)	bang1bu5shang4
 (帶 不 到)	dai4bu5dao5
 (帶 不 到)	dai4bu5dao5
 (帶 不 走)	dai4bu5zou3
@@ -68762,13 +65560,9 @@ $textmode
 (帶 出 去)	dai4chu1qu4
 (幀 太 長)	zheng4tai4chang2
 (幫 不 上)	bang1bu5shang4
-(幫 不 ㊤)	bang1bu5shang4
 (幫 不 上)	bang1bu5shang4
-(幫 不 ㊤)	bang1bu5shang4
 (干 不 下)	gan4bu5xia4
-(干 不 ㊦)	gan4bu5xia4
 (干 不 下)	gan4bu5xia4
-(干 不 ㊦)	gan4bu5xia4
 (干 不 了)	gan4bu5liao3
 (干 不 了)	gan4bu5liao3
 (干 不 了)	gan4bu5liao3
@@ -68794,9 +65588,7 @@ $textmode
 (平 安 裡)	ping2an1li3
 (幸 運 兒)	xing4yun4er2
 (幹 不 下)	gan4bu5xia4
-(幹 不 ㊦)	gan4bu5xia4
 (幹 不 下)	gan4bu5xia4
-(幹 不 ㊦)	gan4bu5xia4
 (幹 不 了)	gan4bu5liao3
 (幹 不 了)	gan4bu5liao3
 (幹 不 了)	gan4bu5liao3
@@ -68842,11 +65634,8 @@ $textmode
 (开 都 河)	kai1du1he2
 (开 都 河)	kai1du1he2
 (弄 不 下)	nong4bu5xia4
-(弄 不 ㊦)	nong4bu5xia4
 (弄 不 下)	nong4bu5xia4
-(弄 不 ㊦)	nong4bu5xia4
 (弄 不 下)	nong4bu5xia4
-(弄 不 ㊦)	nong4bu5xia4
 (弄 不 了)	nong4bu5liao3
 (弄 不 了)	nong4bu5liao3
 (弄 不 了)	nong4bu5liao3
@@ -68894,9 +65683,7 @@ $textmode
 (弄 不 過)	nong4bu5guo4
 (弄 不 過)	nong4bu5guo4
 (弄 得 上)	nong4de5shang4
-(弄 得 ㊤)	nong4de5shang4
 (弄 得 上)	nong4de5shang4
-(弄 得 ㊤)	nong4de5shang4
 (弄 明 白)	nong4ming2bai2
 (弄 明 白)	nong4ming2bai2
 (弓 弦 儿)	gong1xian2r5
@@ -68908,7 +65695,6 @@ $textmode
 (张 华 明)	zhang1hua2ming2
 (张 国 焘)	zhang1guo2tao1
 (张 学 友)	zhang1xue2you3
-(张 ㊫ 友)	zhang1xue2you3
 (弥 勒 佛)	mi2le4fo2
 (弥 勒 佛)	mi2le4fo2
 (張 僧 繇)	zhang1seng1you2
@@ -68954,7 +65740,6 @@ $textmode
 (得 便 宜)	de2pian2yi5
 (得 劲 儿)	de2jin4r5
 (得 天 下)	de2tian1xia4
-(得 天 ㊦)	de2tian1xia4
 (得 尔 塔)	dei3er3ta3
 (得 数 儿)	de2shu4r5
 (得 样 儿)	de2yang4r5
@@ -68972,7 +65757,6 @@ $textmode
 (循 都 姬)	xun2du1ji1
 (循 都 姬)	xun2du1ji1
 (心 上 人)	xin1shang4ren2
-(心 ㊤ 人)	xin1shang4ren2
 (心 眼 儿)	xin1yan3r5
 (心 窝 儿)	xin1wo1r5
 (心 脏 病)	xin1zang4bing4
@@ -68995,17 +65779,11 @@ $textmode
 (快 点 儿)	kuai4dian5r5
 (快 點 兒)	kuai4dian5r5
 (念 不 上)	nian4bu5shang4
-(念 不 ㊤)	nian4bu5shang4
 (念 不 上)	nian4bu5shang4
-(念 不 ㊤)	nian4bu5shang4
 (念 不 上)	nian4bu5shang4
-(念 不 ㊤)	nian4bu5shang4
 (念 不 下)	nian4bu5xia4
-(念 不 ㊦)	nian4bu5xia4
 (念 不 下)	nian4bu5xia4
-(念 不 ㊦)	nian4bu5xia4
 (念 不 下)	nian4bu5xia4
-(念 不 ㊦)	nian4bu5xia4
 (怎 見 得)	zen3jian4de2
 (怎 見 得)	zen3jian4de2
 (怎 见 得)	zen3jian4de2
@@ -69035,7 +65813,6 @@ $textmode
 (恶 势 力)	e4shi4li4
 (恶 势 力)	e4shi4li4
 (恶 名 儿)	e4ming2r5
-(恶 ㊔ 儿)	e4ming2r5
 (悄 悄 地)	qiao1qiao1de5
 (悶 不 住)	men4bu5zhu4
 (悶 不 住)	men4bu5zhu4
@@ -69049,7 +65826,6 @@ $textmode
 (惡 勢 力)	e4shi4li4
 (惡 勢 力)	e4shi4li4
 (想 一 想)	xiang3yi5xiang5
-(想 ㊀ 想)	xiang3yi5xiang5
 (想 不 出)	xiang3bu5chu1
 (想 不 出)	xiang3bu5chu1
 (想 不 到)	xiang3bu5dao4
@@ -69076,11 +65852,8 @@ $textmode
 (惹 不 起)	re3bu5qi3
 (慕 道 友)	mu4dao4you3
 (慢 下 來)	man4xia4lai2
-(慢 ㊦ 來)	man4xia4lai2
 (慢 下 來)	man4xia4lai2
-(慢 ㊦ 來)	man4xia4lai2
 (慢 下 来)	man4xia4lai2
-(慢 ㊦ 来)	man4xia4lai2
 (慢 腾 腾)	man4teng1teng1
 (慢 騰 騰)	man4teng1teng1
 (憋 不 住)	bie1bu5zhu4
@@ -69093,18 +65866,13 @@ $textmode
 (懶 洋 洋)	lan3yang1yang1
 (懶 洋 洋)	lan3yang1yang1
 (成 不 上)	cheng2bu5shang4
-(成 不 ㊤)	cheng2bu5shang4
 (成 不 上)	cheng2bu5shang4
-(成 不 ㊤)	cheng2bu5shang4
 (成 不 了)	cheng2bu5liao3
 (成 不 了)	cheng2bu5liao3
 (成 不 了)	cheng2bu5liao3
 (成 方 儿)	cheng2fang1r5
 (我 得 上)	wo3de2shang4
-(我 得 ㊤)	wo3de2shang4
 (我 得 中)	wo3de2zhong4
-(我 得 🀄)	wo3de2zhong4
-(我 得 ㊥)	wo3de2zhong4
 (我 得 主)	wo3de2zhu3
 (我 得 了)	wo3de2le5
 (我 得 了)	wo3de2le5
@@ -69129,7 +65897,6 @@ $textmode
 (我 得 勝)	wo3de2sheng4
 (我 得 勢)	wo3de2shi4
 (我 得 名)	wo3de2ming2
-(我 得 ㊔)	wo3de2ming2
 (我 得 君)	wo3de2jun1
 (我 得 听)	wo3de2ting1
 (我 得 味)	wo3de2wei4
@@ -69227,11 +65994,8 @@ $textmode
 (戳 不 住)	chuo1bu5zhu4
 (戳 不 住)	chuo1bu5zhu4
 (戴 不 上)	dai4bu5shang4
-(戴 不 ㊤)	dai4bu5shang4
 (戴 不 上)	dai4bu5shang4
-(戴 不 ㊤)	dai4bu5shang4
 (戴 不 上)	dai4bu5shang4
-(戴 不 ㊤)	dai4bu5shang4
 (所 在 地)	suo3zai4di4
 (手 不 稳)	shou3bu5wen3
 (手 不 稳)	shou3bu5wen3
@@ -69247,13 +66011,9 @@ $textmode
 (扒 头 儿)	ba1tou5r5
 (扒 頭 兒)	ba1tou5r5
 (打 下 來)	da3xia4lai2
-(打 ㊦ 來)	da3xia4lai2
 (打 下 來)	da3xia4lai2
-(打 ㊦ 來)	da3xia4lai2
 (打 下 去)	da3xia4qu4
-(打 ㊦ 去)	da3xia4qu4
 (打 下 来)	da3xia4lai2
-(打 ㊦ 来)	da3xia4lai2
 (打 不 了)	da3bu5liao3
 (打 不 了)	da3bu5liao3
 (打 不 了)	da3bu5liao3
@@ -69306,9 +66066,7 @@ $textmode
 (扯 不 動)	che3bu5dong4
 (扯 不 動)	che3bu5dong4
 (找 不 上)	zhao3bu5shang4
-(找 不 ㊤)	zhao3bu5shang4
 (找 不 上)	zhao3bu5shang4
-(找 不 ㊤)	zhao3bu5shang4
 (找 不 出)	zhao3bu5chu1
 (找 不 出)	zhao3bu5chu1
 (找 不 到)	zhao3bu5dao4
@@ -69337,17 +66095,12 @@ $textmode
 (承 重 孫)	cheng2zhong4sun1
 (抄 近 儿)	chao1jin4r5
 (把 手 上)	ba3shou3shang5
-(把 手 ㊤)	ba3shou3shang5
 (把 手 下)	ba3shou3xia4
-(把 手 ㊦)	ba3shou3xia4
 (把 手 中)	ba3shou3zhong1
-(把 手 🀄)	ba3shou3zhong1
-(把 手 ㊥)	ba3shou3zhong1
 (把 手 举)	ba3shou3ju3
 (把 手 冊)	ba3shou3ce4
 (把 手 册)	ba3shou3ce4
 (把 手 写)	ba3shou3xie3
-(把 手 ㊢)	ba3shou3xie3
 (把 手 动)	ba3shou3dong4
 (把 手 势)	ba3shou3shi4
 (把 手 動)	ba3shou3dong4
@@ -69445,9 +66198,7 @@ $textmode
 (折 過 兒)	zhe1guo4r5
 (护 发 素)	hu4fa4su4
 (报 不 下)	bao4bu5xia4
-(报 不 ㊦)	bao4bu5xia4
 (报 不 下)	bao4bu5xia4
-(报 不 ㊦)	bao4bu5xia4
 (报 务 员)	bao4wu4yuan2
 (抬 不 动)	tai2bu5dong4
 (抬 不 动)	tai2bu5dong4
@@ -69461,49 +66212,31 @@ $textmode
 (抱 佛 脚)	bao4fo2jiao3
 (抱 佛 腳)	bao4fo2jiao3
 (抵 不 上)	di3bu5shang4
-(抵 不 ㊤)	di3bu5shang4
 (抵 不 上)	di3bu5shang4
-(抵 不 ㊤)	di3bu5shang4
 (抵 不 了)	di3bu5liao3
 (抵 不 了)	di3bu5liao3
 (抵 不 了)	di3bu5liao3
 (抵 不 住)	di3bu5zhu4
 (抵 不 住)	di3bu5zhu4
 (抵 得 上)	di3de5shang4
-(抵 得 ㊤)	di3de5shang4
 (抹 不 下)	ma1bu5xia4
-(抹 不 ㊦)	ma1bu5xia4
 (抹 不 下)	ma1bu5xia4
-(抹 不 ㊦)	ma1bu5xia4
 (担 不 起)	dan1bu5qi3
 (担 不 起)	dan1bu5qi3
 (担 担 面)	dan4dan4mian4
 (拉 上 來)	la1shang4lai2
-(拉 ㊤ 來)	la1shang4lai2
 (拉 上 來)	la1shang4lai2
-(拉 ㊤ 來)	la1shang4lai2
 (拉 上 來)	la1shang4lai2
-(拉 ㊤ 來)	la1shang4lai2
 (拉 上 来)	la1shang4lai2
-(拉 ㊤ 来)	la1shang4lai2
 (拉 上 来)	la1shang4lai2
-(拉 ㊤ 来)	la1shang4lai2
 (拉 下 來)	la1xia4lai2
-(拉 ㊦ 來)	la1xia4lai2
 (拉 下 來)	la1xia4lai2
-(拉 ㊦ 來)	la1xia4lai2
 (拉 下 來)	la1xia4lai2
-(拉 ㊦ 來)	la1xia4lai2
 (拉 下 来)	la1xia4lai2
-(拉 ㊦ 来)	la1xia4lai2
 (拉 下 来)	la1xia4lai2
-(拉 ㊦ 来)	la1xia4lai2
 (拉 不 上)	la1bu5shang4
-(拉 不 ㊤)	la1bu5shang4
 (拉 不 上)	la1bu5shang4
-(拉 不 ㊤)	la1bu5shang4
 (拉 不 上)	la1bu5shang4
-(拉 不 ㊤)	la1bu5shang4
 (拉 不 动)	la1bu5dong4
 (拉 不 动)	la1bu5dong4
 (拉 不 动)	la1bu5dong4
@@ -69574,9 +66307,7 @@ $textmode
 (拾 起 来)	shi2qi3lai5
 (拾 起 来)	shi2qi3lai5
 (拿 不 上)	na2bu5shang4
-(拿 不 ㊤)	na2bu5shang4
 (拿 不 上)	na2bu5shang4
-(拿 不 ㊤)	na2bu5shang4
 (拿 不 了)	na2bu5liao3
 (拿 不 了)	na2bu5liao3
 (拿 不 了)	na2bu5liao3
@@ -69613,13 +66344,9 @@ $textmode
 (拿 起 來)	na2qi3lai5
 (拿 起 来)	na2qi3lai5
 (挂 不 上)	gua4bu5shang4
-(挂 不 ㊤)	gua4bu5shang4
 (挂 不 上)	gua4bu5shang4
-(挂 不 ㊤)	gua4bu5shang4
 (挂 不 下)	gua4bu5xia4
-(挂 不 ㊦)	gua4bu5xia4
 (挂 不 下)	gua4bu5xia4
-(挂 不 ㊦)	gua4bu5xia4
 (挂 不 住)	gua4bu5zhu4
 (挂 不 住)	gua4bu5zhu4
 (挂 起 来)	gua4qi3lai5
@@ -69628,9 +66355,7 @@ $textmode
 (挎 兜 儿)	kua4dou1er5
 (挎 兜 兒)	kua4dou1er5
 (挑 不 上)	tiao1bu5shang4
-(挑 不 ㊤)	tiao1bu5shang4
 (挑 不 上)	tiao1bu5shang4
-(挑 不 ㊤)	tiao1bu5shang4
 (挑 不 动)	tiao1bu5dong4
 (挑 不 动)	tiao1bu5dong4
 (挑 不 動)	tiao1bu5dong4
@@ -69644,9 +66369,7 @@ $textmode
 (挡 不 住)	dang3bu5zhu4
 (挡 不 住)	dang3bu5zhu4
 (挣 不 上)	zheng4bu5shang4
-(挣 不 ㊤)	zheng4bu5shang4
 (挣 不 上)	zheng4bu5shang4
-(挣 不 ㊤)	zheng4bu5shang4
 (挣 不 了)	zheng4bu5liao3
 (挣 不 了)	zheng4bu5liao3
 (挣 不 了)	zheng4bu5liao3
@@ -69654,13 +66377,9 @@ $textmode
 (挣 不 着)	zheng4bu5zhao2
 (挣 不 着)	zheng4bu5zhao2
 (挤 不 上)	ji3bu5shang4
-(挤 不 ㊤)	ji3bu5shang4
 (挤 不 上)	ji3bu5shang4
-(挤 不 ㊤)	ji3bu5shang4
 (挤 不 下)	ji3bu5xia4
-(挤 不 ㊦)	ji3bu5xia4
 (挤 不 下)	ji3bu5xia4
-(挤 不 ㊦)	ji3bu5xia4
 (挤 不 动)	ji3bu5dong4
 (挤 不 动)	ji3bu5dong4
 (挤 不 开)	ji3bu5kai1
@@ -69668,9 +66387,7 @@ $textmode
 (挤 不 进)	ji3bu5jin4
 (挤 不 进)	ji3bu5jin4
 (挨 不 上)	ai1bu5shang4
-(挨 不 ㊤)	ai1bu5shang4
 (挨 不 上)	ai1bu5shang4
-(挨 不 ㊤)	ai1bu5shang4
 (挨 不 得)	ai1bu5de5
 (挨 不 得)	ai1bu5de5
 (挨 呲 儿)	ai1ci1r5
@@ -69699,7 +66416,6 @@ $textmode
 (捆 起 來)	kun3qi3lai5
 (捆 起 来)	kun3qi3lai5
 (捞 一 票)	lao1yi2piao4
-(捞 ㊀ 票)	lao1yi2piao4
 (捡 得 着)	jian3de5zhao2
 (捡 得 着)	jian3de5zhao2
 (换 不 出)	huan4bu5chu1
@@ -69719,13 +66435,9 @@ $textmode
 (掃 不 清)	sao3bu5qing1
 (掃 不 清)	sao3bu5qing1
 (掉 下 來)	diao4xia4lai2
-(掉 ㊦ 來)	diao4xia4lai2
 (掉 下 來)	diao4xia4lai2
-(掉 ㊦ 來)	diao4xia4lai2
 (掉 下 去)	diao4xia4qu4
-(掉 ㊦ 去)	diao4xia4qu4
 (掉 下 来)	diao4xia4lai2
-(掉 ㊦ 来)	diao4xia4lai2
 (掉 价 儿)	diao4jia4r5
 (掌 不 了)	zhang3bu5liao3
 (掌 不 了)	zhang3bu5liao3
@@ -69734,9 +66446,7 @@ $textmode
 (掏 出 來)	tao1chu1lai2
 (掏 出 来)	tao1chu1lai2
 (掙 不 上)	zheng4bu5shang4
-(掙 不 ㊤)	zheng4bu5shang4
 (掙 不 上)	zheng4bu5shang4
-(掙 不 ㊤)	zheng4bu5shang4
 (掙 不 了)	zheng4bu5liao3
 (掙 不 了)	zheng4bu5liao3
 (掙 不 了)	zheng4bu5liao3
@@ -69744,13 +66454,9 @@ $textmode
 (掙 不 著)	zheng4bu5zhao2
 (掙 不 著)	zheng4bu5zhao2
 (掛 不 上)	gua4bu5shang4
-(掛 不 ㊤)	gua4bu5shang4
 (掛 不 上)	gua4bu5shang4
-(掛 不 ㊤)	gua4bu5shang4
 (掛 不 下)	gua4bu5xia4
-(掛 不 ㊦)	gua4bu5xia4
 (掛 不 下)	gua4bu5xia4
-(掛 不 ㊦)	gua4bu5xia4
 (掛 不 住)	gua4bu5zhu4
 (掛 不 住)	gua4bu5zhu4
 (掛 起 來)	gua4qi3lai5
@@ -69761,17 +66467,11 @@ $textmode
 (探 不 见)	tan4bu5jian4
 (探 不 见)	tan4bu5jian4
 (接 上 去)	jie1shang4qu4
-(接 ㊤ 去)	jie1shang4qu4
 (接 下 來)	jie1xia4lai2
-(接 ㊦ 來)	jie1xia4lai2
 (接 下 來)	jie1xia4lai2
-(接 ㊦ 來)	jie1xia4lai2
 (接 下 来)	jie1xia4lai2
-(接 ㊦ 来)	jie1xia4lai2
 (接 不 上)	jie1bu5shang4
-(接 不 ㊤)	jie1bu5shang4
 (接 不 上)	jie1bu5shang4
-(接 不 ㊤)	jie1bu5shang4
 (接 納 為)	jie1na4wei2
 (接 纳 为)	jie1na4wei2
 (控 制 杆)	kong4zhi4gan3
@@ -69804,9 +66504,7 @@ $textmode
 (提 葫 蘆)	ti2hu2lu2
 (提 葫 蘆)	ti2hu2lu2
 (插 一 脚)	cha1yi4jiao3
-(插 ㊀ 脚)	cha1yi4jiao3
 (插 一 腳)	cha1yi4jiao3
-(插 ㊀ 腳)	cha1yi4jiao3
 (揚 子 江)	yang2zi3jiang1
 (換 不 出)	huan4bu5chu1
 (換 不 出)	huan4bu5chu1
@@ -69815,11 +66513,8 @@ $textmode
 (搀 不 到)	chan1bu5dao4
 (搀 不 到)	chan1bu5dao4
 (搁 下 来)	ge1xia4lai2
-(搁 ㊦ 来)	ge1xia4lai2
 (搁 不 下)	ge1bu5xia4
-(搁 不 ㊦)	ge1bu5xia4
 (搁 不 下)	ge1bu5xia4
-(搁 不 ㊦)	ge1bu5xia4
 (搁 不 住)	ge1bu5zhu4
 (搁 不 住)	ge1bu5zhu4
 (搁 得 住)	ge2de5zhu4
@@ -69832,18 +66527,14 @@ $textmode
 (搬 不 倒)	ban1bu5dao3
 (搬 不 倒)	ban1bu5dao3
 (搭 不 上)	da1bu5shang4
-(搭 不 ㊤)	da1bu5shang4
 (搭 不 上)	da1bu5shang4
-(搭 不 ㊤)	da1bu5shang4
 (搭 茬 儿)	da2cha2r5
 (搭 茬 兒)	da2cha2r5
 (摁 釦 儿)	en4kou4er5
 (摁 釦 兒)	en4kou4er5
 (摁 钉 儿)	en4ding1r5
 (摆 不 下)	bai3bu5xia4
-(摆 不 ㊦)	bai3bu5xia4
 (摆 不 下)	bai3bu5xia4
-(摆 不 ㊦)	bai3bu5xia4
 (摆 不 了)	bai3bu5liao3
 (摆 不 了)	bai3bu5liao3
 (摆 不 了)	bai3bu5liao3
@@ -69856,11 +66547,8 @@ $textmode
 (摔 不 掉)	shuai1bu5diao4
 (摔 不 掉)	shuai1bu5diao4
 (摘 下 來)	zhai1xia4lai2
-(摘 ㊦ 來)	zhai1xia4lai2
 (摘 下 來)	zhai1xia4lai2
-(摘 ㊦ 來)	zhai1xia4lai2
 (摘 下 来)	zhai1xia4lai2
-(摘 ㊦ 来)	zhai1xia4lai2
 (摘 不 去)	zhai1bu5qu4
 (摘 不 去)	zhai1bu5qu4
 (摸 不 清)	mo1bu5qing1
@@ -69874,9 +66562,7 @@ $textmode
 (摸 不 透)	mo1bu5tou4
 (摸 不 透)	mo1bu5tou4
 (摹 扎 特)	mo2za1te4
-(摹 扎 ㊕)	mo2za1te4
 (撈 一 票)	lao1yi2piao4
-(撈 ㊀ 票)	lao1yi2piao4
 (撐 不 住)	cheng1bu5zhu4
 (撐 不 住)	cheng1bu5zhu4
 (撐 得 慌)	cheng1de5huang5
@@ -69891,11 +66577,7 @@ $textmode
 (撒 哈 拉)	sa1ha1la1
 (撒 布 得)	sa1bu4de2
 (撒 西 金)	sa1xi1jin1
-(撒 🀂 金)	sa1xi1jin1
-(撒 西 ㊎)	sa1xi1jin1
-(撒 🀂 ㊎)	sa1xi1jin1
 (撒 西 金)	sa1xi1jin1
-(撒 🀂 金)	sa1xi1jin1
 (撒 非 喇)	sa1fei1la1
 (撒 非 喇)	sa1fei1la1
 (撤 旦 教)	che4dan4jiao1
@@ -69924,13 +66606,9 @@ $textmode
 (擔 不 起)	dan1bu5qi3
 (擔 擔 麵)	dan4dan4mian4
 (擠 不 上)	ji3bu5shang4
-(擠 不 ㊤)	ji3bu5shang4
 (擠 不 上)	ji3bu5shang4
-(擠 不 ㊤)	ji3bu5shang4
 (擠 不 下)	ji3bu5xia4
-(擠 不 ㊦)	ji3bu5xia4
 (擠 不 下)	ji3bu5xia4
-(擠 不 ㊦)	ji3bu5xia4
 (擠 不 動)	ji3bu5dong4
 (擠 不 動)	ji3bu5dong4
 (擠 不 進)	ji3bu5jin4
@@ -69941,29 +66619,21 @@ $textmode
 (擰 不 過)	ning2bu5guo4
 (擰 不 過)	ning2bu5guo4
 (擱 下 來)	ge1xia4lai2
-(擱 ㊦ 來)	ge1xia4lai2
 (擱 下 來)	ge1xia4lai2
-(擱 ㊦ 來)	ge1xia4lai2
 (擱 不 下)	ge1bu5xia4
-(擱 不 ㊦)	ge1bu5xia4
 (擱 不 下)	ge1bu5xia4
-(擱 不 ㊦)	ge1bu5xia4
 (擱 不 住)	ge1bu5zhu4
 (擱 不 住)	ge1bu5zhu4
 (擱 得 住)	ge2de5zhu4
 (擺 不 下)	bai3bu5xia4
-(擺 不 ㊦)	bai3bu5xia4
 (擺 不 下)	bai3bu5xia4
-(擺 不 ㊦)	bai3bu5xia4
 (擺 不 了)	bai3bu5liao3
 (擺 不 了)	bai3bu5liao3
 (擺 不 了)	bai3bu5liao3
 (擺 地 攤)	bai3di4tan1
 (擺 設 兒)	bai3she4er5
 (攀 不 上)	pan1bu5shang4
-(攀 不 ㊤)	pan1bu5shang4
 (攀 不 上)	pan1bu5shang4
-(攀 不 ㊤)	pan1bu5shang4
 (攆 不 掉)	nian3bu5diao4
 (攆 不 掉)	nian3bu5diao4
 (攆 不 開)	nian3bu5kai1
@@ -69986,13 +66656,9 @@ $textmode
 (改 不 過)	gai3bu5guo4
 (改 不 過)	gai3bu5guo4
 (放 一 码)	fang4yi4ma3
-(放 ㊀ 码)	fang4yi4ma3
 (放 一 碼)	fang4yi4ma3
-(放 ㊀ 碼)	fang4yi4ma3
 (放 不 下)	fang4bu5xia4
-(放 不 ㊦)	fang4bu5xia4
 (放 不 下)	fang4bu5xia4
-(放 不 ㊦)	fang4bu5xia4
 (放 出 來)	fang4chu1lai2
 (放 出 來)	fang4chu1lai2
 (放 出 来)	fang4chu1lai2
@@ -70031,11 +66697,8 @@ $textmode
 (散 座 儿)	san3zuo4er5
 (散 座 兒)	san3zuo4er5
 (数 一 数)	shu3yi4shu3
-(数 ㊀ 数)	shu3yi4shu3
 (数 不 上)	shu3bu5shang4
-(数 不 ㊤)	shu3bu5shang4
 (数 不 上)	shu3bu5shang4
-(数 不 ㊤)	shu3bu5shang4
 (数 不 了)	shu3bu5liao3
 (数 不 了)	shu3bu5liao3
 (数 不 了)	shu3bu5liao3
@@ -70051,7 +66714,6 @@ $textmode
 (数 不 过)	shu3bu5guo4
 (数 不 过)	shu3bu5guo4
 (数 得 上)	shu3de5shang4
-(数 得 ㊤)	shu3de5shang4
 (数 得 着)	shu3de5zhao2
 (数 得 着)	shu3de5zhao2
 (敵 不 了)	di2bu5liao3
@@ -70062,15 +66724,10 @@ $textmode
 (敵 不 過)	di2bu5guo4
 (敵 不 過)	di2bu5guo4
 (數 一 數)	shu3yi4shu3
-(數 ㊀ 數)	shu3yi4shu3
 (數 一 數)	shu3yi4shu3
-(數 ㊀ 數)	shu3yi4shu3
 (數 不 上)	shu3bu5shang4
-(數 不 ㊤)	shu3bu5shang4
 (數 不 上)	shu3bu5shang4
-(數 不 ㊤)	shu3bu5shang4
 (數 不 上)	shu3bu5shang4
-(數 不 ㊤)	shu3bu5shang4
 (數 不 了)	shu3bu5liao3
 (數 不 了)	shu3bu5liao3
 (數 不 了)	shu3bu5liao3
@@ -70092,9 +66749,7 @@ $textmode
 (數 不 過)	shu3bu5guo4
 (數 不 過)	shu3bu5guo4
 (數 得 上)	shu3de5shang4
-(數 得 ㊤)	shu3de5shang4
 (數 得 上)	shu3de5shang4
-(數 得 ㊤)	shu3de5shang4
 (數 得 著)	shu3de5zhao2
 (數 得 著)	shu3de5zhao2
 (數 得 著)	shu3de5zhao2
@@ -70104,9 +66759,7 @@ $textmode
 (斗 不 过)	dou4bu5guo4
 (斗 不 过)	dou4bu5guo4
 (斗 南 鎮)	dou3nan2zhen4
-(斗 🀁 鎮)	dou3nan2zhen4
 (斗 南 镇)	dou3nan2zhen4
-(斗 🀁 镇)	dou3nan2zhen4
 (斗 趣 儿)	dou4qu4r5
 (料 不 到)	liao4bu5dao4
 (料 不 到)	liao4bu5dao4
@@ -70121,7 +66774,6 @@ $textmode
 (斯 巴 达)	si1ba1da2
 (斯 巴 達)	si1ba1da2
 (斯 旺 西)	si1wang4xi1
-(斯 旺 🀂)	si1wang4xi1
 (斯 賓 塞)	si1bin1se4
 (斯 賓 塞)	si1bin1se4
 (斯 賓 塞)	si1bin1se4
@@ -70129,11 +66781,8 @@ $textmode
 (新 埔 镇)	xin1bu4zhen4
 (新 生 兒)	xin1sheng1er2
 (新 西 兰)	xin1xi1lan2
-(新 🀂 兰)	xin1xi1lan2
 (新 西 蘭)	xin1xi1lan2
-(新 🀂 蘭)	xin1xi1lan2
 (新 西 蘭)	xin1xi1lan2
-(新 🀂 蘭)	xin1xi1lan2
 (斷 不 了)	duan4bu5liao3
 (斷 不 了)	duan4bu5liao3
 (斷 不 了)	duan4bu5liao3
@@ -70151,7 +66800,6 @@ $textmode
 (星 巴 克)	xing1ba1ke4
 (星 巴 剋)	xing1ba1ke4
 (星 相 学)	xing1xiang4xue2
-(星 相 ㊫)	xing1xiang4xue2
 (星 相 學)	xing1xiang4xue2
 (星 相 师)	xing1xiang4shi1
 (星 相 師)	xing1xiang4shi1
@@ -70165,9 +66813,7 @@ $textmode
 (晒 不 透)	shai4bu5tou4
 (晕 高 儿)	yun4gao1r5
 (晚 上 好)	wan3shang4hao3
-(晚 ㊤ 好)	wan3shang4hao3
 (晾 一 晾)	liang4yi5liang4
-(晾 ㊀ 晾)	liang4yi5liang4
 (暈 高 兒)	yun4gao1r5
 (暈 高 兒)	yun4gao1r5
 (暗 地 里)	an4di4li5
@@ -70202,54 +66848,29 @@ $textmode
 (會 裡 縣)	hui4li3xian4
 (會 裡 縣)	hui4li3xian4
 (有 助 於)	you3zhu4yu2
-(㊒ 助 於)	you3zhu4yu2
 (有 势 力)	you3shi4li4
-(㊒ 势 力)	you3shi4li4
 (有 势 力)	you3shi4li4
-(㊒ 势 力)	you3shi4li4
 (有 勢 力)	you3shi4li4
-(㊒ 勢 力)	you3shi4li4
 (有 勢 力)	you3shi4li4
-(㊒ 勢 力)	you3shi4li4
 (有 好 处)	you3hao3chu4
-(㊒ 好 处)	you3hao3chu4
 (有 好 處)	you3hao3chu4
-(㊒ 好 處)	you3hao3chu4
 (有 学 问)	you3xue2wen4
-(有 ㊫ 问)	you3xue2wen4
-(㊒ 学 问)	you3xue2wen4
 (有 學 問)	you3xue2wen4
-(㊒ 學 問)	you3xue2wen4
 (有 年 头)	you3nian2tou5
-(㊒ 年 头)	you3nian2tou5
 (有 年 头)	you3nian2tou5
-(㊒ 年 头)	you3nian2tou5
 (有 年 頭)	you3nian2tou5
-(㊒ 年 頭)	you3nian2tou5
 (有 年 頭)	you3nian2tou5
-(㊒ 年 頭)	you3nian2tou5
 (有 志 气)	you3zhi4qi4
-(㊒ 志 气)	you3zhi4qi4
 (有 志 氣)	you3zhi4qi4
-(㊒ 志 氣)	you3zhi4qi4
 (有 点 儿)	you3dian3r5
-(㊒ 点 儿)	you3dian3r5
 (有 眉 目)	you3mei2mu4
-(㊒ 眉 目)	you3mei2mu4
 (有 見 識)	you3jian4shi2
-(㊒ 見 識)	you3jian4shi2
 (有 見 識)	you3jian4shi2
-(㊒ 見 識)	you3jian4shi2
 (有 見 識)	you3jian4shi2
-(㊒ 見 識)	you3jian4shi2
 (有 见 识)	you3jian4shi2
-(㊒ 见 识)	you3jian4shi2
 (有 賴 於)	you3lai4yu2
-(㊒ 賴 於)	you3lai4yu2
 (有 道 理)	you3dao4li3
-(㊒ 道 理)	you3dao4li3
 (有 道 理)	you3dao4li3
-(㊒ 道 理)	you3dao4li3
 (望 不 到)	wang4bu5dao4
 (望 不 到)	wang4bu5dao4
 (望 不 到)	wang4bu5dao4
@@ -70265,9 +66886,7 @@ $textmode
 (望 夫 石)	wang4fu1shi2
 (望 夫 石)	wang4fu1shi2
 (木 子 美)	mu4zi3mei3
-(㊍ 子 美)	mu4zi3mei3
 (木 棉 花)	mu4mian2hua1
-(㊍ 棉 花)	mu4mian2hua1
 (未 婚 夫)	wei4hun1fu1
 (未 成 冠)	wei4cheng2guan1
 (未 見 得)	wei4jian4de2
@@ -70298,11 +66917,8 @@ $textmode
 (来 不 得)	lai2bu5de5
 (来 不 得)	lai2bu5de5
 (来 火 儿)	lai2huo3r5
-(来 ㊋ 儿)	lai2huo3r5
 (杨 家 将)	yang2jia1jiang4
 (杨 澄 中)	yang2cheng2zhong1
-(杨 澄 🀄)	yang2cheng2zhong1
-(杨 澄 ㊥)	yang2cheng2zhong1
 (杰 佛 兹)	jie2fo2zi1
 (東 邊 兒)	dong1bian1r5
 (松 巴 哇)	song1ba1wa1
@@ -70348,19 +66964,12 @@ $textmode
 (桔 黃 色)	jie2huang2se4
 (桔 黄 色)	jie2huang2se4
 (梅 西 叶)	mei2xi1ye4
-(梅 🀂 叶)	mei2xi1ye4
 (梅 西 叶)	mei2xi1ye4
-(梅 🀂 叶)	mei2xi1ye4
 (梅 西 耶)	mei2xi1ye1
-(梅 🀂 耶)	mei2xi1ye1
 (梅 西 耶)	mei2xi1ye1
-(梅 🀂 耶)	mei2xi1ye1
 (梅 西 葉)	mei2xi1ye4
-(梅 🀂 葉)	mei2xi1ye4
 (梅 西 葉)	mei2xi1ye4
-(梅 🀂 葉)	mei2xi1ye4
 (梅 西 葉)	mei2xi1ye4
-(梅 🀂 葉)	mei2xi1ye4
 (棒 棒 糖)	bang4bang5tang2
 (棒 棒 糖)	bang4bang5tang2
 (棲 息 地)	qi1xi1di4
@@ -70368,8 +66977,6 @@ $textmode
 (椎 间 盘)	zhui1jian1pan2
 (楊 家 將)	yang2jia1jiang4
 (楊 澄 中)	yang2cheng2zhong1
-(楊 澄 🀄)	yang2cheng2zhong1
-(楊 澄 ㊥)	yang2cheng2zhong1
 (楚 庄 王)	chu3zhuang1wang2
 (楚 莊 王)	chu3zhuang1wang2
 (楞 子 眼)	leng2zi5yan3
@@ -70384,7 +66991,6 @@ $textmode
 (樂 學 者)	yue4xue2zhe3
 (標 準 差)	biao1zhun3cha1
 (模 特 儿)	mo2te4r5
-(模 ㊕ 儿)	mo2te4r5
 (横 桁 帆)	heng2heng2fan1
 (横 结 肠)	heng2jie1chang2
 (機 務 段)	ji1wu4duan4
@@ -70393,17 +66999,12 @@ $textmode
 (欣 嫩 子)	xin1nen4zi3
 (欧 米 伽)	ou1mi3ga1
 (歇 一 会)	xie1yi4hui3
-(歇 ㊀ 会)	xie1yi4hui3
 (歇 一 會)	xie1yi4hui3
-(歇 ㊀ 會)	xie1yi4hui3
 (歌 仔 戏)	ge1zai3xi4
 (歌 仔 戲)	ge1zai3xi4
 (歌 罗 西)	ge1luo2xi1
-(歌 罗 🀂)	ge1luo2xi1
 (歌 羅 西)	ge1luo2xi1
-(歌 羅 🀂)	ge1luo2xi1
 (歌 羅 西)	ge1luo2xi1
-(歌 羅 🀂)	ge1luo2xi1
 (歐 米 伽)	ou1mi3ga1
 (止 不 了)	zhi3bu5liao3
 (止 不 了)	zhi3bu5liao3
@@ -70412,21 +67013,14 @@ $textmode
 (止 不 住)	zhi3bu5zhu4
 (止 疼 片)	zhi3teng2pian1
 (正 仓 院)	zheng1cang1yuan4
-(㊣ 仓 院)	zheng1cang1yuan4
 (正 倉 院)	zheng1cang1yuan4
-(㊣ 倉 院)	zheng1cang1yuan4
 (正 当 性)	zheng4dang4xing4
-(㊣ 当 性)	zheng4dang4xing4
 (正 當 性)	zheng4dang4xing4
-(㊣ 當 性)	zheng4dang4xing4
 (武 仙 座)	wu3xian1zuo4
 (武 打 片)	wu3da3pian1
 (歪 一 歪)	wai1yi5wai1
-(歪 ㊀ 歪)	wai1yi5wai1
 (歷 史 上)	li4shi3shang5
-(歷 史 ㊤)	li4shi3shang5
 (歷 史 上)	li4shi3shang5
-(歷 史 ㊤)	li4shi3shang5
 (歸 咎 於)	gui1jiu4yu2
 (死 不 了)	si3bu5liao3
 (死 不 了)	si3bu5liao3
@@ -70447,7 +67041,6 @@ $textmode
 (殘 疾 兒)	can2ji5er2
 (母 亲 节)	mu3qin1jie2
 (母 夜 叉)	mu3ye4cha1
-(母 ㊰ 叉)	mu3ye4cha1
 (母 親 節)	mu3qin1jie2
 (母 親 節)	mu3qin1jie2
 (母 親 節)	mu3qin1jie2
@@ -70456,42 +67049,31 @@ $textmode
 (毒 不 過)	du2bu5guo4
 (毒 不 過)	du2bu5guo4
 (比 一 比)	bi3yi5bi3
-(比 ㊀ 比)	bi3yi5bi3
 (比 不 上)	bi3bu5shang4
-(比 不 ㊤)	bi3bu5shang4
 (比 不 上)	bi3bu5shang4
-(比 不 ㊤)	bi3bu5shang4
 (比 不 得)	bi3bu5de2
 (比 不 得)	bi3bu5de2
 (比 得 上)	bi3de5shang4
-(比 得 ㊤)	bi3de5shang4
 (比 斯 巴)	bi3si1ba1
 (比 桿 賽)	bi3gan1sai4
 (比 較 少)	bi3jiao3shao3
 (比 较 少)	bi3jiao3shao3
 (毕 宿 五)	bi4xiu4wu3
-(毕 宿 ㊄)	bi4xiu4wu3
 (毛 哔 叽)	mao2bi4ji5
 (毛 嗶 嘰)	mao2bi4ji5
 (气 不 忿)	qi4bu5fen4
 (气 不 忿)	qi4bu5fen4
 (气 头 上)	qi4tou2shang5
-(气 头 ㊤)	qi4tou2shang5
 (氣 不 忿)	qi4bu5fen4
 (氣 不 忿)	qi4bu5fen4
 (氣 頭 上)	qi4tou2shang5
-(氣 頭 ㊤)	qi4tou2shang5
 (氨 哮 素)	an1xiao4su4
 (水 浒 传)	shui3hu3zhuan4
-(㊌ 浒 传)	shui3hu3zhuan4
 (水 滸 傳)	shui3hu3zhuan4
-(㊌ 滸 傳)	shui3hu3zhuan4
 (水 饺 儿)	shui3jiao3r5
-(㊌ 饺 儿)	shui3jiao3r5
 (汇 出 行)	hui4chu1hang2
 (汇 出 行)	hui4chu1hang2
 (沃 夫 西)	wo4fu1xi1
-(沃 夫 🀂)	wo4fu1xi1
 (沃 尔 夫)	wo4er3fu1
 (沃 爾 夫)	wo4er3fu1
 (沉 甸 甸)	chen2dian1dian1
@@ -70524,11 +67106,8 @@ $textmode
 (沿 条 儿)	yan2tiao2r5
 (沿 边 儿)	yan2bian1r5
 (法 律 上)	fa3lv4shang5
-(法 律 ㊤)	fa3lv4shang5
 (法 律 上)	fa3lv4shang5
-(法 律 ㊤)	fa3lv4shang5
 (法 西 斯)	fa3xi1si1
-(法 🀂 斯)	fa3xi1si1
 (法 論 功)	fa3lun2gong1
 (法 論 功)	fa3lun2gong1
 (法 论 功)	fa3lun2gong1
@@ -70538,15 +67117,10 @@ $textmode
 (波 隆 那)	bo1long1na4
 (波 隆 那)	bo1long1na4
 (泥 水 匠)	ni2shui3jiang4
-(泥 ㊌ 匠)	ni2shui3jiang4
 (泥 水 匠)	ni2shui3jiang4
-(泥 ㊌ 匠)	ni2shui3jiang4
 (泼 冷 水)	po1leng3shui3
-(泼 冷 ㊌)	po1leng3shui3
 (泼 冷 水)	po1leng3shui3
-(泼 冷 ㊌)	po1leng3shui3
 (泼 水 节)	po1shui3jie2
-(泼 ㊌ 节)	po1shui3jie2
 (泼 烟 花)	po1yan1hua1
 (洗 不 掉)	xi3bu5diao4
 (洗 不 掉)	xi3bu5diao4
@@ -70554,18 +67128,13 @@ $textmode
 (洗 不 清)	xi3bu5qing1
 (洗 发 剂)	xi3fa4ji4
 (洗 发 水)	xi3fa4shui3
-(洗 发 ㊌)	xi3fa4shui3
 (洗 发 皂)	xi3fa4zao4
 (洗 发 露)	xi3fa4lu4
 (洗 发 露)	xi3fa4lu4
 (活 下 來)	huo2xia4lai2
-(活 ㊦ 來)	huo2xia4lai2
 (活 下 來)	huo2xia4lai2
-(活 ㊦ 來)	huo2xia4lai2
 (活 下 去)	huo2xia4qu4
-(活 ㊦ 去)	huo2xia4qu4
 (活 下 来)	huo2xia4lai2
-(活 ㊦ 来)	huo2xia4lai2
 (活 不 了)	huo2bu5liao3
 (活 不 了)	huo2bu5liao3
 (活 不 了)	huo2bu5liao3
@@ -70597,34 +67166,24 @@ $textmode
 (消 闲 儿)	xiao1xian2r5
 (消 食 儿)	xiao1shi2r5
 (涌 上 來)	yong3shang4lai5
-(涌 ㊤ 來)	yong3shang4lai5
 (涌 上 來)	yong3shang4lai5
-(涌 ㊤ 來)	yong3shang4lai5
 (涌 上 来)	yong3shang4lai5
-(涌 ㊤ 来)	yong3shang4lai5
 (混 一 混)	hun4yi2hun4
-(混 ㊀ 混)	hun4yi2hun4
 (混 不 上)	hun4bu5shang4
-(混 不 ㊤)	hun4bu5shang4
 (混 不 上)	hun4bu5shang4
-(混 不 ㊤)	hun4bu5shang4
 (混 名 儿)	hun4ming2r5
-(混 ㊔ 儿)	hun4ming2r5
 (混 混 儿)	hun4hun4r5
 (混 血 兒)	hun4xue4er2
 (添 不 起)	tian1bu5qi3
 (添 不 起)	tian1bu5qi3
 (清 一 色)	qing1yi2se4
-(清 ㊀ 色)	qing1yi2se4
 (清 道 夫)	qing1dao4fu1
 (港 务 局)	gang3wu4ju2
 (港 務 局)	gang3wu4ju2
 (渾 不 似)	hun2bu5si4
 (渾 不 似)	hun2bu5si4
 (湊 不 上)	cou4bu5shang4
-(湊 不 ㊤)	cou4bu5shang4
 (湊 不 上)	cou4bu5shang4
-(湊 不 ㊤)	cou4bu5shang4
 (準 不 準)	zhun3bu5zhun3
 (準 不 準)	zhun3bu5zhun3
 (溜 边 儿)	liu1bian1r5
@@ -70644,15 +67203,10 @@ $textmode
 (滿 洲 裡)	man3zhou1li3
 (漚 得 慌)	ou4de5huang5
 (潑 冷 水)	po1leng3shui3
-(潑 冷 ㊌)	po1leng3shui3
 (潑 冷 水)	po1leng3shui3
-(潑 冷 ㊌)	po1leng3shui3
 (潑 水 節)	po1shui3jie2
-(潑 ㊌ 節)	po1shui3jie2
 (潑 水 節)	po1shui3jie2
-(潑 ㊌ 節)	po1shui3jie2
 (潑 水 節)	po1shui3jie2
-(潑 ㊌ 節)	po1shui3jie2
 (潑 煙 花)	po1yan1hua1
 (潛 意 識)	qian2yi4shi2
 (潛 意 識)	qian2yi4shi2
@@ -70662,7 +67216,6 @@ $textmode
 (灌 米 汤)	guan4mi3tang5
 (灌 米 湯)	guan4mi3tang5
 (灵 性 上)	ling2xing4shang5
-(灵 性 ㊤)	ling2xing4shang5
 (灵 长 目)	ling2zhang3mu4
 (灵 长 类)	ling2zhang3lei4
 (灵 长 类)	ling2zhang3lei4
@@ -70701,7 +67254,6 @@ $textmode
 (烧 不 着)	shao1bu5zhao2
 (烧 得 慌)	shao1de5huang5
 (烫 一 烫)	tang4yi2tang4
-(烫 ㊀ 烫)	tang4yi2tang4
 (烫 不 着)	tang4bu5zhao2
 (烫 不 着)	tang4bu5zhao2
 (烫 不 着)	tang4bu5zhao2
@@ -70730,16 +67282,13 @@ $textmode
 (燒 不 著)	shao1bu5zhao2
 (燒 得 慌)	shao1de5huang5
 (燙 一 燙)	tang4yi2tang4
-(燙 ㊀ 燙)	tang4yi2tang4
 (燙 不 著)	tang4bu5zhao2
 (燙 不 著)	tang4bu5zhao2
 (燙 不 著)	tang4bu5zhao2
 (爪 尖 儿)	zhua3jian1r5
 (爪 尖 兒)	zhua3jian1r5
 (爬 不 上)	pa2bu5shang4
-(爬 不 ㊤)	pa2bu5shang4
 (爬 不 上)	pa2bu5shang4
-(爬 不 ㊤)	pa2bu5shang4
 (爬 不 动)	pa2bu5dong4
 (爬 不 动)	pa2bu5dong4
 (爬 不 動)	pa2bu5dong4
@@ -70768,15 +67317,10 @@ $textmode
 (牡 丹 坊)	mu3dan1fang1
 (牧 夫 座)	mu4fu1zuo4
 (特 別 是)	te4bie2shi5
-(㊕ 別 是)	te4bie2shi5
 (特 别 是)	te4bie2shi5
-(㊕ 别 是)	te4bie2shi5
 (犯 不 上)	fan4bu5shang4
-(犯 不 ㊤)	fan4bu5shang4
 (犯 不 上)	fan4bu5shang4
-(犯 不 ㊤)	fan4bu5shang4
 (犯 不 上)	fan4bu5shang4
-(犯 不 ㊤)	fan4bu5shang4
 (犯 不 着)	fan4bu5zhao2
 (犯 不 着)	fan4bu5zhao2
 (犯 不 着)	fan4bu5zhao2
@@ -70786,9 +67330,7 @@ $textmode
 (犯 不 著)	fan4bu5zhao2
 (犯 不 著)	fan4bu5zhao2
 (犯 得 上)	fan4de5shang4
-(犯 得 ㊤)	fan4de5shang4
 (犯 得 上)	fan4de5shang4
-(犯 得 ㊤)	fan4de5shang4
 (犯 得 着)	fan4de5zhao2
 (犯 得 着)	fan4de5zhao2
 (犯 得 着)	fan4de5zhao2
@@ -70800,7 +67342,6 @@ $textmode
 (犹 士 都)	you2shi4du1
 (狂 想 曲)	kuang2xiang3qu3
 (独 一 词)	du2yi4ci2
-(独 ㊀ 词)	du2yi4ci2
 (独 院 儿)	du2yuan4r5
 (猛 不 防)	meng3bu5fang2
 (猛 不 防)	meng3bu5fang2
@@ -70818,7 +67359,6 @@ $textmode
 (猶 士 都)	you2shi4du1
 (猶 士 都)	you2shi4du1
 (獨 一 詞)	du2yi4ci2
-(獨 ㊀ 詞)	du2yi4ci2
 (玉 夫 座)	yu4fu1zuo4
 (玉 米 粉)	yu4mi5fen3
 (玉 素 甫)	yu4su4fu3
@@ -70833,9 +67373,7 @@ $textmode
 (玛 奇 朵)	ma3qi2duo3
 (玛 得 缅)	ma3de2mian3
 (玛 拿 西)	ma3na2xi1
-(玛 拿 🀂)	ma3na2xi1
 (玛 西 拿)	ma3xi1na2
-(玛 🀂 拿)	ma3xi1na2
 (玩 不 轉)	wan2bu5zhuan4
 (玩 不 轉)	wan2bu5zhuan4
 (玩 不 转)	wan2bu5zhuan4
@@ -70849,15 +67387,10 @@ $textmode
 (理 事 长)	li3shi4zhang3
 (理 事 长)	li3shi4zhang3
 (理 論 上)	li3lun4shang5
-(理 論 ㊤)	li3lun4shang5
 (理 論 上)	li3lun4shang5
-(理 論 ㊤)	li3lun4shang5
 (理 論 上)	li3lun4shang5
-(理 論 ㊤)	li3lun4shang5
 (理 论 上)	li3lun4shang5
-(理 论 ㊤)	li3lun4shang5
 (理 论 上)	li3lun4shang5
-(理 论 ㊤)	li3lun4shang5
 (琉 璃 塔)	liu2li2ta3
 (琉 璃 塔)	liu2li2ta3
 (琐 比 巴)	suo3bi3ba1
@@ -70867,21 +67400,14 @@ $textmode
 (瑪 奇 朵)	ma3qi2duo3
 (瑪 得 緬)	ma3de2mian3
 (瑪 拿 西)	ma3na2xi1
-(瑪 拿 🀂)	ma3na2xi1
 (瑪 西 拿)	ma3xi1na2
-(瑪 🀂 拿)	ma3xi1na2
 (瓦 德 西)	wa3ee2xi1
-(瓦 德 🀂)	wa3ee2xi1
 (瓦 裡 斯)	wa3li3si1
 (瓦 裡 斯)	wa3li3si1
 (瓦 西 裡)	wa3xi1li3
-(瓦 🀂 裡)	wa3xi1li3
 (瓦 西 裡)	wa3xi1li3
-(瓦 🀂 裡)	wa3xi1li3
 (瓦 西 里)	wa3xi1li3
-(瓦 🀂 里)	wa3xi1li3
 (瓦 西 里)	wa3xi1li3
-(瓦 🀂 里)	wa3xi1li3
 (甚 至 於)	shen4zhi4yu2
 (甚 高 頻)	shen4gao1pin2
 (甚 高 頻)	shen4gao1pin2
@@ -70890,11 +67416,8 @@ $textmode
 (甜 不 唧)	tian2bu5ji1
 (甜 不 唧)	tian2bu5ji1
 (生 下 來)	sheng1xia4lai2
-(生 ㊦ 來)	sheng1xia4lai2
 (生 下 來)	sheng1xia4lai2
-(生 ㊦ 來)	sheng1xia4lai2
 (生 下 来)	sheng1xia4lai2
-(生 ㊦ 来)	sheng1xia4lai2
 (生 卒 年)	sheng1zu2nian2
 (生 卒 年)	sheng1zu2nian2
 (生 詞 語)	sheng1ci2yu2
@@ -70941,9 +67464,7 @@ $textmode
 (甩 不 開)	shuai3bu5kai1
 (甩 出 去)	shuai3chu1qu4
 (田 納 西)	tian2na4xi1
-(田 納 🀂)	tian2na4xi1
 (田 纳 西)	tian2na4xi1
-(田 纳 🀂)	tian2na4xi1
 (由 不 了)	you2bu5liao3
 (由 不 了)	you2bu5liao3
 (由 不 了)	you2bu5liao3
@@ -70959,24 +67480,16 @@ $textmode
 (电 荷 量)	dian4he2liang4
 (电 荷 量)	dian4he2liang4
 (男 孩 儿)	nan2hai2r5
-(㊚ 孩 儿)	nan2hai2r5
 (留 下 來)	liu2xia4lai2
-(留 ㊦ 來)	liu2xia4lai2
 (留 下 來)	liu2xia4lai2
-(留 ㊦ 來)	liu2xia4lai2
 (留 下 來)	liu2xia4lai2
-(留 ㊦ 來)	liu2xia4lai2
 (留 下 来)	liu2xia4lai2
-(留 ㊦ 来)	liu2xia4lai2
 (留 下 来)	liu2xia4lai2
-(留 ㊦ 来)	liu2xia4lai2
 (留 不 住)	liu2bu5zhu4
 (留 不 住)	liu2bu5zhu4
 (留 不 住)	liu2bu5zhu4
 (留 学 生)	liu2xue2sheng1
-(留 ㊫ 生)	liu2xue2sheng1
 (留 学 生)	liu2xue2sheng1
-(留 ㊫ 生)	liu2xue2sheng1
 (留 學 生)	liu2xue2sheng1
 (留 學 生)	liu2xue2sheng1
 (留 成 儿)	liu2cheng2r5
@@ -70984,7 +67497,6 @@ $textmode
 (畜 产 品)	xu4chan3pin3
 (畜 產 品)	xu4chan3pin3
 (畢 宿 五)	bi4xiu4wu3
-(畢 宿 ㊄)	bi4xiu4wu3
 (當 不 了)	dang1bu5liao3
 (當 不 了)	dang1bu5liao3
 (當 不 了)	dang1bu5liao3
@@ -71025,7 +67537,6 @@ $textmode
 (百 分 之)	bai3fen4zhi1
 (百 夫 长)	bai3fu1zhang3
 (百 日 咳)	bai3ri4ke2
-(百 ㊐ 咳)	bai3ri4ke2
 (的 地 壳)	de5di4qiao4
 (的 地 方)	de5di4fang5
 (的 地 殼)	de5di4qiao4
@@ -71035,7 +67546,6 @@ $textmode
 (盡 本 分)	jin4ben3fen4
 (盡 義 務)	jin4yi4wu4
 (監 獄 長)	jian1yu4zhang3
-(㊬ 獄 長)	jian1yu4zhang3
 (目 的 地)	mu4di4di4
 (直 不 棱)	zhi2bu5leng5
 (直 不 棱)	zhi2bu5leng5
@@ -71049,11 +67559,8 @@ $textmode
 (相 空 間)	xiang4kong1jian1
 (相 空 间)	xiang4kong1jian1
 (省 不 下)	sheng3bu5xia4
-(省 不 ㊦)	sheng3bu5xia4
 (省 不 下)	sheng3bu5xia4
-(省 不 ㊦)	sheng3bu5xia4
 (省 不 下)	sheng3bu5xia4
-(省 不 ㊦)	sheng3bu5xia4
 (省 劲 儿)	sheng3jin4r5
 (省 劲 儿)	sheng3jin4r5
 (省 字 号)	sheng3zi4hao4
@@ -71063,25 +67570,14 @@ $textmode
 (省 得 出)	sheng3de5chu1
 (省 得 出)	sheng3de5chu1
 (看 一 看)	kan4yi2kan4
-(看 ㊀ 看)	kan4yi2kan4
 (看 上 去)	kan4shang5qu5
-(看 ㊤ 去)	kan4shang5qu5
 (看 下 去)	kan4xia4qu4
-(看 ㊦ 去)	kan4xia4qu4
 (看 不 上)	kan4bu5shang4
-(看 不 ㊤)	kan4bu5shang4
 (看 不 上)	kan4bu5shang4
-(看 不 ㊤)	kan4bu5shang4
 (看 不 下)	kan4bu5xia4
-(看 不 ㊦)	kan4bu5xia4
 (看 不 下)	kan4bu5xia4
-(看 不 ㊦)	kan4bu5xia4
 (看 不 中)	kan4bu5zhong4
-(看 不 🀄)	kan4bu5zhong4
-(看 不 ㊥)	kan4bu5zhong4
 (看 不 中)	kan4bu5zhong4
-(看 不 🀄)	kan4bu5zhong4
-(看 不 ㊥)	kan4bu5zhong4
 (看 不 來)	kan4bu5lai2
 (看 不 來)	kan4bu5lai2
 (看 不 來)	kan4bu5lai2
@@ -71123,10 +67619,7 @@ $textmode
 (看 不 過)	kan4bu5guo4
 (看 不 過)	kan4bu5guo4
 (看 得 上)	kan4de5shang4
-(看 得 ㊤)	kan4de5shang4
 (看 得 中)	kan4de5zhong4
-(看 得 🀄)	kan4de5zhong4
-(看 得 ㊥)	kan4de5zhong4
 (看 得 住)	kan1de5zhu4
 (看 得 來)	kan4de5lai2
 (看 得 來)	kan4de5lai2
@@ -71141,7 +67634,6 @@ $textmode
 (真 是 的)	zhen1shi5de5
 (眨 眼 睛)	zha3yan3jing1
 (眼 底 下)	yan3di3xia5
-(眼 底 ㊦)	yan3di3xia5
 (眼 珠 儿)	yan3zhu1r5
 (着 劲 儿)	zhuo2jin4r5
 (着 劲 儿)	zhuo2jin4r5
@@ -71152,9 +67644,7 @@ $textmode
 (睜 不 開)	zheng1bu5kai1
 (睜 不 開)	zheng1bu5kai1
 (睡 不 下)	shui4bu5xia4
-(睡 不 ㊦)	shui4bu5xia4
 (睡 不 下)	shui4bu5xia4
-(睡 不 ㊦)	shui4bu5xia4
 (睡 不 好)	shui4bu5hao3
 (睡 不 好)	shui4bu5hao3
 (睡 不 着)	shui4bu5zhao2
@@ -71208,9 +67698,7 @@ $textmode
 (瞧 不 過)	qiao2bu5guo4
 (瞧 不 過)	qiao2bu5guo4
 (瞧 得 上)	qiao2de5shang4
-(瞧 得 ㊤)	qiao2de5shang4
 (瞧 得 上)	qiao2de5shang4
-(瞧 得 ㊤)	qiao2de5shang4
 (瞭 望 台)	liao4wang4tai2
 (瞭 望 台)	liao4wang4tai2
 (瞭 望 臺)	liao4wang4tai2
@@ -71236,11 +67724,8 @@ $textmode
 (石 河 子)	shi2he2zi3
 (矿 务 局)	kuang4wu4ju2
 (砍 下 來)	kan3xia4lai2
-(砍 ㊦ 來)	kan3xia4lai2
 (砍 下 來)	kan3xia4lai2
-(砍 ㊦ 來)	kan3xia4lai2
 (砍 下 来)	kan3xia4lai2
-(砍 ㊦ 来)	kan3xia4lai2
 (硌 得 慌)	ge4de5huang1
 (碍 不 着)	ai4bu5zhao2
 (碍 不 着)	ai4bu5zhao2
@@ -71288,11 +67773,8 @@ $textmode
 (离 得 了)	li2de5liao3
 (离 得 了)	li2de5liao3
 (科 何 西)	ke1he2xi1
-(科 何 🀂)	ke1he2xi1
 (秘 书 长)	mi4shu1zhang3
-(㊙ 书 长)	mi4shu1zhang3
 (秘 書 長)	mi4shu1zhang3
-(㊙ 書 長)	mi4shu1zhang3
 (租 不 起)	zu1bu5qi3
 (租 不 起)	zu1bu5qi3
 (租 借 地)	zu1jie4di4
@@ -71300,17 +67782,13 @@ $textmode
 (秦 吉 了)	qin2ji2liao3
 (称 之 为)	cheng1zhi1wei2
 (称 得 上)	cheng1de5shang4
-(称 得 ㊤)	cheng1de5shang4
 (稱 之 為)	cheng1zhi1wei2
 (稱 得 上)	cheng1de5shang4
-(稱 得 ㊤)	cheng1de5shang4
 (稽 查 员)	ji1cha2yuan2
 (稽 查 員)	ji1cha2yuan2
 (空 心 儿)	kong1xin1r5
 (穿 不 上)	chuan1bu5shang4
-(穿 不 ㊤)	chuan1bu5shang4
 (穿 不 上)	chuan1bu5shang4
-(穿 不 ㊤)	chuan1bu5shang4
 (穿 不 住)	chuan1bu5zhu4
 (穿 不 住)	chuan1bu5zhu4
 (穿 不 得)	chuan1bu5de5
@@ -71333,11 +67811,8 @@ $textmode
 (竹 篱 笆)	zhu2li2ba1
 (竹 籬 笆)	zhu2li2ba1
 (笑 一 笑)	xiao4yi2xiao4
-(笑 ㊀ 笑)	xiao4yi2xiao4
 (笑 不 上)	xiao4bu5shang4
-(笑 不 ㊤)	xiao4bu5shang4
 (笑 不 上)	xiao4bu5shang4
-(笑 不 ㊤)	xiao4bu5shang4
 (笑 不 出)	xiao4bu5chu1
 (笑 不 出)	xiao4bu5chu1
 (笑 不 唧)	xiao4bu5ji1
@@ -71350,383 +67825,193 @@ $textmode
 (笛 卡 尔)	di1ka3er3
 (笛 卡 爾)	di1ka3er3
 (第 一 两)	di4yi1liang3
-(第 ㊀ 两)	di4yi1liang3
 (第 一 个)	di4yi1ge5
-(第 ㊀ 个)	di4yi1ge5
 (第 一 串)	di4yi1chuan4
-(第 ㊀ 串)	di4yi1chuan4
 (第 一 串)	di4yi1chuan4
-(第 ㊀ 串)	di4yi1chuan4
 (第 一 义)	di4yi1yi4
-(第 ㊀ 义)	di4yi1yi4
 (第 一 亇)	di4yi1ge4
-(第 ㊀ 亇)	di4yi1ge4
 (第 一 亩)	di4yi1mu3
-(第 ㊀ 亩)	di4yi1mu3
 (第 一 代)	di4yi1dai4
-(第 ㊀ 代)	di4yi1dai4
 (第 一 件)	di4yi1jian4
-(第 ㊀ 件)	di4yi1jian4
 (第 一 份)	di4yi1fen4
-(第 ㊀ 份)	di4yi1fen4
 (第 一 位)	di4yi1wei4
-(第 ㊀ 位)	di4yi1wei4
 (第 一 例)	di4yi1li4
-(第 ㊀ 例)	di4yi1li4
 (第 一 例)	di4yi1li4
-(第 ㊀ 例)	di4yi1li4
 (第 一 個)	di4yi1ge5
-(第 ㊀ 個)	di4yi1ge5
 (第 一 兩)	di4yi1liang3
-(第 ㊀ 兩)	di4yi1liang3
 (第 一 兩)	di4yi1liang3
-(第 ㊀ 兩)	di4yi1liang3
 (第 一 具)	di4yi1ju4
-(第 ㊀ 具)	di4yi1ju4
 (第 一 冊)	di4yi1ce4
-(第 ㊀ 冊)	di4yi1ce4
 (第 一 册)	di4yi1ce4
-(第 ㊀ 册)	di4yi1ce4
 (第 一 出)	di4yi1chu1
-(第 ㊀ 出)	di4yi1chu1
 (第 一 刻)	di4yi1ke4
-(第 ㊀ 刻)	di4yi1ke4
 (第 一 副)	di4yi1fu4
-(第 ㊀ 副)	di4yi1fu4
 (第 一 包)	di4yi1bao1
-(第 ㊀ 包)	di4yi1bao1
 (第 一 匹)	di4yi1pi3
-(第 ㊀ 匹)	di4yi1pi3
 (第 一 双)	di4yi1shuang1
-(第 ㊀ 双)	di4yi1shuang1
 (第 一 发)	di4yi1fa1
-(第 ㊀ 发)	di4yi1fa1
 (第 一 口)	di4yi1kou3
-(第 ㊀ 口)	di4yi1kou3
 (第 一 句)	di4yi1ju4
-(第 ㊀ 句)	di4yi1ju4
 (第 一 句)	di4yi1ju4
-(第 ㊀ 句)	di4yi1ju4
 (第 一 只)	di4yi1zhi1
-(第 ㊀ 只)	di4yi1zhi1
 (第 一 台)	di4yi1tai2
-(第 ㊀ 台)	di4yi1tai2
 (第 一 名)	di4yi1ming2
-(第 ㊀ 名)	di4yi1ming2
-(第 一 ㊔)	di4yi1ming2
 (第 一 听)	di4yi1ting1
-(第 ㊀ 听)	di4yi1ting1
 (第 一 响)	di4yi1xiang3
-(第 ㊀ 响)	di4yi1xiang3
 (第 一 哪)	di4yi1nei3
-(第 ㊀ 哪)	di4yi1nei3
 (第 一 回)	di4yi1hui2
-(第 ㊀ 回)	di4yi1hui2
 (第 一 圈)	di4yi1quan1
-(第 ㊀ 圈)	di4yi1quan1
 (第 一 场)	di4yi1chang2
-(第 ㊀ 场)	di4yi1chang2
 (第 一 块)	di4yi1kuai4
-(第 ㊀ 块)	di4yi1kuai4
 (第 一 場)	di4yi1chang2
-(第 ㊀ 場)	di4yi1chang2
 (第 一 堵)	di4yi1du3
-(第 ㊀ 堵)	di4yi1du3
 (第 一 塊)	di4yi1kuai4
-(第 ㊀ 塊)	di4yi1kuai4
 (第 一 声)	di4yi1sheng1
-(第 ㊀ 声)	di4yi1sheng1
 (第 一 壶)	di4yi1hu2
-(第 ㊀ 壶)	di4yi1hu2
 (第 一 壺)	di4yi1hu2
-(第 ㊀ 壺)	di4yi1hu2
 (第 一 处)	di4yi1chu4
-(第 ㊀ 处)	di4yi1chu4
 (第 一 天)	di4yi1tian1
-(第 ㊀ 天)	di4yi1tian1
 (第 一 头)	di4yi1tou2
-(第 ㊀ 头)	di4yi1tou2
 (第 一 套)	di4yi1tao4
-(第 ㊀ 套)	di4yi1tao4
 (第 一 审)	di4yi1shen3
-(第 ㊀ 审)	di4yi1shen3
 (第 一 家)	di4yi1jia1
-(第 ㊀ 家)	di4yi1jia1
 (第 一 審)	di4yi1shen3
-(第 ㊀ 審)	di4yi1shen3
 (第 一 封)	di4yi1feng1
-(第 ㊀ 封)	di4yi1feng1
 (第 一 尊)	di4yi1zun1
-(第 ㊀ 尊)	di4yi1zun1
 (第 一 局)	di4yi1ju2
-(第 ㊀ 局)	di4yi1ju2
 (第 一 层)	di4yi1ceng2
-(第 ㊀ 层)	di4yi1ceng2
 (第 一 屆)	di4yi1jie4
-(第 ㊀ 屆)	di4yi1jie4
 (第 一 届)	di4yi1jie4
-(第 ㊀ 届)	di4yi1jie4
 (第 一 層)	di4yi1ceng2
-(第 ㊀ 層)	di4yi1ceng2
 (第 一 層)	di4yi1ceng2
-(第 ㊀ 層)	di4yi1ceng2
 (第 一 岁)	di4yi1sui4
-(第 ㊀ 岁)	di4yi1sui4
 (第 一 幅)	di4yi1fu2
-(第 ㊀ 幅)	di4yi1fu2
 (第 一 幢)	di4yi1chuang2
-(第 ㊀ 幢)	di4yi1chuang2
 (第 一 年)	di4yi1nian2
-(第 ㊀ 年)	di4yi1nian2
 (第 一 年)	di4yi1nian2
-(第 ㊀ 年)	di4yi1nian2
 (第 一 床)	di4yi1chuang2
-(第 ㊀ 床)	di4yi1chuang2
 (第 一 座)	di4yi1zuo4
-(第 ㊀ 座)	di4yi1zuo4
 (第 一 张)	di4yi1zhang1
-(第 ㊀ 张)	di4yi1zhang1
 (第 一 張)	di4yi1zhang1
-(第 ㊀ 張)	di4yi1zhang1
 (第 一 所)	di4yi1suo3
-(第 ㊀ 所)	di4yi1suo3
 (第 一 扇)	di4yi1shan4
-(第 ㊀ 扇)	di4yi1shan4
 (第 一 手)	di4yi1shou3
-(第 ㊀ 手)	di4yi1shou3
 (第 一 批)	di4yi1pi1
-(第 ㊀ 批)	di4yi1pi1
 (第 一 把)	di4yi1ba3
-(第 ㊀ 把)	di4yi1ba3
 (第 一 折)	di4yi1zhe2
-(第 ㊀ 折)	di4yi1zhe2
 (第 一 抹)	di4yi1mo3
-(第 ㊀ 抹)	di4yi1mo3
 (第 一 挺)	di4yi1ting3
-(第 ㊀ 挺)	di4yi1ting3
 (第 一 排)	di4yi1pai2
-(第 ㊀ 排)	di4yi1pai2
 (第 一 支)	di4yi1zhi1
-(第 ㊀ 支)	di4yi1zhi1
 (第 一 方)	di4yi1fang1
-(第 ㊀ 方)	di4yi1fang1
 (第 一 本)	di4yi1ben3
-(第 ㊀ 本)	di4yi1ben3
 (第 一 朵)	di4yi1duo3
-(第 ㊀ 朵)	di4yi1duo3
 (第 一 杆)	di4yi1gan3
-(第 ㊀ 杆)	di4yi1gan3
 (第 一 束)	di4yi1shu4
-(第 ㊀ 束)	di4yi1shu4
 (第 一 条)	di4yi1tiao2
-(第 ㊀ 条)	di4yi1tiao2
 (第 一 杯)	di4yi1bei1
-(第 ㊀ 杯)	di4yi1bei1
 (第 一 枚)	di4yi1mei2
-(第 ㊀ 枚)	di4yi1mei2
 (第 一 枝)	di4yi1zhi1
-(第 ㊀ 枝)	di4yi1zhi1
 (第 一 架)	di4yi1jia4
-(第 ㊀ 架)	di4yi1jia4
 (第 一 栋)	di4yi1dong4
-(第 ㊀ 栋)	di4yi1dong4
 (第 一 株)	di4yi1zhu1
-(第 ㊀ 株)	di4yi1zhu1
-(第 一 ㊑)	di4yi1zhu1
 (第 一 根)	di4yi1gen1
-(第 ㊀ 根)	di4yi1gen1
 (第 一 档)	di4yi1dang4
-(第 ㊀ 档)	di4yi1dang4
 (第 一 桿)	di4yi1gan3
-(第 ㊀ 桿)	di4yi1gan3
 (第 一 條)	di4yi1tiao2
-(第 ㊀ 條)	di4yi1tiao2
 (第 一 棟)	di4yi1dong4
-(第 ㊀ 棟)	di4yi1dong4
 (第 一 棵)	di4yi1ke1
-(第 ㊀ 棵)	di4yi1ke1
 (第 一 榀)	di4yi1pin3
-(第 ㊀ 榀)	di4yi1pin3
 (第 一 樘)	di4yi1tang2
-(第 ㊀ 樘)	di4yi1tang2
 (第 一 檔)	di4yi1dang4
-(第 ㊀ 檔)	di4yi1dang4
 (第 一 次)	di4yi1ci4
-(第 ㊀ 次)	di4yi1ci4
 (第 一 步)	di4yi1bu4
-(第 ㊀ 步)	di4yi1bu4
 (第 一 歲)	di4yi1sui4
-(第 ㊀ 歲)	di4yi1sui4
 (第 一 段)	di4yi1duan4
-(第 ㊀ 段)	di4yi1duan4
 (第 一 毛)	di4yi1mao2
-(第 ㊀ 毛)	di4yi1mao2
 (第 一 泡)	di4yi1pao1
-(第 ㊀ 泡)	di4yi1pao1
 (第 一 流)	di4yi1liu2
-(第 ㊀ 流)	di4yi1liu2
 (第 一 流)	di4yi1liu2
-(第 ㊀ 流)	di4yi1liu2
 (第 一 流)	di4yi1liu2
-(第 ㊀ 流)	di4yi1liu2
 (第 一 点)	di4yi1dian3
-(第 ㊀ 点)	di4yi1dian3
 (第 一 片)	di4yi1pian4
-(第 ㊀ 片)	di4yi1pian4
 (第 一 班)	di4yi1ban1
-(第 ㊀ 班)	di4yi1ban1
 (第 一 瓶)	di4yi1ping2
-(第 ㊀ 瓶)	di4yi1ping2
 (第 一 甬)	di4yi1yong3
-(第 ㊀ 甬)	di4yi1yong3
 (第 一 畝)	di4yi1mu3
-(第 ㊀ 畝)	di4yi1mu3
 (第 一 番)	di4yi1fan1
-(第 ㊀ 番)	di4yi1fan1
 (第 一 發)	di4yi1fa1
-(第 ㊀ 發)	di4yi1fa1
 (第 一 盏)	di4yi1zhan3
-(第 ㊀ 盏)	di4yi1zhan3
 (第 一 盘)	di4yi1pan2
-(第 ㊀ 盘)	di4yi1pan2
 (第 一 盞)	di4yi1zhan3
-(第 ㊀ 盞)	di4yi1zhan3
 (第 一 盤)	di4yi1pan2
-(第 ㊀ 盤)	di4yi1pan2
 (第 一 种)	di4yi1zhong3
-(第 ㊀ 种)	di4yi1zhong3
 (第 一 種)	di4yi1zhong3
-(第 ㊀ 種)	di4yi1zhong3
 (第 一 笔)	di4yi1bi3
-(第 ㊀ 笔)	di4yi1bi3
 (第 一 筆)	di4yi1bi3
-(第 ㊀ 筆)	di4yi1bi3
 (第 一 箇)	di4yi1ge4
-(第 ㊀ 箇)	di4yi1ge4
 (第 一 節)	di4yi1jie2
-(第 ㊀ 節)	di4yi1jie2
 (第 一 節)	di4yi1jie2
-(第 ㊀ 節)	di4yi1jie2
 (第 一 節)	di4yi1jie2
-(第 ㊀ 節)	di4yi1jie2
 (第 一 篇)	di4yi1pian1
-(第 ㊀ 篇)	di4yi1pian1
 (第 一 簇)	di4yi1cu4
-(第 ㊀ 簇)	di4yi1cu4
 (第 一 米)	di4yi1mi3
-(第 ㊀ 米)	di4yi1mi3
 (第 一 粒)	di4yi1li4
-(第 ㊀ 粒)	di4yi1li4
 (第 一 粒)	di4yi1li4
-(第 ㊀ 粒)	di4yi1li4
 (第 一 級)	di4yi1ji2
-(第 ㊀ 級)	di4yi1ji2
 (第 一 絞)	di4yi1jiao3
-(第 ㊀ 絞)	di4yi1jiao3
 (第 一 線)	di4yi1xian4
-(第 ㊀ 線)	di4yi1xian4
 (第 一 级)	di4yi1ji2
-(第 ㊀ 级)	di4yi1ji2
 (第 一 线)	di4yi1xian4
-(第 ㊀ 线)	di4yi1xian4
 (第 一 绞)	di4yi1jiao3
-(第 ㊀ 绞)	di4yi1jiao3
 (第 一 缸)	di4yi1gang1
-(第 ㊀ 缸)	di4yi1gang1
 (第 一 義)	di4yi1yi4
-(第 ㊀ 義)	di4yi1yi4
 (第 一 聲)	di4yi1sheng1
-(第 ㊀ 聲)	di4yi1sheng1
 (第 一 聽)	di4yi1ting1
-(第 ㊀ 聽)	di4yi1ting1
 (第 一 股)	di4yi1gu3
-(第 ㊀ 股)	di4yi1gu3
 (第 一 臺)	di4yi1tai2
-(第 ㊀ 臺)	di4yi1tai2
 (第 一 艘)	di4yi1sou1
-(第 ㊀ 艘)	di4yi1sou1
 (第 一 节)	di4yi1jie2
-(第 ㊀ 节)	di4yi1jie2
 (第 一 處)	di4yi1chu4
-(第 ㊀ 處)	di4yi1chu4
 (第 一 袭)	di4yi1xi2
-(第 ㊀ 袭)	di4yi1xi2
 (第 一 襲)	di4yi1xi2
-(第 ㊀ 襲)	di4yi1xi2
 (第 一 起)	di4yi1qi3
-(第 ㊀ 起)	di4yi1qi3
 (第 一 趟)	di4yi1tang4
-(第 ㊀ 趟)	di4yi1tang4
 (第 一 身)	di4yi1shen1
-(第 ㊀ 身)	di4yi1shen1
 (第 一 輛)	di4yi1liang4
-(第 ㊀ 輛)	di4yi1liang4
 (第 一 輪)	di4yi1lun2
-(第 ㊀ 輪)	di4yi1lun2
 (第 一 輪)	di4yi1lun2
-(第 ㊀ 輪)	di4yi1lun2
 (第 一 轮)	di4yi1lun2
-(第 ㊀ 轮)	di4yi1lun2
 (第 一 辆)	di4yi1liang4
-(第 ㊀ 辆)	di4yi1liang4
 (第 一 这)	di4yi1zhe4
-(第 ㊀ 这)	di4yi1zhe4
 (第 一 這)	di4yi1zhe4
-(第 ㊀ 這)	di4yi1zhe4
 (第 一 道)	di4yi1dao4
-(第 ㊀ 道)	di4yi1dao4
 (第 一 遭)	di4yi1zao1
-(第 ㊀ 遭)	di4yi1zao1
 (第 一 那)	di4yi1na4
-(第 ㊀ 那)	di4yi1na4
 (第 一 部)	di4yi1bu4
-(第 ㊀ 部)	di4yi1bu4
 (第 一 門)	di4yi1men2
-(第 ㊀ 門)	di4yi1men2
 (第 一 間)	di4yi1jian1
-(第 ㊀ 間)	di4yi1jian1
 (第 一 门)	di4yi1men2
-(第 ㊀ 门)	di4yi1men2
 (第 一 间)	di4yi1jian1
-(第 ㊀ 间)	di4yi1jian1
 (第 一 阵)	di4yi1zhen4
-(第 ㊀ 阵)	di4yi1zhen4
 (第 一 陣)	di4yi1zhen4
-(第 ㊀ 陣)	di4yi1zhen4
 (第 一 隻)	di4yi1zhi1
-(第 ㊀ 隻)	di4yi1zhi1
 (第 一 集)	di4yi1ji2
-(第 ㊀ 集)	di4yi1ji2
 (第 一 雙)	di4yi1shuang1
-(第 ㊀ 雙)	di4yi1shuang1
 (第 一 面)	di4yi1mian4
-(第 ㊀ 面)	di4yi1mian4
 (第 一 響)	di4yi1xiang3
-(第 ㊀ 響)	di4yi1xiang3
 (第 一 響)	di4yi1xiang3
-(第 ㊀ 響)	di4yi1xiang3
 (第 一 響)	di4yi1xiang3
-(第 ㊀ 響)	di4yi1xiang3
 (第 一 頂)	di4yi1ding3
-(第 ㊀ 頂)	di4yi1ding3
 (第 一 頓)	di4yi1dun4
-(第 ㊀ 頓)	di4yi1dun4
 (第 一 頭)	di4yi1tou2
-(第 ㊀ 頭)	di4yi1tou2
 (第 一 顆)	di4yi1ke1
-(第 ㊀ 顆)	di4yi1ke1
 (第 一 顶)	di4yi1ding3
-(第 ㊀ 顶)	di4yi1ding3
 (第 一 顿)	di4yi1dun4
-(第 ㊀ 顿)	di4yi1dun4
 (第 一 颗)	di4yi1ke1
-(第 ㊀ 颗)	di4yi1ke1
 (第 一 首)	di4yi1shou3
-(第 ㊀ 首)	di4yi1shou3
 (第 一 點)	di4yi1dian3
-(第 ㊀ 點)	di4yi1dian3
 (第 一 齣)	di4yi1chu1
-(第 ㊀ 齣)	di4yi1chu1
 (等 不 了)	deng3bu5liao3
 (等 不 了)	deng3bu5liao3
 (等 不 了)	deng3bu5liao3
@@ -71735,22 +68020,16 @@ $textmode
 (等 不 得)	deng3bu5de2
 (等 不 得)	deng3bu5de2
 (答 不 上)	da2bu5shang4
-(答 不 ㊤)	da2bu5shang4
 (答 不 上)	da2bu5shang4
-(答 不 ㊤)	da2bu5shang4
 (答 不 出)	da2bu5chu1
 (答 不 出)	da2bu5chu1
 (答 巴 俄)	da2ba1e2
 (答 得 上)	da2de5shang4
-(答 得 ㊤)	da2de5shang4
 (策 源 地)	ce4yuan2di4
 (简 帖 儿)	jian3tie3r5
 (算 一 算)	suan4yi5suan4
-(算 ㊀ 算)	suan4yi5suan4
 (算 不 上)	suan4bu5shang4
-(算 不 ㊤)	suan4bu5shang4
 (算 不 上)	suan4bu5shang4
-(算 不 ㊤)	suan4bu5shang4
 (算 不 了)	suan4bu5liao3
 (算 不 了)	suan4bu5liao3
 (算 不 了)	suan4bu5liao3
@@ -71764,7 +68043,6 @@ $textmode
 (算 不 清)	suan4bu5qing1
 (算 不 清)	suan4bu5qing1
 (算 得 上)	suan4de5shang4
-(算 得 ㊤)	suan4de5shang4
 (算 得 了)	suan4de5liao3
 (算 得 了)	suan4de5liao3
 (管 不 了)	guan3bu5liao3
@@ -71796,13 +68074,9 @@ $textmode
 (紅 蘿 蔔)	hong2luo2bo2
 (紅 高 粱)	hong2gao1liang2
 (納 西 族)	na4xi1zu2
-(納 🀂 族)	na4xi1zu2
 (紐 西 蘭)	niu3xi1lan2
-(紐 🀂 蘭)	niu3xi1lan2
 (紐 西 蘭)	niu3xi1lan2
-(紐 🀂 蘭)	niu3xi1lan2
 (紐 西 蘭)	niu3xi1lan2
-(紐 🀂 蘭)	niu3xi1lan2
 (紙 莎 草)	zhi3suo1cao3
 (紧 绷 绷)	jin3beng1beng1
 (紫 菜 苔)	zi3cai4tai2
@@ -71828,11 +68102,8 @@ $textmode
 (給 不 了)	gei3bu5liao3
 (給 不 了)	gei3bu5liao3
 (統 一 化)	tong3yi2hua4
-(統 ㊀ 化)	tong3yi2hua4
 (統 一 性)	tong3yi2xing4
-(統 ㊀ 性)	tong3yi2xing4
 (統 一 碼)	tong3yi4ma3
-(統 ㊀ 碼)	tong3yi4ma3
 (經 不 起)	jing1bu5qi3
 (經 不 起)	jing1bu5qi3
 (綜 合 徵)	zong1he2zheng1
@@ -71858,7 +68129,6 @@ $textmode
 (约 维 克)	yao1wei2ke4
 (纪 传 体)	ji4zhuan4ti3
 (纳 西 族)	na4xi1zu2
-(纳 🀂 族)	na4xi1zu2
 (纳 闷 儿)	na4men4r5
 (纸 煤 儿)	zhi3mei2r5
 (纸 莎 草)	zhi3suo1cao3
@@ -71866,7 +68136,6 @@ $textmode
 (纹 丝 儿)	wen2si1r5
 (纹 缕 儿)	wen2lv5r5
 (纽 西 兰)	niu3xi1lan2
-(纽 🀂 兰)	niu3xi1lan2
 (经 不 起)	jing1bu5qi3
 (经 不 起)	jing1bu5qi3
 (结 不 了)	jie2bu5liao3
@@ -71878,11 +68147,8 @@ $textmode
 (给 不 了)	gei3bu5liao3
 (给 不 了)	gei3bu5liao3
 (统 一 化)	tong3yi2hua4
-(统 ㊀ 化)	tong3yi2hua4
 (统 一 性)	tong3yi2xing4
-(统 ㊀ 性)	tong3yi2xing4
 (统 一 码)	tong3yi4ma3
-(统 ㊀ 码)	tong3yi4ma3
 (绷 不 住)	beng1bu5zhu4
 (绷 不 住)	beng1bu5zhu4
 (绿 油 油)	lv4you1you1
@@ -71893,7 +68159,6 @@ $textmode
 (缠 不 清)	chan2bu5qing1
 (缠 不 清)	chan2bu5qing1
 (罗 一 秀)	luo2yi2xiu4
-(罗 ㊀ 秀)	luo2yi2xiu4
 (罗 伯 逊)	luo1bo2xun4
 (罗 圈 儿)	luo2quan1r5
 (罗 姆 酒)	luo1mu3jiu3
@@ -71905,9 +68170,7 @@ $textmode
 (罩 不 住)	zhao4bu5zhu4
 (罩 不 住)	zhao4bu5zhu4
 (羅 一 秀)	luo2yi2xiu4
-(羅 ㊀ 秀)	luo2yi2xiu4
 (羅 一 秀)	luo2yi2xiu4
-(羅 ㊀ 秀)	luo2yi2xiu4
 (羅 伯 遜)	luo1bo2xun4
 (羅 伯 遜)	luo1bo2xun4
 (羅 姆 酒)	luo1mu3jiu3
@@ -71925,7 +68188,6 @@ $textmode
 (美 差 事)	mei3chai1shi4
 (美 智 子)	mei3zhi4zi3
 (翻 一 翻)	fan1yi4fan1
-(翻 ㊀ 翻)	fan1yi4fan1
 (翻 出 來)	fan1chu5lai5
 (翻 出 來)	fan1chu5lai5
 (翻 出 来)	fan1chu5lai5
@@ -71935,13 +68197,9 @@ $textmode
 (翻 過 來)	fan1guo5lai5
 (翻 過 來)	fan1guo5lai5
 (老 一 輩)	lao3yi2bei4
-(老 ㊀ 輩)	lao3yi2bei4
 (老 一 輩)	lao3yi2bei4
-(老 ㊀ 輩)	lao3yi2bei4
 (老 一 辈)	lao3yi2bei4
-(老 ㊀ 辈)	lao3yi2bei4
 (老 一 辈)	lao3yi2bei4
-(老 ㊀ 辈)	lao3yi2bei4
 (老 不 修)	lao3bu5xiu1
 (老 不 修)	lao3bu5xiu1
 (老 不 修)	lao3bu5xiu1
@@ -71972,15 +68230,9 @@ $textmode
 (老 来 少)	lao3lai2shao4
 (老 来 少)	lao3lai2shao4
 (考 不 上)	kao3bu5shang4
-(考 不 ㊤)	kao3bu5shang4
 (考 不 上)	kao3bu5shang4
-(考 不 ㊤)	kao3bu5shang4
 (考 不 中)	kao3bu5zhong4
-(考 不 🀄)	kao3bu5zhong4
-(考 不 ㊥)	kao3bu5zhong4
 (考 不 中)	kao3bu5zhong4
-(考 不 🀄)	kao3bu5zhong4
-(考 不 ㊥)	kao3bu5zhong4
 (考 不 取)	kao3bu5qu3
 (考 不 取)	kao3bu5qu3
 (耍 不 了)	shua3bu5liao3
@@ -71996,10 +68248,8 @@ $textmode
 (联 不 到)	lian2bu5dao4
 (联 不 到)	lian2bu5dao4
 (聖 荷 西)	sheng4he2xi1
-(聖 荷 🀂)	sheng4he2xi1
 (聚 居 地)	ju4ju1di4
 (聞 一 多)	wen2yi4duo1
-(聞 ㊀ 多)	wen2yi4duo1
 (聞 不 出)	wen2bu5chu1
 (聞 不 出)	wen2bu5chu1
 (聞 不 得)	wen2bu5de2
@@ -72069,9 +68319,7 @@ $textmode
 (脸 蛋 儿)	lian3dan4r5
 (腦 脊 液)	nao3ji3ye4
 (腾 不 下)	teng2bu5xia4
-(腾 不 ㊦)	teng2bu5xia4
 (腾 不 下)	teng2bu5xia4
-(腾 不 ㊦)	teng2bu5xia4
 (腾 不 出)	teng2bu5chu1
 (腾 不 出)	teng2bu5chu1
 (腾 不 开)	teng2bu5kai1
@@ -72093,8 +68341,6 @@ $textmode
 (興 不 開)	xing1bu5kai1
 (興 不 開)	xing1bu5kai1
 (興 中 會)	xing1zhong1hui4
-(興 🀄 會)	xing1zhong1hui4
-(興 ㊥ 會)	xing1zhong1hui4
 (舍 不 了)	she3bu5liao3
 (舍 不 了)	she3bu5liao3
 (舍 不 了)	she3bu5liao3
@@ -72110,7 +68356,6 @@ $textmode
 (舍 穆 理)	she4mu4li3
 (舍 穆 理)	she4mu4li3
 (舔 一 舔)	tian3yi4tian3
-(舔 ㊀ 舔)	tian3yi4tian3
 (芎 林 乡)	xiong1lin2xiang1
 (芎 林 乡)	xiong1lin2xiang1
 (芎 林 鄉)	xiong1lin2xiang1
@@ -72137,7 +68382,6 @@ $textmode
 (花 衣 服)	hua1yi1fu2
 (芸 苔 子)	yun2tai2zi3
 (苏 打 水)	su1da3shui3
-(苏 打 ㊌)	su1da3shui3
 (苑 裡 鎮)	yuan4li3zhen4
 (苑 裡 鎮)	yuan4li3zhen4
 (英 仙 座)	ying1xian1zuo4
@@ -72153,7 +68397,6 @@ $textmode
 (荨 麻 疹)	xun2ma2zhen3
 (药 师 佛)	yao4shi1fo2
 (药 水 儿)	yao4shui3r5
-(药 ㊌ 儿)	yao4shui3r5
 (荳 角 儿)	dou4jiao3r5
 (莊 稼 地)	zhuang1jia5di4
 (菟 丝 子)	tu4si1zi3
@@ -72168,25 +68411,16 @@ $textmode
 (菸 碱 酸)	yu1jian3suan1
 (菸 鹼 酸)	yu1jian3suan1
 (萧 一 山)	xiao1yi4shan1
-(萧 ㊀ 山)	xiao1yi4shan1
 (萧 子 显)	xiao1zi3xian3
 (萬 事 得)	wan4shi4de2
 (落 下 來)	luo4xia5lai5
-(落 ㊦ 來)	luo4xia5lai5
 (落 下 來)	luo4xia5lai5
-(落 ㊦ 來)	luo4xia5lai5
 (落 下 來)	luo4xia5lai5
-(落 ㊦ 來)	luo4xia5lai5
 (落 下 来)	luo4xia5lai5
-(落 ㊦ 来)	luo4xia5lai5
 (落 下 来)	luo4xia5lai5
-(落 ㊦ 来)	luo4xia5lai5
 (落 不 下)	lao4bu5xia4
-(落 不 ㊦)	lao4bu5xia4
 (落 不 下)	lao4bu5xia4
-(落 不 ㊦)	lao4bu5xia4
 (落 不 下)	lao4bu5xia4
-(落 不 ㊦)	lao4bu5xia4
 (落 不 着)	lao4bu5zhao2
 (落 不 着)	lao4bu5zhao2
 (落 不 着)	lao4bu5zhao2
@@ -72233,10 +68467,8 @@ $textmode
 (蔫 不 聲)	nian1bu5sheng1
 (蕁 麻 疹)	xun2ma2zhen3
 (蕭 一 山)	xiao1yi4shan1
-(蕭 ㊀ 山)	xiao1yi4shan1
 (蕭 子 顯)	xiao1zi3xian3
 (薄 一 波)	bo2yi4bo1
-(薄 ㊀ 波)	bo2yi4bo1
 (薄 油 层)	bo2you2ceng2
 (薄 油 層)	bo2you2ceng2
 (薄 油 層)	bo2you2ceng2
@@ -72259,15 +68491,12 @@ $textmode
 (藏 羚 羊)	cang2ling2yang2
 (藥 師 佛)	yao4shi1fo2
 (蘇 打 水)	su1da3shui3
-(蘇 打 ㊌)	su1da3shui3
 (虎 不 拉)	hu4bu5la3
 (虎 不 拉)	hu4bu5la3
 (虎 不 拉)	hu4bu5la3
 (虎 爪 派)	hu3zhua3pai4
 (處 不 下)	chu4bu5xia4
-(處 不 ㊦)	chu4bu5xia4
 (處 不 下)	chu4bu5xia4
-(處 不 ㊦)	chu4bu5xia4
 (處 不 來)	chu3bu5lai2
 (處 不 來)	chu3bu5lai2
 (處 不 來)	chu3bu5lai2
@@ -72317,13 +68546,9 @@ $textmode
 (被 誉 为)	bei4yu4wei2
 (被 譽 為)	bei4yu4wei2
 (装 不 下)	zhuang1bu5xia4
-(装 不 ㊦)	zhuang1bu5xia4
 (装 不 下)	zhuang1bu5xia4
-(装 不 ㊦)	zhuang1bu5xia4
 (裝 不 下)	zhuang1bu5xia4
-(裝 不 ㊦)	zhuang1bu5xia4
 (裝 不 下)	zhuang1bu5xia4
-(裝 不 ㊦)	zhuang1bu5xia4
 (裡 士 滿)	li3shi4man3
 (裡 士 滿)	li3shi4man3
 (裡 奧 斯)	li3ao4si1
@@ -72337,261 +68562,129 @@ $textmode
 (製 鞋 匠)	zhi4xie2jiang4
 (褒 禪 山)	bao1chan2shan1
 (西 三 条)	xi1san1tiao2
-(🀂 三 条)	xi1san1tiao2
-(西 ㊂ 条)	xi1san1tiao2
-(🀂 ㊂ 条)	xi1san1tiao2
 (西 三 條)	xi1san1tiao2
-(🀂 三 條)	xi1san1tiao2
-(西 ㊂ 條)	xi1san1tiao2
-(🀂 ㊂ 條)	xi1san1tiao2
 (西 伊 伯)	xi1yi1bo2
-(🀂 伊 伯)	xi1yi1bo2
 (西 伊 拉)	xi1yi1la1
-(🀂 伊 拉)	xi1yi1la1
 (西 伊 拉)	xi1yi1la1
-(🀂 伊 拉)	xi1yi1la1
 (西 公 都)	xi1gong1du1
-(🀂 公 都)	xi1gong1du1
 (西 公 都)	xi1gong1du1
-(🀂 公 都)	xi1gong1du1
 (西 兰 花)	xi1lan2hua1
-(🀂 兰 花)	xi1lan2hua1
 (西 利 拉)	xi1li4la1
-(🀂 利 拉)	xi1li4la1
 (西 利 拉)	xi1li4la1
-(🀂 利 拉)	xi1li4la1
 (西 利 拉)	xi1li4la1
-(🀂 利 拉)	xi1li4la1
 (西 半 球)	xi1ban4qiu2
-(🀂 半 球)	xi1ban4qiu2
 (西 卡 里)	xi1ka3li3
-(🀂 卡 里)	xi1ka3li3
 (西 卡 里)	xi1ka3li3
-(🀂 卡 里)	xi1ka3li3
 (西 印 度)	xi1yin4du4
-(🀂 印 度)	xi1yin4du4
-(西 ㊞ 度)	xi1yin4du4
-(🀂 ㊞ 度)	xi1yin4du4
 (西 印 度)	xi1yin4du4
-(🀂 印 度)	xi1yin4du4
-(西 ㊞ 度)	xi1yin4du4
-(🀂 ㊞ 度)	xi1yin4du4
 (西 厢 记)	xi1xiang1ji4
-(🀂 厢 记)	xi1xiang1ji4
 (西 城 区)	xi1cheng2qu1
-(🀂 城 区)	xi1cheng2qu1
 (西 城 區)	xi1cheng2qu1
-(🀂 城 區)	xi1cheng2qu1
 (西 塞 罗)	xi1sai1luo2
-(🀂 塞 罗)	xi1sai1luo2
 (西 塞 罗)	xi1sai1luo2
-(🀂 塞 罗)	xi1sai1luo2
 (西 塞 羅)	xi1sai1luo2
-(🀂 塞 羅)	xi1sai1luo2
 (西 塞 羅)	xi1sai1luo2
-(🀂 塞 羅)	xi1sai1luo2
 (西 塞 羅)	xi1sai1luo2
-(🀂 塞 羅)	xi1sai1luo2
 (西 屯 区)	xi1tun2qu1
-(🀂 屯 区)	xi1tun2qu1
 (西 屯 區)	xi1tun2qu1
-(🀂 屯 區)	xi1tun2qu1
 (西 山 区)	xi1shan1qu1
-(🀂 山 区)	xi1shan1qu1
 (西 山 區)	xi1shan1qu1
-(🀂 山 區)	xi1shan1qu1
 (西 屿 乡)	xi1yu3xiang1
-(🀂 屿 乡)	xi1yu3xiang1
 (西 嶼 鄉)	xi1yu3xiang1
-(🀂 嶼 鄉)	xi1yu3xiang1
 (西 工 区)	xi1gong1qu1
-(🀂 工 区)	xi1gong1qu1
 (西 工 區)	xi1gong1qu1
-(🀂 工 區)	xi1gong1qu1
 (西 市 区)	xi1shi4qu1
-(🀂 市 区)	xi1shi4qu1
 (西 市 區)	xi1shi4qu1
-(🀂 市 區)	xi1shi4qu1
 (西 布 伦)	xi1bu4lun2
-(🀂 布 伦)	xi1bu4lun2
 (西 布 倫)	xi1bu4lun2
-(🀂 布 倫)	xi1bu4lun2
 (西 布 倫)	xi1bu4lun2
-(🀂 布 倫)	xi1bu4lun2
 (西 布 勒)	xi1bu4le4
-(🀂 布 勒)	xi1bu4le4
 (西 布 勒)	xi1bu4le4
-(🀂 布 勒)	xi1bu4le4
 (西 庇 太)	xi1bi4tai4
-(🀂 庇 太)	xi1bi4tai4
 (西 底 家)	xi1di3jia1
-(🀂 底 家)	xi1di3jia1
 (西 廂 記)	xi1xiang1ji4
-(🀂 廂 記)	xi1xiang1ji4
 (西 徐 亚)	xi1xu2ya4
-(🀂 徐 亚)	xi1xu2ya4
 (西 徐 亞)	xi1xu2ya4
-(🀂 徐 亞)	xi1xu2ya4
 (西 拿 雅)	xi1na2ya3
-(🀂 拿 雅)	xi1na2ya3
 (西 提 利)	xi1ti2li4
-(🀂 提 利)	xi1ti2li4
 (西 提 利)	xi1ti2li4
-(🀂 提 利)	xi1ti2li4
 (西 提 拿)	xi1ti2na2
-(🀂 提 拿)	xi1ti2na2
 (西 播 列)	xi1bo1lie4
-(🀂 播 列)	xi1bo1lie4
 (西 播 列)	xi1bo1lie4
-(🀂 播 列)	xi1bo1lie4
 (西 斐 仑)	xi1fei3lun2
-(🀂 斐 仑)	xi1fei3lun2
 (西 斐 侖)	xi1fei3lun2
-(🀂 斐 侖)	xi1fei3lun2
 (西 斐 安)	xi1fei3an1
-(🀂 斐 安)	xi1fei3an1
 (西 斯 迈)	xi1si1mai4
-(🀂 斯 迈)	xi1si1mai4
 (西 斯 邁)	xi1si1mai4
-(🀂 斯 邁)	xi1si1mai4
 (西 格 玛)	xi1ge2ma3
-(🀂 格 玛)	xi1ge2ma3
 (西 格 瑪)	xi1ge2ma3
-(🀂 格 瑪)	xi1ge2ma3
 (西 格 馬)	xi1ge2ma3
-(🀂 格 馬)	xi1ge2ma3
 (西 格 马)	xi1ge2ma3
-(🀂 格 马)	xi1ge2ma3
 (西 楼 梦)	xi1lou2meng4
-(🀂 楼 梦)	xi1lou2meng4
 (西 楼 记)	xi1lou2ji4
-(🀂 楼 记)	xi1lou2ji4
 (西 樓 夢)	xi1lou2meng4
-(🀂 樓 夢)	xi1lou2meng4
 (西 樓 夢)	xi1lou2meng4
-(🀂 樓 夢)	xi1lou2meng4
 (西 樓 記)	xi1lou2ji4
-(🀂 樓 記)	xi1lou2ji4
 (西 樓 記)	xi1lou2ji4
-(🀂 樓 記)	xi1lou2ji4
 (西 比 亚)	xi1bi3ya4
-(🀂 比 亚)	xi1bi3ya4
 (西 比 亞)	xi1bi3ya4
-(🀂 比 亞)	xi1bi3ya4
 (西 比 拿)	xi1bi3na2
-(🀂 比 拿)	xi1bi3na2
 (西 比 玛)	xi1bi3ma3
-(🀂 比 玛)	xi1bi3ma3
 (西 比 瑪)	xi1bi3ma3
-(🀂 比 瑪)	xi1bi3ma3
 (西 比 該)	xi1bi3gai1
-(🀂 比 該)	xi1bi3gai1
 (西 比 该)	xi1bi3gai1
-(🀂 比 该)	xi1bi3gai1
 (西 比 雅)	xi1bi3ya3
-(🀂 比 雅)	xi1bi3ya3
 (西 比 黛)	xi1bi3dai4
-(🀂 比 黛)	xi1bi3dai4
 (西 港 乡)	xi1gang3xiang1
-(🀂 港 乡)	xi1gang3xiang1
 (西 港 鄉)	xi1gang3xiang1
-(🀂 港 鄉)	xi1gang3xiang1
 (西 王 母)	xi1wang2mu3
-(🀂 王 母)	xi1wang2mu3
 (西 玛 迦)	xi1ma3jia1
-(🀂 玛 迦)	xi1ma3jia1
 (西 瑪 迦)	xi1ma3jia1
-(🀂 瑪 迦)	xi1ma3jia1
 (西 番 莲)	xi1fan1lian2
-(🀂 番 莲)	xi1fan1lian2
 (西 番 蓮)	xi1fan1lian2
-(🀂 番 蓮)	xi1fan1lian2
 (西 番 蓮)	xi1fan1lian2
-(🀂 番 蓮)	xi1fan1lian2
 (西 番 雅)	xi1fan1ya3
-(🀂 番 雅)	xi1fan1ya3
 (西 直 門)	xi1zhi2men2
-(🀂 直 門)	xi1zhi2men2
 (西 直 門)	xi1zhi2men2
-(🀂 直 門)	xi1zhi2men2
 (西 直 门)	xi1zhi2men2
-(🀂 直 门)	xi1zhi2men2
 (西 直 门)	xi1zhi2men2
-(🀂 直 门)	xi1zhi2men2
 (西 紅 柿)	xi1hong2shi4
-(🀂 紅 柿)	xi1hong2shi4
 (西 红 柿)	xi1hong2shi4
-(🀂 红 柿)	xi1hong2shi4
 (西 罗 亚)	xi1luo2ya4
-(🀂 罗 亚)	xi1luo2ya4
 (西 罗 雅)	xi1luo2ya3
-(🀂 罗 雅)	xi1luo2ya3
 (西 羅 亞)	xi1luo2ya4
-(🀂 羅 亞)	xi1luo2ya4
 (西 羅 亞)	xi1luo2ya4
-(🀂 羅 亞)	xi1luo2ya4
 (西 羅 雅)	xi1luo2ya3
-(🀂 羅 雅)	xi1luo2ya3
 (西 羅 雅)	xi1luo2ya3
-(🀂 羅 雅)	xi1luo2ya3
 (西 花 厅)	xi1hua1ting1
-(🀂 花 厅)	xi1hua1ting1
 (西 花 廳)	xi1hua1ting1
-(🀂 花 廳)	xi1hua1ting1
 (西 莱 雅)	xi1lai2ya3
-(🀂 莱 雅)	xi1lai2ya3
 (西 萊 雅)	xi1lai2ya3
-(🀂 萊 雅)	xi1lai2ya3
 (西 葫 芦)	xi1hu2lu5
-(🀂 葫 芦)	xi1hu2lu5
 (西 葫 蘆)	xi1hu2lu5
-(🀂 葫 蘆)	xi1hu2lu5
 (西 葫 蘆)	xi1hu2lu5
-(🀂 葫 蘆)	xi1hu2lu5
 (西 蘭 花)	xi1lan2hua1
-(🀂 蘭 花)	xi1lan2hua1
 (西 蘭 花)	xi1lan2hua1
-(🀂 蘭 花)	xi1lan2hua1
 (西 螺 鎮)	xi1luo2zhen4
-(🀂 螺 鎮)	xi1luo2zhen4
 (西 螺 鎮)	xi1luo2zhen4
-(🀂 螺 鎮)	xi1luo2zhen4
 (西 螺 镇)	xi1luo2zhen4
-(🀂 螺 镇)	xi1luo2zhen4
 (西 螺 镇)	xi1luo2zhen4
-(🀂 螺 镇)	xi1luo2zhen4
 (西 裡 爾)	xi1li3er3
-(🀂 裡 爾)	xi1li3er3
 (西 裡 爾)	xi1li3er3
-(🀂 裡 爾)	xi1li3er3
 (西 西 拉)	xi1xi1la1
-(🀂 🀂 拉)	xi1xi1la1
 (西 西 拉)	xi1xi1la1
-(🀂 🀂 拉)	xi1xi1la1
 (西 西 里)	xi1xi1li3
-(🀂 🀂 里)	xi1xi1li3
 (西 西 里)	xi1xi1li3
-(🀂 🀂 里)	xi1xi1li3
 (西 边 儿)	xi1bian5r5
-(🀂 边 儿)	xi1bian5r5
 (西 迦 迦)	xi1jia1jia1
-(🀂 迦 迦)	xi1jia1jia1
 (西 遊 补)	xi1you2bu3
-(🀂 遊 补)	xi1you2bu3
 (西 遊 補)	xi1you2bu3
-(🀂 遊 補)	xi1you2bu3
 (西 遊 記)	xi1you2ji4
-(🀂 遊 記)	xi1you2ji4
 (西 遊 记)	xi1you2ji4
-(🀂 遊 记)	xi1you2ji4
 (西 里 尔)	xi1li3er3
-(🀂 里 尔)	xi1li3er3
 (西 里 尔)	xi1li3er3
-(🀂 里 尔)	xi1li3er3
 (西 門 子)	xi1men2zi3
-(🀂 門 子)	xi1men2zi3
 (西 门 子)	xi1men2zi3
-(🀂 门 子)	xi1men2zi3
 (要 不 得)	yao4bu5de5
 (要 不 得)	yao4bu5de5
 (要 不 是)	yao4bu5shi4
@@ -72618,7 +68711,6 @@ $textmode
 (見 得 著)	jian4de5zhao2
 (見 得 著)	jian4de5zhao2
 (規 一 化)	gui1yi2hua4
-(規 ㊀ 化)	gui1yi2hua4
 (覺 不 出)	jue2bu5chu1
 (覺 不 出)	jue2bu5chu1
 (覺 不 到)	jue2bu5dao4
@@ -72635,7 +68727,6 @@ $textmode
 (见 得 着)	jian4de5zhao2
 (见 得 着)	jian4de5zhao2
 (规 一 化)	gui1yi2hua4
-(规 ㊀ 化)	gui1yi2hua4
 (觉 不 出)	jue2bu5chu1
 (觉 不 出)	jue2bu5chu1
 (觉 不 到)	jue2bu5dao4
@@ -72657,9 +68748,7 @@ $textmode
 (訕 不 搭)	shan4bu5da1
 (訕 不 搭)	shan4bu5da1
 (記 下 來)	ji4xia4lai2
-(記 ㊦ 來)	ji4xia4lai2
 (記 下 來)	ji4xia4lai2
-(記 ㊦ 來)	ji4xia4lai2
 (記 不 住)	ji4bu5zhu4
 (記 不 住)	ji4bu5zhu4
 (記 不 全)	ji4bu5quan2
@@ -72677,9 +68766,7 @@ $textmode
 (許 廑 父)	xu3qin2fu4
 (証 监 会)	zheng4jian4hui4
 (証 監 會)	zheng4jian4hui4
-(証 ㊬ 會)	zheng4jian4hui4
 (試 一 試)	shi4yi2shi4
-(試 ㊀ 試)	shi4yi2shi4
 (試 不 好)	shi4bu5hao3
 (試 不 好)	shi4bu5hao3
 (該 不 著)	gai1bu5zhao2
@@ -72697,21 +68784,13 @@ $textmode
 (誤 不 了)	wu4bu5liao3
 (誤 不 了)	wu4bu5liao3
 (說 不 上)	shuo1bu5shang4
-(說 不 ㊤)	shuo1bu5shang4
 (說 不 上)	shuo1bu5shang4
-(說 不 ㊤)	shuo1bu5shang4
 (說 不 上)	shuo1bu5shang4
-(說 不 ㊤)	shuo1bu5shang4
 (說 不 上)	shuo1bu5shang4
-(說 不 ㊤)	shuo1bu5shang4
 (說 不 下)	shuo1bu5xia4
-(說 不 ㊦)	shuo1bu5xia4
 (說 不 下)	shuo1bu5xia4
-(說 不 ㊦)	shuo1bu5xia4
 (說 不 下)	shuo1bu5xia4
-(說 不 ㊦)	shuo1bu5xia4
 (說 不 下)	shuo1bu5xia4
-(說 不 ㊦)	shuo1bu5xia4
 (說 不 了)	shuo1bu5liao3
 (說 不 了)	shuo1bu5liao3
 (說 不 了)	shuo1bu5liao3
@@ -72788,11 +68867,8 @@ $textmode
 (說 不 齊)	shuo1bu5qi2
 (說 不 齊)	shuo1bu5qi2
 (說 得 上)	shuo1de5shang4
-(說 得 ㊤)	shuo1de5shang4
 (說 得 上)	shuo1de5shang4
-(說 得 ㊤)	shuo1de5shang4
 (說 得 上)	shuo1de5shang4
-(說 得 ㊤)	shuo1de5shang4
 (說 得 來)	shuo1de5lai2
 (說 得 來)	shuo1de5lai2
 (說 得 來)	shuo1de5lai2
@@ -72811,16 +68887,13 @@ $textmode
 (調 藥 刀)	tiao2yao4dao1
 (調 藥 刀)	tiao2yao4dao1
 (談 不 上)	tan2bu5shang4
-(談 不 ㊤)	tan2bu5shang4
 (談 不 上)	tan2bu5shang4
-(談 不 ㊤)	tan2bu5shang4
 (談 不 來)	tan2bu5lai2
 (談 不 來)	tan2bu5lai2
 (談 不 來)	tan2bu5lai2
 (談 不 到)	tan2bu5dao4
 (談 不 到)	tan2bu5dao4
 (談 得 上)	tan2de5shang4
-(談 得 ㊤)	tan2de5shang4
 (談 得 來)	tan2de5lai2
 (談 得 來)	tan2de5lai2
 (談 得 到)	tan2de5dao4
@@ -72836,7 +68909,6 @@ $textmode
 (變 奏 曲)	bian4zou4qu3
 (變 奏 曲)	bian4zou4qu3
 (讓 一 讓)	rang4yi5rang4
-(讓 ㊀ 讓)	rang4yi5rang4
 (认 不 出)	ren4bu5chu1
 (认 不 出)	ren4bu5chu1
 (认 不 得)	ren4bu5de2
@@ -72852,11 +68924,9 @@ $textmode
 (讨 便 宜)	tao3pian2yi5
 (讨 底 儿)	tao3di3r5
 (让 一 让)	rang4yi5rang4
-(让 ㊀ 让)	rang4yi5rang4
 (讪 不 搭)	shan4bu5da1
 (讪 不 搭)	shan4bu5da1
 (记 下 来)	ji4xia4lai2
-(记 ㊦ 来)	ji4xia4lai2
 (记 不 住)	ji4bu5zhu4
 (记 不 住)	ji4bu5zhu4
 (记 不 全)	ji4bu5quan2
@@ -72878,7 +68948,6 @@ $textmode
 (许 地 山)	xu3di4shan1
 (许 廑 父)	xu3qin2fu4
 (试 一 试)	shi4yi2shi4
-(试 ㊀ 试)	shi4yi2shi4
 (试 不 好)	shi4bu5hao3
 (试 不 好)	shi4bu5hao3
 (话 茬 儿)	hua4cha2r5
@@ -72889,13 +68958,9 @@ $textmode
 (误 不 了)	wu4bu5liao3
 (误 不 了)	wu4bu5liao3
 (说 不 上)	shuo1bu5shang4
-(说 不 ㊤)	shuo1bu5shang4
 (说 不 上)	shuo1bu5shang4
-(说 不 ㊤)	shuo1bu5shang4
 (说 不 下)	shuo1bu5xia4
-(说 不 ㊦)	shuo1bu5xia4
 (说 不 下)	shuo1bu5xia4
-(说 不 ㊦)	shuo1bu5xia4
 (说 不 了)	shuo1bu5liao3
 (说 不 了)	shuo1bu5liao3
 (说 不 了)	shuo1bu5liao3
@@ -72935,7 +69000,6 @@ $textmode
 (说 不 齐)	shuo1bu5qi2
 (说 不 齐)	shuo1bu5qi2
 (说 得 上)	shuo1de5shang4
-(说 得 ㊤)	shuo1de5shang4
 (说 得 出)	shuo1de5chu1
 (说 得 来)	shuo1de5lai2
 (说 得 着)	shuo1de5zhao2
@@ -72944,15 +69008,12 @@ $textmode
 (谁 知 道)	shei2zhi1dao4
 (调 药 刀)	tiao2yao4dao1
 (谈 不 上)	tan2bu5shang4
-(谈 不 ㊤)	tan2bu5shang4
 (谈 不 上)	tan2bu5shang4
-(谈 不 ㊤)	tan2bu5shang4
 (谈 不 到)	tan2bu5dao4
 (谈 不 到)	tan2bu5dao4
 (谈 不 来)	tan2bu5lai2
 (谈 不 来)	tan2bu5lai2
 (谈 得 上)	tan2de5shang4
-(谈 得 ㊤)	tan2de5shang4
 (谈 得 到)	tan2de5dao4
 (谈 得 来)	tan2de5lai2
 (谐 振 子)	xie2zhen4zi3
@@ -72964,19 +69025,12 @@ $textmode
 (谷 梁 傳)	gu4liang2zhuan4
 (負 重 擔)	fu4zhong4dan1
 (貯 水 處)	zhu3shui3chu4
-(貯 ㊌ 處)	zhu3shui3chu4
 (買 下 來)	mai3xia4lai2
-(買 ㊦ 來)	mai3xia4lai2
 (買 下 來)	mai3xia4lai2
-(買 ㊦ 來)	mai3xia4lai2
 (買 不 上)	mai3bu5shang4
-(買 不 ㊤)	mai3bu5shang4
 (買 不 上)	mai3bu5shang4
-(買 不 ㊤)	mai3bu5shang4
 (買 不 下)	mai3bu5xia4
-(買 不 ㊦)	mai3bu5xia4
 (買 不 下)	mai3bu5xia4
-(買 不 ㊦)	mai3bu5xia4
 (買 不 來)	mai3bu5lai2
 (買 不 來)	mai3bu5lai2
 (買 不 來)	mai3bu5lai2
@@ -73010,9 +69064,7 @@ $textmode
 (賠 不 了)	pei2bu5liao3
 (賠 不 了)	pei2bu5liao3
 (賣 不 上)	mai4bu5shang4
-(賣 不 ㊤)	mai4bu5shang4
 (賣 不 上)	mai4bu5shang4
-(賣 不 ㊤)	mai4bu5shang4
 (賣 不 了)	mai4bu5liao3
 (賣 不 了)	mai4bu5liao3
 (賣 不 了)	mai4bu5liao3
@@ -73035,7 +69087,6 @@ $textmode
 (负 重 担)	fu4zhong4dan1
 (败 家 子)	bai4jia1zi3
 (贮 水 处)	zhu3shui3chu4
-(贮 ㊌ 处)	zhu3shui3chu4
 (贴 不 起)	tie1bu5qi3
 (贴 不 起)	tie1bu5qi3
 (费 不 了)	fei4bu5liao3
@@ -73093,11 +69144,8 @@ $textmode
 (走 神 儿)	zou3shen2r5
 (走 神 儿)	zou3shen2r5
 (赶 上 来)	gan3shang4lai2
-(赶 ㊤ 来)	gan3shang4lai2
 (赶 不 上)	gan3bu5shang4
-(赶 不 ㊤)	gan3bu5shang4
 (赶 不 上)	gan3bu5shang4
-(赶 不 ㊤)	gan3bu5shang4
 (赶 不 及)	gan3bu5ji2
 (赶 不 及)	gan3bu5ji2
 (赶 不 来)	gan3bu5lai2
@@ -73105,27 +69153,21 @@ $textmode
 (赶 出 去)	gan3chu1qu4
 (赶 出 来)	gan3chu1lai2
 (赶 得 上)	gan3de5shang4
-(赶 得 ㊤)	gan3de5shang4
 (起 不 來)	qi3bu5lai2
 (起 不 來)	qi3bu5lai2
 (起 不 來)	qi3bu5lai2
 (起 不 来)	qi3bu5lai2
 (起 不 来)	qi3bu5lai2
 (起 名 儿)	qi3ming2r5
-(起 ㊔ 儿)	qi3ming2r5
 (起 扑 杆)	qi3pu1gan3
 (超 不 过)	chao1bu5guo4
 (超 不 过)	chao1bu5guo4
 (超 不 過)	chao1bu5guo4
 (超 不 過)	chao1bu5guo4
 (趕 上 來)	gan3shang4lai2
-(趕 ㊤ 來)	gan3shang4lai2
 (趕 上 來)	gan3shang4lai2
-(趕 ㊤ 來)	gan3shang4lai2
 (趕 不 上)	gan3bu5shang4
-(趕 不 ㊤)	gan3bu5shang4
 (趕 不 上)	gan3bu5shang4
-(趕 不 ㊤)	gan3bu5shang4
 (趕 不 來)	gan3bu5lai2
 (趕 不 來)	gan3bu5lai2
 (趕 不 來)	gan3bu5lai2
@@ -73135,9 +69177,7 @@ $textmode
 (趕 出 來)	gan3chu1lai2
 (趕 出 去)	gan3chu1qu4
 (趕 得 上)	gan3de5shang4
-(趕 得 ㊤)	gan3de5shang4
 (跌 一 跤)	die1yi4jiao1
-(跌 ㊀ 跤)	die1yi4jiao1
 (跑 不 了)	pao3bu5liao3
 (跑 不 了)	pao3bu5liao3
 (跑 不 了)	pao3bu5liao3
@@ -73154,21 +69194,14 @@ $textmode
 (跑 神 儿)	pao3shen2r5
 (跑 腿 儿)	pao3tui3r5
 (跟 不 上)	gen1bu5shang4
-(跟 不 ㊤)	gen1bu5shang4
 (跟 不 上)	gen1bu5shang4
-(跟 不 ㊤)	gen1bu5shang4
 (跟 得 上)	gen1de5shang4
-(跟 得 ㊤)	gen1de5shang4
 (跪 下 來)	gui4xia4lai5
-(跪 ㊦ 來)	gui4xia4lai5
 (跪 下 來)	gui4xia4lai5
-(跪 ㊦ 來)	gui4xia4lai5
 (跪 下 来)	gui4xia4lai5
-(跪 ㊦ 来)	gui4xia4lai5
 (路 司 得)	lu4si1de2
 (路 司 得)	lu4si1de2
 (跳 下 去)	tiao4xia4qu4
-(跳 ㊦ 去)	tiao4xia4qu4
 (蹦 高 儿)	beng4gao1r5
 (身 板 儿)	shen1ban3r5
 (躲 不 了)	duo3bu5liao3
@@ -73181,15 +69214,10 @@ $textmode
 (躲 不 開)	duo3bu5kai1
 (躲 不 開)	duo3bu5kai1
 (躺 下 來)	tang3xia4lai2
-(躺 ㊦ 來)	tang3xia4lai2
 (躺 下 來)	tang3xia4lai2
-(躺 ㊦ 來)	tang3xia4lai2
 (躺 下 来)	tang3xia4lai2
-(躺 ㊦ 来)	tang3xia4lai2
 (躺 不 下)	tang3bu5xia4
-(躺 不 ㊦)	tang3bu5xia4
 (躺 不 下)	tang3bu5xia4
-(躺 不 ㊦)	tang3bu5xia4
 (躺 不 稳)	tang3bu5wen3
 (躺 不 稳)	tang3bu5wen3
 (躺 不 穩)	tang3bu5wen3
@@ -73206,9 +69234,7 @@ $textmode
 (輻 射 場)	fu3she4chang3
 (輻 射 場)	fu3she4chang3
 (轉 一 趟)	zhuan4yi2tang4
-(轉 ㊀ 趟)	zhuan4yi2tang4
 (轉 一 轉)	zhuan4yi5zhuan4
-(轉 ㊀ 轉)	zhuan4yi5zhuan4
 (轉 不 過)	zhuan3bu5guo4
 (轉 不 過)	zhuan3bu5guo4
 (轉 字 鎖)	zhuan4zi4suo3
@@ -73219,14 +69245,11 @@ $textmode
 (轉 輪 王)	zhuan3lun2wang2
 (车 把 式)	che1ba3shi5
 (转 一 趟)	zhuan4yi2tang4
-(转 ㊀ 趟)	zhuan4yi2tang4
 (转 一 转)	zhuan4yi5zhuan4
-(转 ㊀ 转)	zhuan4yi5zhuan4
 (转 不 过)	zhuan3bu5guo4
 (转 不 过)	zhuan3bu5guo4
 (转 字 锁)	zhuan4zi4suo3
 (转 学 生)	zhuan3xue2sheng1
-(转 ㊫ 生)	zhuan3xue2sheng1
 (转 车 台)	zhuan4che1tai2
 (转 轮 王)	zhuan3lun2wang2
 (转 轴 儿)	zhuan4zhou2r5
@@ -73243,9 +69266,7 @@ $textmode
 (辜 振 甫)	gu1zhen4fu3
 (辣 哈 布)	la1ha1bu4
 (辦 不 下)	ban4bu5xia4
-(辦 不 ㊦)	ban4bu5xia4
 (辦 不 下)	ban4bu5xia4
-(辦 不 ㊦)	ban4bu5xia4
 (辦 不 了)	ban4bu5liao3
 (辦 不 了)	ban4bu5liao3
 (辦 不 了)	ban4bu5liao3
@@ -73271,11 +69292,8 @@ $textmode
 (辯 護 士)	bian4hu4shi4
 (达 喀 尔)	da2ka4er3
 (达 芬 西)	da2fen1xi1
-(达 芬 🀂)	da2fen1xi1
 (过 不 下)	guo4bu5xia4
-(过 不 ㊦)	guo4bu5xia4
 (过 不 下)	guo4bu5xia4
-(过 不 ㊦)	guo4bu5xia4
 (过 不 了)	guo4bu5liao3
 (过 不 了)	guo4bu5liao3
 (过 不 了)	guo4bu5liao3
@@ -73297,7 +69315,6 @@ $textmode
 (迈 不 开)	mai4bu5kai1
 (还 得 起)	huan2de5qi3
 (这 个 月)	zhei4ge4yue4
-(这 个 ㊊)	zhei4ge4yue4
 (这 些 个)	zhe4xie1ge5
 (这 会 儿)	zhe4hui4r5
 (这 年 头)	zhe4nian2tou5
@@ -73311,17 +69328,13 @@ $textmode
 (进 行 曲)	jin4xing2qu3
 (进 行 曲)	jin4xing2qu3
 (连 不 上)	lian2bu5shang4
-(连 不 ㊤)	lian2bu5shang4
 (连 不 上)	lian2bu5shang4
-(连 不 ㊤)	lian2bu5shang4
 (迦 勒 得)	jia1le4de2
 (迦 勒 得)	jia1le4de2
 (迫 击 炮)	pai3ji1pao4
 (迫 擊 炮)	pai3ji1pao4
 (追 不 上)	zhui1bu5shang4
-(追 不 ㊤)	zhui1bu5shang4
 (追 不 上)	zhui1bu5shang4
-(追 不 ㊤)	zhui1bu5shang4
 (追 不 到)	zhui1bu5dao4
 (追 不 到)	zhui1bu5dao4
 (送 不 起)	song4bu5qi3
@@ -73343,7 +69356,6 @@ $textmode
 (逗 趣 儿)	dou4qu4r5
 (這 些 個)	zhe4xie1ge5
 (這 個 月)	zhei4ge4yue4
-(這 個 ㊊)	zhei4ge4yue4
 (這 年 頭)	zhe4nian2tou5
 (這 年 頭)	zhe4nian2tou5
 (通 不 过)	tong1bu5guo4
@@ -73351,16 +69363,12 @@ $textmode
 (通 不 過)	tong1bu5guo4
 (通 不 過)	tong1bu5guo4
 (逛 一 逛)	guang4yi2guang4
-(逛 ㊀ 逛)	guang4yi2guang4
 (速 調 管)	su4tiao2guan3
 (速 調 管)	su4tiao2guan3
 (速 调 管)	su4tiao2guan3
 (連 不 上)	lian2bu5shang4
-(連 不 ㊤)	lian2bu5shang4
 (連 不 上)	lian2bu5shang4
-(連 不 ㊤)	lian2bu5shang4
 (連 不 上)	lian2bu5shang4
-(連 不 ㊤)	lian2bu5shang4
 (進 不 來)	jin4bu5lai2
 (進 不 來)	jin4bu5lai2
 (進 不 來)	jin4bu5lai2
@@ -73369,13 +69377,9 @@ $textmode
 (進 行 曲)	jin4xing2qu3
 (進 行 曲)	jin4xing2qu3
 (遇 不 上)	yu4bu5shang4
-(遇 不 ㊤)	yu4bu5shang4
 (遇 不 上)	yu4bu5shang4
-(遇 不 ㊤)	yu4bu5shang4
 (過 不 下)	guo4bu5xia4
-(過 不 ㊦)	guo4bu5xia4
 (過 不 下)	guo4bu5xia4
-(過 不 ㊦)	guo4bu5xia4
 (過 不 了)	guo4bu5liao3
 (過 不 了)	guo4bu5liao3
 (過 不 了)	guo4bu5liao3
@@ -73397,7 +69401,6 @@ $textmode
 (過 得 著)	guo4de5zhao2
 (達 喀 爾)	da2ka4er3
 (達 芬 西)	da2fen1xi1
-(達 芬 🀂)	da2fen1xi1
 (遗 腹 子)	yi2fu4zi3
 (遞 不 到)	di4bu5dao4
 (遞 不 到)	di4bu5dao4
@@ -73430,11 +69433,8 @@ $textmode
 (都 江 堰)	du1jiang1yan4
 (都 江 堰)	du1jiang1yan4
 (配 不 上)	pei4bu5shang4
-(配 不 ㊤)	pei4bu5shang4
 (配 不 上)	pei4bu5shang4
-(配 不 ㊤)	pei4bu5shang4
 (配 得 上)	pei4de5shang4
-(配 得 ㊤)	pei4de5shang4
 (配 得 來)	pei4de5lai2
 (配 得 來)	pei4de5lai2
 (配 得 来)	pei4de5lai2
@@ -73452,14 +69452,11 @@ $textmode
 (里 边 儿)	li3bian1r5
 (里 边 儿)	li3bian1r5
 (重 孙 女)	chong2sun1nv5
-(重 孙 ㊛)	chong2sun1nv5
 (重 孙 女)	chong2sun1nv5
 (重 孫 女)	chong2sun1nv5
-(重 孫 ㊛)	chong2sun1nv5
 (重 孫 女)	chong2sun1nv5
 (重 定 向)	chong2ding4xiang4
 (重 正 化)	chong2zheng4hua4
-(重 ㊣ 化)	chong2zheng4hua4
 (重 眼 皮)	chong2yan3pi2
 (重 結 晶)	chong2jie2jing1
 (重 结 晶)	chong2jie2jing1
@@ -73469,9 +69466,7 @@ $textmode
 (重 量 计)	zhong4liang4ji4
 (野 葡 萄)	ye3pu2tao2
 (量 一 量)	liang2yi5liang2
-(量 ㊀ 量)	liang2yi5liang2
 (量 一 量)	liang2yi5liang2
-(量 ㊀ 量)	liang2yi5liang2
 (量 体 温)	liang2ti3wen1
 (量 体 温)	liang2ti3wen1
 (量 体 重)	liang2ti3zhong4
@@ -73486,43 +69481,28 @@ $textmode
 (量 體 重)	liang2ti3zhong4
 (量 體 重)	liang2ti3zhong4
 (金 不 换)	jin1bu5huan4
-(㊎ 不 换)	jin1bu5huan4
 (金 不 换)	jin1bu5huan4
 (金 不 换)	jin1bu5huan4
-(㊎ 不 换)	jin1bu5huan4
 (金 不 換)	jin1bu5huan4
-(㊎ 不 換)	jin1bu5huan4
 (金 不 換)	jin1bu5huan4
 (金 不 換)	jin1bu5huan4
-(㊎ 不 換)	jin1bu5huan4
 (金 合 欢)	jin1he2huan1
-(㊎ 合 欢)	jin1he2huan1
 (金 合 欢)	jin1he2huan1
 (金 合 歡)	jin1he2huan1
-(㊎ 合 歡)	jin1he2huan1
 (金 合 歡)	jin1he2huan1
 (金 裡 奇)	jin1li3qi2
-(㊎ 裡 奇)	jin1li3qi2
 (金 裡 奇)	jin1li3qi2
 (金 裡 奇)	jin1li3qi2
-(㊎ 裡 奇)	jin1li3qi2
 (金 針 菇)	jin1zhen1gu1
-(㊎ 針 菇)	jin1zhen1gu1
 (金 針 菇)	jin1zhen1gu1
 (金 针 菇)	jin1zhen1gu1
-(㊎ 针 菇)	jin1zhen1gu1
 (金 针 菇)	jin1zhen1gu1
 (金 龜 子)	jin1gui1zi3
-(㊎ 龜 子)	jin1gui1zi3
 (金 龜 子)	jin1gui1zi3
-(㊎ 龜 子)	jin1gui1zi3
 (金 龜 子)	jin1gui1zi3
-(㊎ 龜 子)	jin1gui1zi3
 (金 龜 子)	jin1gui1zi3
-(㊎ 龜 子)	jin1gui1zi3
 (金 龜 子)	jin1gui1zi3
 (金 龟 子)	jin1gui1zi3
-(㊎ 龟 子)	jin1gui1zi3
 (金 龟 子)	jin1gui1zi3
 (釘 書 針)	ding4shu1zhen1
 (銀 晃 晃)	yin2huang4huang5
@@ -73536,9 +69516,7 @@ $textmode
 (錯 不 了)	cuo4bu5liao3
 (鍾 子 期)	zhong1zi3qi1
 (鎖 不 上)	suo3bu5shang4
-(鎖 不 ㊤)	suo3bu5shang4
 (鎖 不 上)	suo3bu5shang4
-(鎖 不 ㊤)	suo3bu5shang4
 (鎖 不 住)	suo3bu5zhu4
 (鎖 不 住)	suo3bu5zhu4
 (鐺 鐺 車)	dang1dang1che1
@@ -73555,9 +69533,7 @@ $textmode
 (铺 石 地)	pu1shi2di4
 (铺 面 房)	pu4mian4fang2
 (锁 不 上)	suo3bu5shang4
-(锁 不 ㊤)	suo3bu5shang4
 (锁 不 上)	suo3bu5shang4
-(锁 不 ㊤)	suo3bu5shang4
 (锁 不 住)	suo3bu5zhu4
 (锁 不 住)	suo3bu5zhu4
 (错 不 了)	cuo4bu5liao3
@@ -73625,7 +69601,6 @@ $textmode
 (闹 不 清)	nao4bu5qing1
 (闹 笑 话)	nao4xiao4hua4
 (闻 一 多)	wen2yi4duo1
-(闻 ㊀ 多)	wen2yi4duo1
 (闻 不 出)	wen2bu5chu1
 (闻 不 出)	wen2bu5chu1
 (闻 不 得)	wen2bu5de2
@@ -73667,7 +69642,6 @@ $textmode
 (阿 魯 巴)	a1lu3ba1
 (阿 鲁 巴)	a1lu3ba1
 (陆 西 星)	lu4xi1xing1
-(陆 🀂 星)	lu4xi1xing1
 (陈 天 华)	chen2tian1hua4
 (陈 省 身)	chen2xing3shen1
 (陈 省 身)	chen2xing3shen1
@@ -73683,9 +69657,7 @@ $textmode
 (陸 徵 祥)	lu4zheng1xiang2
 (陸 徵 祥)	lu4zheng1xiang2
 (陸 西 星)	lu4xi1xing1
-(陸 🀂 星)	lu4xi1xing1
 (陸 西 星)	lu4xi1xing1
-(陸 🀂 星)	lu4xi1xing1
 (随 风 倒)	sui2feng1dao3
 (隐 密 巴)	yin3mi4ba1
 (隨 風 倒)	sui2feng1dao3
@@ -73701,16 +69673,12 @@ $textmode
 (雀 盲 眼)	qiao3mang5yan3
 (雄 赳 赳)	xiong2jiu1jiu1
 (雅 利 西)	ya3li4xi1
-(雅 利 🀂)	ya3li4xi1
 (雅 利 西)	ya3li4xi1
-(雅 利 🀂)	ya3li4xi1
 (雅 哥 巴)	ya3ge1ba1
 (雅 温 得)	ya3wen1de2
 (雅 溫 得)	ya3wen1de2
 (雅 西 业)	ya3xi1ye4
-(雅 🀂 业)	ya3xi1ye4
 (雅 西 業)	ya3xi1ye4
-(雅 🀂 業)	ya3xi1ye4
 (雅 諾 什)	ya3nuo4shi2
 (雅 諾 什)	ya3nuo4shi2
 (雅 諾 什)	ya3nuo4shi2
@@ -73759,9 +69727,7 @@ $textmode
 (霍 華 得)	huo4hua1de5
 (霍 華 得)	huo4hua1de5
 (露 一 手)	lou4yi4shou3
-(露 ㊀ 手)	lou4yi4shou3
 (露 一 手)	lou4yi4shou3
-(露 ㊀ 手)	lou4yi4shou3
 (露 出 來)	lou4chu1lai5
 (露 出 來)	lou4chu1lai5
 (露 出 來)	lou4chu1lai5
@@ -73774,9 +69740,7 @@ $textmode
 (露 马 脚)	lou4ma3jiao3
 (露 马 脚)	lou4ma3jiao3
 (靈 性 上)	ling2xing4shang5
-(靈 性 ㊤)	ling2xing4shang5
 (靈 性 上)	ling2xing4shang5
-(靈 性 ㊤)	ling2xing4shang5
 (靈 長 目)	ling2zhang3mu4
 (靈 長 目)	ling2zhang3mu4
 (靈 長 類)	ling2zhang3lei4
@@ -73784,16 +69748,11 @@ $textmode
 (靈 長 類)	ling2zhang3lei4
 (青 葙 子)	qing1xiang1zi3
 (静 一 静)	jing4yi2jing4
-(静 ㊀ 静)	jing4yi2jing4
 (静 下 来)	jing4xia4lai2
-(静 ㊦ 来)	jing4xia4lai2
 (静 悄 悄)	jing4qiao1qiao1
 (靜 一 靜)	jing4yi2jing4
-(靜 ㊀ 靜)	jing4yi2jing4
 (靜 下 來)	jing4xia4lai2
-(靜 ㊦ 來)	jing4xia4lai2
 (靜 下 來)	jing4xia4lai2
-(靜 ㊦ 來)	jing4xia4lai2
 (靜 悄 悄)	jing4qiao1qiao1
 (非 斯 都)	fei1si1du1
 (非 斯 都)	fei1si1du1
@@ -73810,13 +69769,9 @@ $textmode
 (韦 应 物)	wei2ying4wu4
 (韩 非 子)	han2fei1zi3
 (頂 不 上)	ding3bu5shang4
-(頂 不 ㊤)	ding3bu5shang4
 (頂 不 上)	ding3bu5shang4
-(頂 不 ㊤)	ding3bu5shang4
 (頂 不 下)	ding3bu5xia4
-(頂 不 ㊦)	ding3bu5xia4
 (頂 不 下)	ding3bu5xia4
-(頂 不 ㊦)	ding3bu5xia4
 (頂 不 了)	ding3bu5liao3
 (頂 不 了)	ding3bu5liao3
 (頂 不 了)	ding3bu5liao3
@@ -73826,11 +69781,8 @@ $textmode
 (頂 得 了)	ding3de2liao3
 (頂 得 了)	ding3de2liao3
 (頭 一 摸)	tou2yi4mo1
-(頭 ㊀ 摸)	tou2yi4mo1
 (顧 不 上)	gu4bu5shang4
-(顧 不 ㊤)	gu4bu5shang4
 (顧 不 上)	gu4bu5shang4
-(顧 不 ㊤)	gu4bu5shang4
 (顧 不 了)	gu4bu5liao3
 (顧 不 了)	gu4bu5liao3
 (顧 不 了)	gu4bu5liao3
@@ -73843,13 +69795,9 @@ $textmode
 (顯 不 出)	xian3bu5chu1
 (顯 示 屏)	xian3shi4bing3
 (顶 不 上)	ding3bu5shang4
-(顶 不 ㊤)	ding3bu5shang4
 (顶 不 上)	ding3bu5shang4
-(顶 不 ㊤)	ding3bu5shang4
 (顶 不 下)	ding3bu5xia4
-(顶 不 ㊦)	ding3bu5xia4
 (顶 不 下)	ding3bu5xia4
-(顶 不 ㊦)	ding3bu5xia4
 (顶 不 了)	ding3bu5liao3
 (顶 不 了)	ding3bu5liao3
 (顶 不 了)	ding3bu5liao3
@@ -73861,9 +69809,7 @@ $textmode
 (顺 嘴 儿)	shun4zui3r5
 (顺 手 儿)	shun4shou3r5
 (顾 不 上)	gu4bu5shang4
-(顾 不 ㊤)	gu4bu5shang4
 (顾 不 上)	gu4bu5shang4
-(顾 不 ㊤)	gu4bu5shang4
 (顾 不 了)	gu4bu5liao3
 (顾 不 了)	gu4bu5liao3
 (顾 不 了)	gu4bu5liao3
@@ -73878,9 +69824,7 @@ $textmode
 (餓 不 著)	e4bu5zhao2
 (餓 不 著)	e4bu5zhao2
 (餘 下 來)	yu2xia4lai2
-(餘 ㊦ 來)	yu2xia4lai2
 (餘 下 來)	yu2xia4lai2
-(餘 ㊦ 來)	yu2xia4lai2
 (饭 馆 儿)	fan4guan3r5
 (饱 嗝 儿)	bao3ge2r5
 (饿 不 着)	e4bu5zhao2
@@ -73900,9 +69844,7 @@ $textmode
 (馱 不 動)	tuo2bu5dong4
 (馱 不 動)	tuo2bu5dong4
 (騰 不 下)	teng2bu5xia4
-(騰 不 ㊦)	teng2bu5xia4
 (騰 不 下)	teng2bu5xia4
-(騰 不 ㊦)	teng2bu5xia4
 (騰 不 出)	teng2bu5chu1
 (騰 不 出)	teng2bu5chu1
 (騰 不 開)	teng2bu5kai1
@@ -73968,12 +69910,10 @@ $textmode
 (麦 地 那)	mai4di4na4
 (麦 盖 提)	mai4ge3ti2
 (黃 土 地)	huang2tu3di4
-(黃 ㊏ 地)	huang2tu3di4
 (黃 澄 澄)	huang2deng1deng1
 (黃 賓 虹)	huang2bin1hong2
 (黃 賓 虹)	huang2bin1hong2
 (黄 土 地)	huang2tu3di4
-(黄 ㊏ 地)	huang2tu3di4
 (黄 宾 虹)	huang2bin1hong2
 (黄 澄 澄)	huang2deng1deng1
 (黎 巴 嫩)	li2ba1nen4
@@ -73986,7 +69926,6 @@ $textmode
 (黑 不 溜)	hei1bu5liu1
 (黑 不 溜)	hei1bu5liu1
 (默 西 河)	mo4xi1he2
-(默 🀂 河)	mo4xi1he2
 (點 不 著)	dian3bu5zhao2
 (點 不 著)	dian3bu5zhao2
 (點 不 著)	dian3bu5zhao2
@@ -73995,2042 +69934,945 @@ $textmode
 (點 點 頭)	dian3dian5tou2
 (鼻 牛 儿)	bi2niu2r5
 (一 一 如 命)	yi4yi4ru2ming4
-(㊀ ㊀ 如 命)	yi4yi4ru2ming4
 (一 一 对 应)	yi4yi2dui4ying4
-(㊀ ㊀ 对 应)	yi4yi2dui4ying4
 (一 一 對 應)	yi4yi2dui4ying4
-(㊀ ㊀ 對 應)	yi4yi2dui4ying4
 (一 丁 不 識)	yi4ding1bu4shi2
-(㊀ 丁 不 識)	yi4ding1bu4shi2
 (一 丁 不 識)	yi4ding1bu4shi2
-(㊀ 丁 不 識)	yi4ding1bu4shi2
 (一 丁 不 識)	yi4ding1bu4shi2
-(㊀ 丁 不 識)	yi4ding1bu4shi2
 (一 丁 不 识)	yi4ding1bu4shi2
-(㊀ 丁 不 识)	yi4ding1bu4shi2
 (一 丁 不 识)	yi4ding1bu4shi2
-(㊀ 丁 不 识)	yi4ding1bu4shi2
 (一 丁 星 儿)	yi4ding1xing1r5
-(㊀ 丁 星 儿)	yi4ding1xing1r5
 (一 丁 星 兒)	yi4ding1xing1r5
-(㊀ 丁 星 兒)	yi4ding1xing1r5
 (一 丁 点 儿)	yi4ding1dian3r5
-(㊀ 丁 点 儿)	yi4ding1dian3r5
 (一 上 一 下)	yi2shang4yi2xia4
-(一 上 一 ㊦)	yi2shang4yi2xia4
-(一 ㊤ 一 下)	yi2shang4yi2xia4
-(㊀ 上 ㊀ 下)	yi2shang4yi2xia4
 (一 上 手 儿)	yi2shang4shou3r5
-(一 ㊤ 手 儿)	yi2shang4shou3r5
-(㊀ 上 手 儿)	yi2shang4shou3r5
 (一 上 手 兒)	yi2shang4shou3r5
-(一 ㊤ 手 兒)	yi2shang4shou3r5
-(㊀ 上 手 兒)	yi2shang4shou3r5
 (一 不 可 再)	yi2bu4ke3zai4
-(㊀ 不 可 再)	yi2bu4ke3zai4
 (一 不 可 再)	yi2bu4ke3zai4
-(㊀ 不 可 再)	yi2bu4ke3zai4
 (一 专 多 能)	yi4zhuan1duo1neng2
-(㊀ 专 多 能)	yi4zhuan1duo1neng2
 (一 丘 之 貉)	yi4qiu1zhi1he2
-(㊀ 丘 之 貉)	yi4qiu1zhi1he2
 (一 丛 翠 竹)	yi4cong2cui4zhu2
-(㊀ 丛 翠 竹)	yi4cong2cui4zhu2
 (一 丝 一 毫)	yi4si1yi4hao2
-(㊀ 丝 ㊀ 毫)	yi4si1yi4hao2
 (一 丝 不 差)	yi4si1bu2cha4
-(㊀ 丝 不 差)	yi4si1bu2cha4
 (一 丝 不 差)	yi4si1bu2cha4
-(㊀ 丝 不 差)	yi4si1bu2cha4
 (一 丝 不 挂)	yi4si1bu2gua4
-(㊀ 丝 不 挂)	yi4si1bu2gua4
 (一 丝 不 挂)	yi4si1bu2gua4
-(㊀ 丝 不 挂)	yi4si1bu2gua4
 (一 丝 不 苟)	yi4si1bu4gou3
-(㊀ 丝 不 苟)	yi4si1bu4gou3
 (一 丝 不 苟)	yi4si1bu4gou3
-(㊀ 丝 不 苟)	yi4si1bu4gou3
 (一 丝 不 错)	yi4si1bu2cuo4
-(㊀ 丝 不 错)	yi4si1bu2cuo4
 (一 丝 不 错)	yi4si1bu2cuo4
-(㊀ 丝 不 错)	yi4si1bu2cuo4
 (一 丝 愁 云)	yi4si1chou2yun2
-(㊀ 丝 愁 云)	yi4si1chou2yun2
 (一 丝 春 意)	yi4si1chun1yi4
-(㊀ 丝 春 意)	yi4si1chun1yi4
 (一 丝 笑 意)	yi4si1xiao4yi4
-(㊀ 丝 笑 意)	yi4si1xiao4yi4
 (一 丟 丟 兒)	yi4diu1diu1r5
-(㊀ 丟 丟 兒)	yi4diu1diu1r5
 (一 丟 就 忘)	yi4diu1jiu4wang4
-(㊀ 丟 就 忘)	yi4diu1jiu4wang4
 (一 丟 點 兒)	yi4diu1dian3r5
-(㊀ 丟 點 兒)	yi4diu1dian3r5
 (一 丢 丢 儿)	yi4diu1diu1r5
-(㊀ 丢 丢 儿)	yi4diu1diu1r5
 (一 丢 就 忘)	yi4diu1jiu4wang4
-(㊀ 丢 就 忘)	yi4diu1jiu4wang4
 (一 丢 点 儿)	yi4diu1dian3r5
-(㊀ 丢 点 儿)	yi4diu1dian3r5
 (一 个 个 儿)	yi2ge4ge4r5
-(㊀ 个 个 儿)	yi2ge4ge4r5
 (一 个 劲 儿)	yi2ge4jin4r5
-(㊀ 个 劲 儿)	yi2ge4jin4r5
 (一 个 过 儿)	yi2ge4guo4r5
-(㊀ 个 过 儿)	yi2ge4guo4r5
 (一 中 一 台)	yi4zhong1yi4tai2
-(一 🀄 一 台)	yi4zhong1yi4tai2
-(一 ㊥ 一 台)	yi4zhong1yi4tai2
-(㊀ 中 ㊀ 台)	yi4zhong1yi4tai2
-(㊀ 🀄 ㊀ 台)	yi4zhong1yi4tai2
 (一 中 一 臺)	yi4zhong1yi4tai2
-(一 🀄 一 臺)	yi4zhong1yi4tai2
-(一 ㊥ 一 臺)	yi4zhong1yi4tai2
-(㊀ 中 ㊀ 臺)	yi4zhong1yi4tai2
-(㊀ 🀄 ㊀ 臺)	yi4zhong1yi4tai2
 (一 中 原 则)	yi4zhong1yuan2ze2
-(一 🀄 原 则)	yi4zhong1yuan2ze2
-(一 ㊥ 原 则)	yi4zhong1yuan2ze2
-(㊀ 中 原 则)	yi4zhong1yuan2ze2
-(㊀ 🀄 原 则)	yi4zhong1yuan2ze2
 (一 中 原 則)	yi4zhong1yuan2ze2
-(一 🀄 原 則)	yi4zhong1yuan2ze2
-(一 ㊥ 原 則)	yi4zhong1yuan2ze2
-(㊀ 中 原 則)	yi4zhong1yuan2ze2
-(㊀ 🀄 原 則)	yi4zhong1yuan2ze2
 (一 举 两 得)	yi4ju3liang3de2
-(㊀ 举 两 得)	yi4ju3liang3de2
 (一 举 多 得)	yi4ju3duo1de2
-(㊀ 举 多 得)	yi4ju3duo1de2
 (一 举 得 男)	yi4ju3de2nan2
-(㊀ 举 得 男)	yi4ju3de2nan2
-(一 举 得 ㊚)	yi4ju3de2nan2
 (一 之 为 甚)	yi4zhi1wei2shen4
-(㊀ 之 为 甚)	yi4zhi1wei2shen4
 (一 之 為 甚)	yi4zhi1wei2shen4
-(㊀ 之 為 甚)	yi4zhi1wei2shen4
 (一 之 謂 甚)	yi4zhi1wei4shen4
-(㊀ 之 謂 甚)	yi4zhi1wei4shen4
 (一 之 谓 甚)	yi4zhi1wei4shen4
-(㊀ 之 谓 甚)	yi4zhi1wei4shen4
 (一 乾 二 凈)	yi4gan1er4jing4
-(㊀ 乾 二 凈)	yi4gan1er4jing4
-(一 乾 ㊁ 凈)	yi4gan1er4jing4
 (一 了 百 了)	yi4liao3bai3liao3
-(㊀ 了 百 了)	yi4liao3bai3liao3
 (一 了 百 了)	yi4liao3bai3liao3
-(㊀ 了 百 了)	yi4liao3bai3liao3
 (一 争 短 长)	yi4zheng1duan3chang2
-(㊀ 争 短 长)	yi4zheng1duan3chang2
 (一 五 一 十)	yi4wu3yi4shi2
-(一 五 一 ㊉)	yi4wu3yi4shi2
-(㊀ 五 ㊀ 十)	yi4wu3yi4shi2
-(一 ㊄ 一 十)	yi4wu3yi4shi2
 (一 亲 芳 泽)	yi4qin1fang1ze2
-(㊀ 亲 芳 泽)	yi4qin1fang1ze2
 (一 人 一 票)	yi4ren2yi2piao4
-(㊀ 人 ㊀ 票)	yi4ren2yi2piao4
 (一 仆 二 主)	yi4pu2er4zhu3
-(㊀ 仆 二 主)	yi4pu2er4zhu3
-(一 仆 ㊁ 主)	yi4pu2er4zhu3
 (一 介 书 生)	yi2jie4shu1sheng1
-(㊀ 介 书 生)	yi2jie4shu1sheng1
 (一 介 寒 儒)	yi2jie4han2ru2
-(㊀ 介 寒 儒)	yi2jie4han2ru2
 (一 介 書 生)	yi2jie4shu1sheng1
-(㊀ 介 書 生)	yi2jie4shu1sheng1
 (一 介 武 夫)	yi2jie4wu3fu1
-(㊀ 介 武 夫)	yi2jie4wu3fu1
 (一 代 宗 匠)	yi2dai4zong1jiang4
-(一 代 ㊪ 匠)	yi2dai4zong1jiang4
-(㊀ 代 宗 匠)	yi2dai4zong1jiang4
 (一 以 抵 十)	yi4yi3di3shi2
-(一 以 抵 ㊉)	yi4yi3di3shi2
-(㊀ 以 抵 十)	yi4yi3di3shi2
 (一 以 抵 百)	yi4yi3di3bai3
-(㊀ 以 抵 百)	yi4yi3di3bai3
 (一 以 貫 之)	yi4yi3guan4zhi1
-(㊀ 以 貫 之)	yi4yi3guan4zhi1
 (一 以 贯 之)	yi4yi3guan4zhi1
-(㊀ 以 贯 之)	yi4yi3guan4zhi1
 (一 会 儿 见)	yi4hui3r5jian4
-(㊀ 会 儿 见)	yi4hui3r5jian4
 (一 來 一 往)	yi4lai2yi4wang3
-(㊀ 來 ㊀ 往)	yi4lai2yi4wang3
 (一 來 一 往)	yi4lai2yi4wang3
-(㊀ 來 ㊀ 往)	yi4lai2yi4wang3
 (一 侧 优 势)	yi2ce4you1shi4
-(㊀ 侧 优 势)	yi2ce4you1shi4
 (一 個 過 兒)	yi2ge4guo4r5
-(㊀ 個 過 兒)	yi2ge4guo4r5
 (一 倾 积 愫)	yi4qing1ji1su4
-(㊀ 倾 积 愫)	yi4qing1ji1su4
 (一 做 就 錯)	yi2zuo4jiu4cuo4
-(㊀ 做 就 錯)	yi2zuo4jiu4cuo4
 (一 做 就 错)	yi2zuo4jiu4cuo4
-(㊀ 做 就 错)	yi2zuo4jiu4cuo4
 (一 側 優 勢)	yi2ce4you1shi4
-(㊀ 側 優 勢)	yi2ce4you1shi4
-(一 側 ㊝ 勢)	yi2ce4you1shi4
 (一 傅 众 咻)	yi2fu4zhong4xiu1
-(㊀ 傅 众 咻)	yi2fu4zhong4xiu1
 (一 傅 眾 咻)	yi2fu4zhong4xiu1
-(㊀ 傅 眾 咻)	yi2fu4zhong4xiu1
 (一 傾 積 愫)	yi4qing1ji1su4
-(㊀ 傾 積 愫)	yi4qing1ji1su4
 (一 僕 二 主)	yi4pu2er4zhu3
-(㊀ 僕 二 主)	yi4pu2er4zhu3
-(一 僕 ㊁ 主)	yi4pu2er4zhu3
 (一 兵 多 用)	yi4bing1duo1yong4
-(㊀ 兵 多 用)	yi4bing1duo1yong4
 (一 兵 多 能)	yi4bing1duo1neng2
-(㊀ 兵 多 能)	yi4bing1duo1neng2
 (一 决 雌 雄)	yi4jue2ci2xiong2
-(㊀ 决 雌 雄)	yi4jue2ci2xiong2
 (一 冷 一 热)	yi4leng3yi2re4
-(㊀ 冷 ㊀ 热)	yi4leng3yi2re4
 (一 冷 一 热)	yi4leng3yi2re4
-(㊀ 冷 ㊀ 热)	yi4leng3yi2re4
 (一 冷 一 熱)	yi4leng3yi2re4
-(㊀ 冷 ㊀ 熱)	yi4leng3yi2re4
 (一 冷 一 熱)	yi4leng3yi2re4
-(㊀ 冷 ㊀ 熱)	yi4leng3yi2re4
 (一 刀 两 断)	yi4dao1liang3duan4
-(㊀ 刀 两 断)	yi4dao1liang3duan4
 (一 刀 兩 斷)	yi4dao1liang3duan4
-(㊀ 刀 兩 斷)	yi4dao1liang3duan4
 (一 刀 兩 斷)	yi4dao1liang3duan4
-(㊀ 刀 兩 斷)	yi4dao1liang3duan4
 (一 分 为 二)	yi4fen1wei2er4
-(㊀ 分 为 二)	yi4fen1wei2er4
-(一 分 为 ㊁)	yi4fen1wei2er4
 (一 分 收 穫)	yi4fen1shou1huo4
-(㊀ 分 收 穫)	yi4fen1shou1huo4
 (一 分 收 获)	yi4fen1shou1huo4
-(㊀ 分 收 获)	yi4fen1shou1huo4
 (一 分 為 二)	yi4fen1wei2er4
-(㊀ 分 為 二)	yi4fen1wei2er4
-(一 分 為 ㊁)	yi4fen1wei2er4
 (一 分 耕 耘)	yi4fen1geng1yun2
-(㊀ 分 耕 耘)	yi4fen1geng1yun2
 (一 剁 两 段)	yi2duo4liang3duan4
-(㊀ 剁 两 段)	yi2duo4liang3duan4
 (一 剁 兩 段)	yi2duo4liang3duan4
-(㊀ 剁 兩 段)	yi2duo4liang3duan4
 (一 剁 兩 段)	yi2duo4liang3duan4
-(㊀ 剁 兩 段)	yi2duo4liang3duan4
 (一 劳 永 逸)	yi4lao2yong3yi4
-(㊀ 劳 永 逸)	yi4lao2yong3yi4
-(一 ㊘ 永 逸)	yi4lao2yong3yi4
 (一 劳 永 逸)	yi4lao2yong3yi4
-(㊀ 劳 永 逸)	yi4lao2yong3yi4
-(一 ㊘ 永 逸)	yi4lao2yong3yi4
 (一 劳 永 逸)	yi4lao2yong3yi4
-(㊀ 劳 永 逸)	yi4lao2yong3yi4
-(一 ㊘ 永 逸)	yi4lao2yong3yi4
 (一 勞 永 逸)	yi4lao2yong3yi4
-(㊀ 勞 永 逸)	yi4lao2yong3yi4
 (一 勞 永 逸)	yi4lao2yong3yi4
-(㊀ 勞 永 逸)	yi4lao2yong3yi4
 (一 勞 永 逸)	yi4lao2yong3yi4
-(㊀ 勞 永 逸)	yi4lao2yong3yi4
 (一 勞 永 逸)	yi4lao2yong3yi4
-(㊀ 勞 永 逸)	yi4lao2yong3yi4
 (一 匡 天 下)	yi4kuang1tian1xia4
-(一 匡 天 ㊦)	yi4kuang1tian1xia4
-(㊀ 匡 天 下)	yi4kuang1tian1xia4
 (一 卵 双 生)	yi4luan3shuang1sheng1
-(㊀ 卵 双 生)	yi4luan3shuang1sheng1
 (一 卵 双 生)	yi4luan3shuang1sheng1
-(㊀ 卵 双 生)	yi4luan3shuang1sheng1
 (一 卵 双 胞)	yi4luan3shuang1bao1
-(㊀ 卵 双 胞)	yi4luan3shuang1bao1
 (一 卵 双 胞)	yi4luan3shuang1bao1
-(㊀ 卵 双 胞)	yi4luan3shuang1bao1
 (一 卵 孪 生)	yi4luan3luan2sheng1
-(㊀ 卵 孪 生)	yi4luan3luan2sheng1
 (一 卵 孪 生)	yi4luan3luan2sheng1
-(㊀ 卵 孪 生)	yi4luan3luan2sheng1
 (一 卵 孿 生)	yi4luan3luan2sheng1
-(㊀ 卵 孿 生)	yi4luan3luan2sheng1
 (一 卵 孿 生)	yi4luan3luan2sheng1
-(㊀ 卵 孿 生)	yi4luan3luan2sheng1
 (一 卵 雙 生)	yi4luan3shuang1sheng1
-(㊀ 卵 雙 生)	yi4luan3shuang1sheng1
 (一 卵 雙 生)	yi4luan3shuang1sheng1
-(㊀ 卵 雙 生)	yi4luan3shuang1sheng1
 (一 卵 雙 胞)	yi4luan3shuang1bao1
-(㊀ 卵 雙 胞)	yi4luan3shuang1bao1
 (一 卵 雙 胞)	yi4luan3shuang1bao1
-(㊀ 卵 雙 胞)	yi4luan3shuang1bao1
 (一 厢 情 愿)	yi4xiang1qing2yuan4
-(㊀ 厢 情 愿)	yi4xiang1qing2yuan4
 (一 去 不 回)	yi2qu4bu4hui2
-(㊀ 去 不 回)	yi2qu4bu4hui2
 (一 去 不 回)	yi2qu4bu4hui2
-(㊀ 去 不 回)	yi2qu4bu4hui2
 (一 去 不 返)	yi2qu4bu4fan3
-(㊀ 去 不 返)	yi2qu4bu4fan3
 (一 去 不 返)	yi2qu4bu4fan3
-(㊀ 去 不 返)	yi2qu4bu4fan3
 (一 发 千 钧)	yi2fa4qian1jun1
-(㊀ 发 千 钧)	yi2fa4qian1jun1
 (一 叙 衷 曲)	yi2xu4zhong1qu3
-(㊀ 叙 衷 曲)	yi2xu4zhong1qu3
 (一 叠 卡 片)	yi4die2ka3pian4
-(㊀ 叠 卡 片)	yi4die2ka3pian4
 (一 叢 翠 竹)	yi4cong2cui4zhu2
-(㊀ 叢 翠 竹)	yi4cong2cui4zhu2
 (一 口 气 儿)	yi4kou3qi4r5
-(㊀ 口 气 儿)	yi4kou3qi4r5
 (一 口 答 应)	yi4kou3da2ying5
-(㊀ 口 答 应)	yi4kou3da2ying5
 (一 口 答 應)	yi4kou3da2ying5
-(㊀ 口 答 應)	yi4kou3da2ying5
 (一 叫 就 到)	yi2jiao4jiu4dao4
-(㊀ 叫 就 到)	yi2jiao4jiu4dao4
 (一 叶 扁 舟)	yi2ye4pian1zhou1
-(㊀ 叶 扁 舟)	yi2ye4pian1zhou1
 (一 叶 知 秋)	yi2ye4zhi1qiu1
-(㊀ 叶 知 秋)	yi2ye4zhi1qiu1
 (一 叶 蔽 目)	yi2ye4bi4mu4
-(㊀ 叶 蔽 目)	yi2ye4bi4mu4
 (一 叶 障 目)	yi2ye4zhang4mu4
-(㊀ 叶 障 目)	yi2ye4zhang4mu4
 (一 吐 为 快)	yi4tu3wei2kuai4
-(㊀ 吐 为 快)	yi4tu3wei2kuai4
 (一 吐 心 声)	yi4tu3xin1sheng1
-(㊀ 吐 心 声)	yi4tu3xin1sheng1
 (一 吐 心 聲)	yi4tu3xin1sheng1
-(㊀ 吐 心 聲)	yi4tu3xin1sheng1
 (一 吐 為 快)	yi4tu3wei2kuai4
-(㊀ 吐 為 快)	yi4tu3wei2kuai4
 (一 味 盲 干)	yi2wei4mang2gan4
-(㊀ 味 盲 干)	yi2wei4mang2gan4
 (一 呼 百 应)	yi4hu1bai3ying4
-(㊀ 呼 百 应)	yi4hu1bai3ying4
 (一 呼 百 應)	yi4hu1bai3ying4
-(㊀ 呼 百 應)	yi4hu1bai3ying4
 (一 呼 百 諾)	yi4hu1bai3nuo4
-(㊀ 呼 百 諾)	yi4hu1bai3nuo4
 (一 呼 百 諾)	yi4hu1bai3nuo4
-(㊀ 呼 百 諾)	yi4hu1bai3nuo4
 (一 呼 百 諾)	yi4hu1bai3nuo4
-(㊀ 呼 百 諾)	yi4hu1bai3nuo4
 (一 呼 百 诺)	yi4hu1bai3nuo4
-(㊀ 呼 百 诺)	yi4hu1bai3nuo4
 (一 品 之 官)	yi4pin3zhi5guan1
-(㊀ 品 之 官)	yi4pin3zhi5guan1
 (一 品 夫 人)	yi4pin3fu1ren2
-(㊀ 品 夫 人)	yi4pin3fu1ren2
 (一 哄 而 上)	yi4hong1er2shang4
-(一 哄 而 ㊤)	yi4hong1er2shang4
-(㊀ 哄 而 上)	yi4hong1er2shang4
 (一 哄 而 出)	yi4hong1er2chu1
-(㊀ 哄 而 出)	yi4hong1er2chu1
 (一 哄 而 散)	yi4hong1er2san4
-(㊀ 哄 而 散)	yi4hong1er2san4
 (一 哄 而 起)	yi4hong1er2qi3
-(㊀ 哄 而 起)	yi4hong1er2qi3
 (一 哨 人 馬)	yi2shao4ren2ma3
-(㊀ 哨 人 馬)	yi2shao4ren2ma3
 (一 哨 人 马)	yi2shao4ren2ma3
-(㊀ 哨 人 马)	yi2shao4ren2ma3
 (一 唱 一 和)	yi2chang4yi2he4
-(㊀ 唱 ㊀ 和)	yi2chang4yi2he4
 (一 唱 三 叹)	yi2chang4san1tan4
-(一 唱 ㊂ 叹)	yi2chang4san1tan4
-(㊀ 唱 三 叹)	yi2chang4san1tan4
 (一 唱 三 嘆)	yi2chang4san1tan4
-(一 唱 ㊂ 嘆)	yi2chang4san1tan4
-(㊀ 唱 三 嘆)	yi2chang4san1tan4
 (一 唱 三 嘆)	yi2chang4san1tan4
-(一 唱 ㊂ 嘆)	yi2chang4san1tan4
-(㊀ 唱 三 嘆)	yi2chang4san1tan4
 (一 問 一 答)	yi2wen4yi4da2
-(㊀ 問 ㊀ 答)	yi2wen4yi4da2
 (一 团 和 气)	yi4tuan2he2qi4
-(㊀ 团 和 气)	yi4tuan2he2qi4
 (一 国 三 公)	yi4guo2san1gong1
-(一 国 ㊂ 公)	yi4guo2san1gong1
-(㊀ 国 三 公)	yi4guo2san1gong1
 (一 国 两 制)	yi4guo2liang3zhi4
-(㊀ 国 两 制)	yi4guo2liang3zhi4
 (一 國 三 公)	yi4guo2san1gong1
-(一 國 ㊂ 公)	yi4guo2san1gong1
-(㊀ 國 三 公)	yi4guo2san1gong1
 (一 國 兩 制)	yi4guo2liang3zhi4
-(㊀ 國 兩 制)	yi4guo2liang3zhi4
 (一 國 兩 制)	yi4guo2liang3zhi4
-(㊀ 國 兩 制)	yi4guo2liang3zhi4
 (一 團 和 氣)	yi4tuan2he2qi4
-(㊀ 團 和 氣)	yi4tuan2he2qi4
 (一 场 好 梦)	yi4chang3hao3meng4
-(㊀ 场 好 梦)	yi4chang3hao3meng4
 (一 场 恶 梦)	yi4chang3e4meng4
-(㊀ 场 恶 梦)	yi4chang3e4meng4
 (一 场 春 梦)	yi4chang3chun1meng4
-(㊀ 场 春 梦)	yi4chang3chun1meng4
 (一 场 虚 惊)	yi4chang3xu1jing1
-(㊀ 场 虚 惊)	yi4chang3xu1jing1
 (一 块 堆 儿)	yi2kuai4dui1r5
-(㊀ 块 堆 儿)	yi2kuai4dui1r5
 (一 場 好 夢)	yi4chang3hao3meng4
-(㊀ 場 好 夢)	yi4chang3hao3meng4
 (一 場 惡 夢)	yi4chang3e4meng4
-(㊀ 場 惡 夢)	yi4chang3e4meng4
 (一 場 惡 夢)	yi4chang3e4meng4
-(㊀ 場 惡 夢)	yi4chang3e4meng4
 (一 場 春 夢)	yi4chang3chun1meng4
-(㊀ 場 春 夢)	yi4chang3chun1meng4
 (一 場 虛 驚)	yi4chang3xu1jing1
-(㊀ 場 虛 驚)	yi4chang3xu1jing1
 (一 塌 刮 子)	yi4ta1gua1zi5
-(㊀ 塌 刮 子)	yi4ta1gua1zi5
 (一 塌 糊 塗)	yi4ta1hu2tu5
-(㊀ 塌 糊 塗)	yi4ta1hu2tu5
 (一 塌 糊 涂)	yi4ta1hu2tu5
-(㊀ 塌 糊 涂)	yi4ta1hu2tu5
 (一 塵 不 染)	yi4chen2bu4ran3
-(㊀ 塵 不 染)	yi4chen2bu4ran3
 (一 塵 不 染)	yi4chen2bu4ran3
-(㊀ 塵 不 染)	yi4chen2bu4ran3
 (一 墙 之 隔)	yi4qiang2zhi1ge2
-(㊀ 墙 之 隔)	yi4qiang2zhi1ge2
 (一 夔 已 足)	yi4kui2yi3zu2
-(㊀ 夔 已 足)	yi4kui2yi3zu2
 (一 夕 数 惊)	yi4xi1shu4jing1
-(㊀ 夕 数 惊)	yi4xi1shu4jing1
 (一 夕 數 驚)	yi4xi1shu4jing1
-(㊀ 夕 數 驚)	yi4xi1shu4jing1
 (一 夕 數 驚)	yi4xi1shu4jing1
-(㊀ 夕 數 驚)	yi4xi1shu4jing1
 (一 多 再 多)	yi4duo1zai4duo1
-(㊀ 多 再 多)	yi4duo1zai4duo1
 (一 多 对 应)	yi4duo1dui4ying4
-(㊀ 多 对 应)	yi4duo1dui4ying4
 (一 多 對 應)	yi4duo1dui4ying4
-(㊀ 多 對 應)	yi4duo1dui4ying4
 (一 夜 露 水)	yi2ye4lu4shui5
-(一 ㊰ 露 水)	yi2ye4lu4shui5
-(一 夜 露 ㊌)	yi2ye4lu4shui5
-(㊀ 夜 露 水)	yi2ye4lu4shui5
 (一 夜 露 水)	yi2ye4lu4shui5
-(一 ㊰ 露 水)	yi2ye4lu4shui5
-(一 夜 露 ㊌)	yi2ye4lu4shui5
-(㊀ 夜 露 水)	yi2ye4lu4shui5
 (一 大 二 公)	yi2da4er4gong1
-(㊀ 大 二 公)	yi2da4er4gong1
-(一 大 ㊁ 公)	yi2da4er4gong1
 (一 大 早 儿)	yi2da4zao3r5
-(㊀ 大 早 儿)	yi2da4zao3r5
 (一 夫 一 妻)	yi4fu1yi4qi1
-(㊀ 夫 ㊀ 妻)	yi4fu1yi4qi1
 (一 奶 同 胞)	yi4nai3tong2bao1
-(㊀ 奶 同 胞)	yi4nai3tong2bao1
 (一 妻 多 夫)	yi4qi1duo1fu1
-(㊀ 妻 多 夫)	yi4qi1duo1fu1
 (一 子 双 祧)	yi4zi3shuang1tiao1
-(㊀ 子 双 祧)	yi4zi3shuang1tiao1
 (一 子 雙 祧)	yi4zi3shuang1tiao1
-(㊀ 子 雙 祧)	yi4zi3shuang1tiao1
 (一 孔 之 見)	yi4kong3zhi1jian4
-(㊀ 孔 之 見)	yi4kong3zhi1jian4
 (一 孔 之 見)	yi4kong3zhi1jian4
-(㊀ 孔 之 見)	yi4kong3zhi1jian4
 (一 孔 之 见)	yi4kong3zhi1jian4
-(㊀ 孔 之 见)	yi4kong3zhi1jian4
 (一 字 一 板)	yi2zi4yi4ban3
-(㊀ 字 ㊀ 板)	yi2zi4yi4ban3
 (一 字 一 泪)	yi2zi4yi2lei4
-(㊀ 字 ㊀ 泪)	yi2zi4yi2lei4
 (一 字 一 淚)	yi2zi4yi2lei4
-(㊀ 字 ㊀ 淚)	yi2zi4yi2lei4
 (一 字 一 淚)	yi2zi4yi2lei4
-(㊀ 字 ㊀ 淚)	yi2zi4yi2lei4
 (一 字 一 珠)	yi2zi4yi4zhu1
-(㊀ 字 ㊀ 珠)	yi2zi4yi4zhu1
 (一 字 不 識)	yi2zi4bu4shi2
-(㊀ 字 不 識)	yi2zi4bu4shi2
 (一 字 不 識)	yi2zi4bu4shi2
-(㊀ 字 不 識)	yi2zi4bu4shi2
 (一 字 不 識)	yi2zi4bu4shi2
-(㊀ 字 不 識)	yi2zi4bu4shi2
 (一 字 不 识)	yi2zi4bu4shi2
-(㊀ 字 不 识)	yi2zi4bu4shi2
 (一 字 不 识)	yi2zi4bu4shi2
-(㊀ 字 不 识)	yi2zi4bu4shi2
 (一 字 之 差)	yi2zi4zhi1cha1
-(㊀ 字 之 差)	yi2zi4zhi1cha1
 (一 存 一 亡)	yi4cun2yi4wang2
-(㊀ 存 ㊀ 亡)	yi4cun2yi4wang2
 (一 官 半 职)	yi4guan1ban4zhi2
-(㊀ 官 半 职)	yi4guan1ban4zhi2
 (一 官 半 職)	yi4guan1ban4zhi2
-(㊀ 官 半 職)	yi4guan1ban4zhi2
 (一 宠 性 儿)	yi4chong3xing4r5
-(㊀ 宠 性 儿)	yi4chong3xing4r5
 (一 寒 如 此)	yi4han2ru2ci3
-(㊀ 寒 如 此)	yi4han2ru2ci3
 (一 寸 丹 心)	yi2cun4dan1xin1
-(㊀ 寸 丹 心)	yi2cun4dan1xin1
 (一 寸 丹 心)	yi2cun4dan1xin1
-(㊀ 寸 丹 心)	yi2cun4dan1xin1
 (一 專 多 能)	yi4zhuan1duo1neng2
-(㊀ 專 多 能)	yi4zhuan1duo1neng2
 (一 小 阵 儿)	yi4xiao3zhen4r5
-(㊀ 小 阵 儿)	yi4xiao3zhen4r5
 (一 尘 不 染)	yi4chen2bu4ran3
-(㊀ 尘 不 染)	yi4chen2bu4ran3
 (一 尘 不 染)	yi4chen2bu4ran3
-(㊀ 尘 不 染)	yi4chen2bu4ran3
 (一 屁 股 臊)	yi2pi4gu5sao1
-(㊀ 屁 股 臊)	yi2pi4gu5sao1
 (一 屋 子 人)	yi4wu1zi5ren2
-(㊀ 屋 子 人)	yi4wu1zi5ren2
 (一 山 一 水)	yi4shan1yi4shui3
-(一 山 一 ㊌)	yi4shan1yi4shui3
-(㊀ 山 ㊀ 水)	yi4shan1yi4shui3
 (一 山 一 石)	yi4shan1yi4shi2
-(㊀ 山 ㊀ 石)	yi4shan1yi4shi2
 (一 山 之 隔)	yi4shan1zhi1ge2
-(㊀ 山 之 隔)	yi4shan1zhi1ge2
 (一 差 二 錯)	yi4cha1er4cuo4
-(㊀ 差 二 錯)	yi4cha1er4cuo4
-(一 差 ㊁ 錯)	yi4cha1er4cuo4
 (一 差 二 错)	yi4cha1er4cuo4
-(㊀ 差 二 错)	yi4cha1er4cuo4
-(一 差 ㊁ 错)	yi4cha1er4cuo4
 (一 市 八 街)	yi2shi4ba1jie1
-(㊀ 市 八 街)	yi2shi4ba1jie1
-(一 市 ㊇ 街)	yi2shi4ba1jie1
 (一 帆 風 順)	yi4fan1feng1shun4
-(㊀ 帆 風 順)	yi4fan1feng1shun4
 (一 帆 风 顺)	yi4fan1feng1shun4
-(㊀ 帆 风 顺)	yi4fan1feng1shun4
 (一 席 之 地)	yi4xi2zhi1di4
-(㊀ 席 之 地)	yi4xi2zhi1di4
 (一 干 到 底)	yi2gan4dao4di3
-(㊀ 干 到 底)	yi2gan4dao4di3
 (一 平 二 調)	yi4ping2er4diao4
-(㊀ 平 二 調)	yi4ping2er4diao4
-(一 平 ㊁ 調)	yi4ping2er4diao4
 (一 平 二 調)	yi4ping2er4diao4
-(㊀ 平 二 調)	yi4ping2er4diao4
-(一 平 ㊁ 調)	yi4ping2er4diao4
 (一 平 二 调)	yi4ping2er4diao4
-(㊀ 平 二 调)	yi4ping2er4diao4
-(一 平 ㊁ 调)	yi4ping2er4diao4
 (一 平 如 鏡)	yi4ping2ru2jing4
-(㊀ 平 如 鏡)	yi4ping2ru2jing4
 (一 平 如 镜)	yi4ping2ru2jing4
-(㊀ 平 如 镜)	yi4ping2ru2jing4
 (一 年 半 載)	yi4nian2ban4zai3
-(㊀ 年 半 載)	yi4nian2ban4zai3
 (一 年 半 載)	yi4nian2ban4zai3
-(㊀ 年 半 載)	yi4nian2ban4zai3
 (一 年 半 载)	yi4nian2ban4zai3
-(㊀ 年 半 载)	yi4nian2ban4zai3
 (一 年 半 载)	yi4nian2ban4zai3
-(㊀ 年 半 载)	yi4nian2ban4zai3
 (一 幹 到 底)	yi2gan4dao4di3
-(㊀ 幹 到 底)	yi2gan4dao4di3
 (一 廂 情 願)	yi4xiang1qing2yuan4
-(㊀ 廂 情 願)	yi4xiang1qing2yuan4
 (一 张 一 弛)	yi4zhang1yi4chi2
-(㊀ 张 ㊀ 弛)	yi4zhang1yi4chi2
 (一 弯 新 月)	yi4wan1xin1yue4
-(一 弯 新 ㊊)	yi4wan1xin1yue4
-(㊀ 弯 新 月)	yi4wan1xin1yue4
 (一 張 一 弛)	yi4zhang1yi4chi2
-(㊀ 張 ㊀ 弛)	yi4zhang1yi4chi2
 (一 彎 新 月)	yi4wan1xin1yue4
-(一 彎 新 ㊊)	yi4wan1xin1yue4
-(㊀ 彎 新 月)	yi4wan1xin1yue4
 (一 往 情 深)	yi4wang3qing2shen1
-(㊀ 往 情 深)	yi4wang3qing2shen1
 (一 往 无 前)	yi4wang3wu2qian2
-(㊀ 往 无 前)	yi4wang3wu2qian2
 (一 往 無 前)	yi4wang3wu2qian2
-(㊀ 往 無 前)	yi4wang3wu2qian2
 (一 往 直 前)	yi4wang3zhi2qian2
-(㊀ 往 直 前)	yi4wang3zhi2qian2
 (一 往 直 前)	yi4wang3zhi2qian2
-(㊀ 往 直 前)	yi4wang3zhi2qian2
 (一 得 一 失)	yi4de2yi4shi1
-(㊀ 得 ㊀ 失)	yi4de2yi4shi1
 (一 德 一 心)	yi4de2yi4xin1
-(㊀ 德 ㊀ 心)	yi4de2yi4xin1
 (一 心 一 德)	yi4xin1yi4de2
-(㊀ 心 ㊀ 德)	yi4xin1yi4de2
 (一 忍 再 忍)	yi4ren3zai4ren3
-(㊀ 忍 再 忍)	yi4ren3zai4ren3
 (一 念 之 差)	yi2nian4zhi1cha1
-(㊀ 念 之 差)	yi2nian4zhi1cha1
 (一 念 之 差)	yi2nian4zhi1cha1
-(㊀ 念 之 差)	yi2nian4zhi1cha1
 (一 念 之 誠)	yi2nian4zhi1cheng2
-(㊀ 念 之 誠)	yi2nian4zhi1cheng2
 (一 念 之 誠)	yi2nian4zhi1cheng2
-(㊀ 念 之 誠)	yi2nian4zhi1cheng2
 (一 念 之 诚)	yi2nian4zhi1cheng2
-(㊀ 念 之 诚)	yi2nian4zhi1cheng2
 (一 念 之 诚)	yi2nian4zhi1cheng2
-(㊀ 念 之 诚)	yi2nian4zhi1cheng2
 (一 怒 而 去)	yi2nu4er2qu4
-(㊀ 怒 而 去)	yi2nu4er2qu4
 (一 怒 而 去)	yi2nu4er2qu4
-(㊀ 怒 而 去)	yi2nu4er2qu4
 (一 息 奄 奄)	yi4xi1yan3yan3
-(㊀ 息 奄 奄)	yi4xi1yan3yan3
 (一 息 奄 奄)	yi4xi1yan3yan3
-(㊀ 息 奄 奄)	yi4xi1yan3yan3
 (一 愁 莫 展)	yi4chou2mo4zhan3
-(㊀ 愁 莫 展)	yi4chou2mo4zhan3
 (一 成 一 旅)	yi4cheng2yi4lv3
-(㊀ 成 ㊀ 旅)	yi4cheng2yi4lv3
 (一 成 一 旅)	yi4cheng2yi4lv3
-(㊀ 成 ㊀ 旅)	yi4cheng2yi4lv3
 (一 成 不 变)	yi4cheng2bu2bian4
-(㊀ 成 不 变)	yi4cheng2bu2bian4
 (一 成 不 变)	yi4cheng2bu2bian4
-(㊀ 成 不 变)	yi4cheng2bu2bian4
 (一 成 不 變)	yi4cheng2bu2bian4
-(㊀ 成 不 變)	yi4cheng2bu2bian4
 (一 成 不 變)	yi4cheng2bu2bian4
-(㊀ 成 不 變)	yi4cheng2bu2bian4
 (一 成 不 變)	yi4cheng2bu2bian4
-(㊀ 成 不 變)	yi4cheng2bu2bian4
 (一 战 而 胜)	yi2zhan4er2sheng4
-(㊀ 战 而 胜)	yi2zhan4er2sheng4
 (一 戰 而 勝)	yi2zhan4er2sheng4
-(㊀ 戰 而 勝)	yi2zhan4er2sheng4
 (一 戳 就 穿)	yi4chuo1jiu4chuan1
-(㊀ 戳 就 穿)	yi4chuo1jiu4chuan1
 (一 戶 住 宅)	yi2hu4zhu4zhai2
-(㊀ 戶 住 宅)	yi2hu4zhu4zhai2
 (一 戶 住 宅)	yi2hu4zhu4zhai2
-(㊀ 戶 住 宅)	yi2hu4zhu4zhai2
 (一 户 住 宅)	yi2hu4zhu4zhai2
-(㊀ 户 住 宅)	yi2hu4zhu4zhai2
 (一 户 住 宅)	yi2hu4zhu4zhai2
-(㊀ 户 住 宅)	yi2hu4zhu4zhai2
 (一 房 一 厅)	yi4fang2yi4ting1
-(㊀ 房 ㊀ 厅)	yi4fang2yi4ting1
 (一 房 一 廳)	yi4fang2yi4ting1
-(㊀ 房 ㊀ 廳)	yi4fang2yi4ting1
 (一 打 一 拉)	yi4da3yi4la1
-(㊀ 打 ㊀ 拉)	yi4da3yi4la1
 (一 打 一 拉)	yi4da3yi4la1
-(㊀ 打 ㊀ 拉)	yi4da3yi4la1
 (一 打 三 反)	yi4da3san1fan3
-(一 打 ㊂ 反)	yi4da3san1fan3
-(㊀ 打 三 反)	yi4da3san1fan3
 (一 扫 而 光)	yi4sao3er2guang1
-(㊀ 扫 而 光)	yi4sao3er2guang1
 (一 扫 而 空)	yi4sao3er2kong1
-(㊀ 扫 而 空)	yi4sao3er2kong1
 (一 技 之 長)	yi2ji4zhi1chang2
-(㊀ 技 之 長)	yi2ji4zhi1chang2
 (一 技 之 长)	yi2ji4zhi1chang2
-(㊀ 技 之 长)	yi2ji4zhi1chang2
 (一 抓 就 灵)	yi4zhua1jiu4ling2
-(㊀ 抓 就 灵)	yi4zhua1jiu4ling2
 (一 抓 就 靈)	yi4zhua1jiu4ling2
-(㊀ 抓 就 靈)	yi4zhua1jiu4ling2
 (一 抓 就 靈)	yi4zhua1jiu4ling2
-(㊀ 抓 就 靈)	yi4zhua1jiu4ling2
 (一 抔 黃 土)	yi4pou2huang2tu3
-(一 抔 黃 ㊏)	yi4pou2huang2tu3
-(㊀ 抔 黃 土)	yi4pou2huang2tu3
 (一 抔 黄 土)	yi4pou2huang2tu3
-(一 抔 黄 ㊏)	yi4pou2huang2tu3
-(㊀ 抔 黄 土)	yi4pou2huang2tu3
 (一 抠 抠 儿)	yi4kou1kou1r5
-(㊀ 抠 抠 儿)	yi4kou1kou1r5
 (一 担 儿 挑)	yi2dan4r5tiao1
-(㊀ 担 儿 挑)	yi2dan4r5tiao1
 (一 拉 溜 儿)	yi4la1liu4r5
-(㊀ 拉 溜 儿)	yi4la1liu4r5
 (一 拉 溜 儿)	yi4la1liu4r5
-(㊀ 拉 溜 儿)	yi4la1liu4r5
 (一 拉 溜 儿)	yi4la1liu4r5
-(㊀ 拉 溜 儿)	yi4la1liu4r5
 (一 拉 溜 兒)	yi4la1liu4r5
-(㊀ 拉 溜 兒)	yi4la1liu4r5
 (一 拉 溜 兒)	yi4la1liu4r5
-(㊀ 拉 溜 兒)	yi4la1liu4r5
 (一 拉 溜 兒)	yi4la1liu4r5
-(㊀ 拉 溜 兒)	yi4la1liu4r5
 (一 拍 两 散)	yi4pai1liang3san4
-(㊀ 拍 两 散)	yi4pai1liang3san4
 (一 拍 兩 散)	yi4pai1liang3san4
-(㊀ 拍 兩 散)	yi4pai1liang3san4
 (一 拍 兩 散)	yi4pai1liang3san4
-(㊀ 拍 兩 散)	yi4pai1liang3san4
 (一 拍 即 合)	yi4pai1ji2he2
-(㊀ 拍 即 合)	yi4pai1ji2he2
 (一 拐 一 拐)	yi4guai3yi4guai3
-(㊀ 拐 ㊀ 拐)	yi4guai3yi4guai3
 (一 招 一 式)	yi4zhao1yi2shi4
-(㊀ 招 ㊀ 式)	yi4zhao1yi2shi4
 (一 招 半 式)	yi4zhao1ban4shi4
-(㊀ 招 半 式)	yi4zhao1ban4shi4
 (一 拳 一 脚)	yi4quan2yi4jiao3
-(㊀ 拳 ㊀ 脚)	yi4quan2yi4jiao3
 (一 拳 一 腳)	yi4quan2yi4jiao3
-(㊀ 拳 ㊀ 腳)	yi4quan2yi4jiao3
 (一 拼 到 底)	yi4pin1dao4di3
-(㊀ 拼 到 底)	yi4pin1dao4di3
 (一 挥 而 就)	yi4hui1er2jiu4
-(㊀ 挥 而 就)	yi4hui1er2jiu4
 (一 损 俱 损)	yi4sun3ju4sun3
-(㊀ 损 俱 损)	yi4sun3ju4sun3
 (一 掃 而 光)	yi4sao3er2guang1
-(㊀ 掃 而 光)	yi4sao3er2guang1
 (一 掃 而 空)	yi4sao3er2kong1
-(㊀ 掃 而 空)	yi4sao3er2kong1
 (一 掠 而 过)	yi2lve4er2guo4
-(㊀ 掠 而 过)	yi2lve4er2guo4
 (一 掠 而 过)	yi2lve4er2guo4
-(㊀ 掠 而 过)	yi2lve4er2guo4
 (一 掠 而 過)	yi2lve4er2guo4
-(㊀ 掠 而 過)	yi2lve4er2guo4
 (一 掠 而 過)	yi2lve4er2guo4
-(㊀ 掠 而 過)	yi2lve4er2guo4
 (一 推 就 倒)	yi4tui1jiu4dao3
-(㊀ 推 就 倒)	yi4tui1jiu4dao3
 (一 掰 两 开)	yi4bai1liang3kai1
-(㊀ 掰 两 开)	yi4bai1liang3kai1
 (一 掰 兩 開)	yi4bai1liang3kai1
-(㊀ 掰 兩 開)	yi4bai1liang3kai1
 (一 掰 兩 開)	yi4bai1liang3kai1
-(㊀ 掰 兩 開)	yi4bai1liang3kai1
 (一 掷 千 金)	yi2zhi4qian1jin1
-(一 掷 千 ㊎)	yi2zhi4qian1jin1
-(㊀ 掷 千 金)	yi2zhi4qian1jin1
 (一 掷 千 金)	yi2zhi4qian1jin1
-(㊀ 掷 千 金)	yi2zhi4qian1jin1
 (一 揮 而 就)	yi4hui1er2jiu4
-(㊀ 揮 而 就)	yi4hui1er2jiu4
 (一 損 俱 損)	yi4sun3ju4sun3
-(㊀ 損 俱 損)	yi4sun3ju4sun3
 (一 搖 一 擺)	yi4yao2yi4bai3
-(㊀ 搖 ㊀ 擺)	yi4yao2yi4bai3
 (一 摇 一 摆)	yi4yao2yi4bai3
-(㊀ 摇 ㊀ 摆)	yi4yao2yi4bai3
 (一 摳 摳 兒)	yi4kou1kou1r5
-(㊀ 摳 摳 兒)	yi4kou1kou1r5
 (一 撇 一 捺)	yi4pie3yi2na4
-(㊀ 撇 ㊀ 捺)	yi4pie3yi2na4
 (一 擔 兒 挑)	yi2dan4r5tiao1
-(㊀ 擔 兒 挑)	yi2dan4r5tiao1
 (一 擲 千 金)	yi2zhi4qian1jin1
-(一 擲 千 ㊎)	yi2zhi4qian1jin1
-(㊀ 擲 千 金)	yi2zhi4qian1jin1
 (一 擲 千 金)	yi2zhi4qian1jin1
-(㊀ 擲 千 金)	yi2zhi4qian1jin1
 (一 改 故 轍)	yi4gai3gu4zhe2
-(㊀ 改 故 轍)	yi4gai3gu4zhe2
 (一 改 故 辙)	yi4gai3gu4zhe2
-(㊀ 改 故 辙)	yi4gai3gu4zhe2
 (一 敗 塗 地)	yi2bai4tu2di4
-(㊀ 敗 塗 地)	yi2bai4tu2di4
 (一 敗 如 水)	yi2bai4ru2shui3
-(一 敗 如 ㊌)	yi2bai4ru2shui3
-(㊀ 敗 如 水)	yi2bai4ru2shui3
 (一 敘 衷 曲)	yi2xu4zhong1qu3
-(㊀ 敘 衷 曲)	yi2xu4zhong1qu3
 (一 文 一 武)	yi4wen2yi4wu3
-(㊀ 文 ㊀ 武)	yi4wen2yi4wu3
 (一 文 不 值)	yi4wen2bu4zhi2
-(㊀ 文 不 值)	yi4wen2bu4zhi2
 (一 文 不 值)	yi4wen2bu4zhi2
-(㊀ 文 不 值)	yi4wen2bu4zhi2
 (一 文 不 名)	yi4wen2bu4ming2
-(㊀ 文 不 名)	yi4wen2bu4ming2
-(一 文 不 ㊔)	yi4wen2bu4ming2
 (一 文 不 名)	yi4wen2bu4ming2
-(㊀ 文 不 名)	yi4wen2bu4ming2
-(一 文 不 ㊔)	yi4wen2bu4ming2
 (一 文 不 花)	yi4wen2bu4hua1
-(㊀ 文 不 花)	yi4wen2bu4hua1
 (一 文 不 花)	yi4wen2bu4hua1
-(㊀ 文 不 花)	yi4wen2bu4hua1
 (一 无 所 长)	yi4wu2suo3chang2
-(㊀ 无 所 长)	yi4wu2suo3chang2
 (一 日 三 秋)	yi2ri4san1qiu1
-(一 日 ㊂ 秋)	yi2ri4san1qiu1
-(㊀ 日 三 秋)	yi2ri4san1qiu1
-(一 ㊐ 三 秋)	yi2ri4san1qiu1
 (一 日 三 餐)	yi2ri4san1can1
-(一 日 ㊂ 餐)	yi2ri4san1can1
-(㊀ 日 三 餐)	yi2ri4san1can1
-(一 ㊐ 三 餐)	yi2ri4san1can1
 (一 日 之 長)	yi2ri4zhi1chang2
-(㊀ 日 之 長)	yi2ri4zhi1chang2
-(一 ㊐ 之 長)	yi2ri4zhi1chang2
 (一 日 之 长)	yi2ri4zhi1chang2
-(㊀ 日 之 长)	yi2ri4zhi1chang2
-(一 ㊐ 之 长)	yi2ri4zhi1chang2
 (一 日 之 雅)	yi2ri4zhi1ya3
-(㊀ 日 之 雅)	yi2ri4zhi1ya3
-(一 ㊐ 之 雅)	yi2ri4zhi1ya3
 (一 日 九 迁)	yi2ri4jiu3qian1
-(一 日 ㊈ 迁)	yi2ri4jiu3qian1
-(㊀ 日 九 迁)	yi2ri4jiu3qian1
-(一 ㊐ 九 迁)	yi2ri4jiu3qian1
 (一 日 九 遷)	yi2ri4jiu3qian1
-(一 日 ㊈ 遷)	yi2ri4jiu3qian1
-(㊀ 日 九 遷)	yi2ri4jiu3qian1
-(一 ㊐ 九 遷)	yi2ri4jiu3qian1
 (一 日 千 里)	yi2ri4qian1li3
-(㊀ 日 千 里)	yi2ri4qian1li3
-(一 ㊐ 千 里)	yi2ri4qian1li3
 (一 日 千 里)	yi2ri4qian1li3
-(㊀ 日 千 里)	yi2ri4qian1li3
-(一 ㊐ 千 里)	yi2ri4qian1li3
 (一 日 数 惊)	yi2ri4shu4jing1
-(㊀ 日 数 惊)	yi2ri4shu4jing1
-(一 ㊐ 数 惊)	yi2ri4shu4jing1
 (一 日 数 起)	yi2ri4shu4qi3
-(㊀ 日 数 起)	yi2ri4shu4qi3
-(一 ㊐ 数 起)	yi2ri4shu4qi3
 (一 日 數 起)	yi2ri4shu4qi3
-(㊀ 日 數 起)	yi2ri4shu4qi3
-(一 ㊐ 數 起)	yi2ri4shu4qi3
 (一 日 數 起)	yi2ri4shu4qi3
-(㊀ 日 數 起)	yi2ri4shu4qi3
-(一 ㊐ 數 起)	yi2ri4shu4qi3
 (一 日 數 驚)	yi2ri4shu4jing1
-(㊀ 日 數 驚)	yi2ri4shu4jing1
-(一 ㊐ 數 驚)	yi2ri4shu4jing1
 (一 日 數 驚)	yi2ri4shu4jing1
-(㊀ 日 數 驚)	yi2ri4shu4jing1
-(一 ㊐ 數 驚)	yi2ri4shu4jing1
 (一 明 两 暗)	yi4ming2liang3an4
-(㊀ 明 两 暗)	yi4ming2liang3an4
 (一 明 兩 暗)	yi4ming2liang3an4
-(㊀ 明 兩 暗)	yi4ming2liang3an4
 (一 明 兩 暗)	yi4ming2liang3an4
-(㊀ 明 兩 暗)	yi4ming2liang3an4
 (一 星 星 儿)	yi4xing1xing1r5
-(㊀ 星 星 儿)	yi4xing1xing1r5
 (一 显 身 手)	yi4xian3shen1shou3
-(㊀ 显 身 手)	yi4xian3shen1shou3
 (一 暴 十 寒)	yi2pu4shi2han2
-(一 暴 ㊉ 寒)	yi2pu4shi2han2
-(㊀ 暴 十 寒)	yi2pu4shi2han2
 (一 暴 十 寒)	yi2pu4shi2han2
-(一 暴 ㊉ 寒)	yi2pu4shi2han2
-(㊀ 暴 十 寒)	yi2pu4shi2han2
 (一 曝 十 寒)	yi2pu4shi2han2
-(一 曝 ㊉ 寒)	yi2pu4shi2han2
-(㊀ 曝 十 寒)	yi2pu4shi2han2
 (一 會 兒 見)	yi4hui3r5jian4
-(㊀ 會 兒 見)	yi4hui3r5jian4
 (一 會 兒 見)	yi4hui3r5jian4
-(㊀ 會 兒 見)	yi4hui3r5jian4
 (一 望 无 垠)	yi2wang4wu2yin2
-(㊀ 望 无 垠)	yi2wang4wu2yin2
 (一 望 无 垠)	yi2wang4wu2yin2
-(㊀ 望 无 垠)	yi2wang4wu2yin2
 (一 望 无 边)	yi2wang4wu2bian1
-(㊀ 望 无 边)	yi2wang4wu2bian1
 (一 望 无 边)	yi2wang4wu2bian1
-(㊀ 望 无 边)	yi2wang4wu2bian1
 (一 望 无 际)	yi2wang4wu2ji4
-(㊀ 望 无 际)	yi2wang4wu2ji4
 (一 望 无 际)	yi2wang4wu2ji4
-(㊀ 望 无 际)	yi2wang4wu2ji4
 (一 望 無 垠)	yi2wang4wu2yin2
-(㊀ 望 無 垠)	yi2wang4wu2yin2
 (一 望 無 垠)	yi2wang4wu2yin2
-(㊀ 望 無 垠)	yi2wang4wu2yin2
 (一 望 無 邊)	yi2wang4wu2bian1
-(㊀ 望 無 邊)	yi2wang4wu2bian1
 (一 望 無 邊)	yi2wang4wu2bian1
-(㊀ 望 無 邊)	yi2wang4wu2bian1
 (一 望 無 際)	yi2wang4wu2ji4
-(㊀ 望 無 際)	yi2wang4wu2ji4
 (一 望 無 際)	yi2wang4wu2ji4
-(㊀ 望 無 際)	yi2wang4wu2ji4
 (一 望 而 知)	yi2wang4er2zhi1
-(㊀ 望 而 知)	yi2wang4er2zhi1
 (一 望 而 知)	yi2wang4er2zhi1
-(㊀ 望 而 知)	yi2wang4er2zhi1
 (一 朝 一 夕)	yi4zhao1yi4xi1
-(㊀ 朝 ㊀ 夕)	yi4zhao1yi4xi1
 (一 期 工 程)	yi4qi1gong1cheng2
-(㊀ 期 工 程)	yi4qi1gong1cheng2
 (一 期 愈 合)	yi4qi1yu4he2
-(㊀ 期 愈 合)	yi4qi1yu4he2
 (一 期 愈 合)	yi4qi1yu4he2
-(㊀ 期 愈 合)	yi4qi1yu4he2
 (一 木 难 支)	yi2mu4nan2zhi1
-(一 ㊍ 难 支)	yi2mu4nan2zhi1
-(㊀ 木 难 支)	yi2mu4nan2zhi1
 (一 木 難 支)	yi2mu4nan2zhi1
-(一 ㊍ 難 支)	yi2mu4nan2zhi1
-(㊀ 木 難 支)	yi2mu4nan2zhi1
 (一 木 難 支)	yi2mu4nan2zhi1
-(一 ㊍ 難 支)	yi2mu4nan2zhi1
-(㊀ 木 難 支)	yi2mu4nan2zhi1
 (一 木 難 支)	yi2mu4nan2zhi1
-(一 ㊍ 難 支)	yi2mu4nan2zhi1
-(㊀ 木 難 支)	yi2mu4nan2zhi1
 (一 机 多 用)	yi4ji1duo1yong4
-(㊀ 机 多 用)	yi4ji1duo1yong4
 (一 条 藤 儿)	yi4tiao2teng2r5
-(㊀ 条 藤 儿)	yi4tiao2teng2r5
 (一 来 一 往)	yi4lai2yi4wang3
-(㊀ 来 ㊀ 往)	yi4lai2yi4wang3
 (一 板 一 眼)	yi4ban3yi4yan3
-(㊀ 板 ㊀ 眼)	yi4ban3yi4yan3
 (一 板 三 眼)	yi4ban3san1yan3
-(一 板 ㊂ 眼)	yi4ban3san1yan3
-(㊀ 板 三 眼)	yi4ban3san1yan3
 (一 板 正 經)	yi4ban3zheng4jing1
-(一 板 ㊣ 經)	yi4ban3zheng4jing1
-(㊀ 板 正 經)	yi4ban3zheng4jing1
 (一 板 正 经)	yi4ban3zheng4jing1
-(一 板 ㊣ 经)	yi4ban3zheng4jing1
-(㊀ 板 正 经)	yi4ban3zheng4jing1
 (一 枕 黃 粱)	yi4zhen3huang2liang2
-(㊀ 枕 黃 粱)	yi4zhen3huang2liang2
 (一 枕 黄 粱)	yi4zhen3huang2liang2
-(㊀ 枕 黄 粱)	yi4zhen3huang2liang2
 (一 枥 两 骡)	yi2li4liang3luo2
-(㊀ 枥 两 骡)	yi2li4liang3luo2
 (一 柱 擎 天)	yi2zhu4qing2tian1
-(㊀ 柱 擎 天)	yi2zhu4qing2tian1
 (一 树 百 获)	yi2shu4bai3huo4
-(㊀ 树 百 获)	yi2shu4bai3huo4
 (一 样 样 价)	yi2yang4yang5jia4
-(㊀ 样 样 价)	yi2yang4yang5jia4
 (一 桥 飞 架)	yi4qiao2fei1jia4
-(㊀ 桥 飞 架)	yi4qiao2fei1jia4
 (一 榮 俱 榮)	yi4rong2ju4rong2
-(㊀ 榮 俱 榮)	yi4rong2ju4rong2
 (一 榻 横 陈)	yi2ta4heng2chen2
-(㊀ 榻 横 陈)	yi2ta4heng2chen2
 (一 榻 橫 陳)	yi2ta4heng2chen2
-(㊀ 榻 橫 陳)	yi2ta4heng2chen2
 (一 模 一 样)	yi4mo2yi2yang4
-(㊀ 模 ㊀ 样)	yi4mo2yi2yang4
 (一 模 一 樣)	yi4mo2yi2yang4
-(㊀ 模 ㊀ 樣)	yi4mo2yi2yang4
 (一 模 活 脫)	yi4mu2huo2tuo1
-(㊀ 模 活 脫)	yi4mu2huo2tuo1
 (一 模 活 脱)	yi4mu2huo2tuo1
-(㊀ 模 活 脱)	yi4mu2huo2tuo1
 (一 樣 樣 價)	yi2yang4yang5jia4
-(㊀ 樣 樣 價)	yi2yang4yang5jia4
 (一 樹 百 獲)	yi2shu4bai3huo4
-(㊀ 樹 百 獲)	yi2shu4bai3huo4
 (一 橋 飛 架)	yi4qiao2fei1jia4
-(㊀ 橋 飛 架)	yi4qiao2fei1jia4
 (一 機 多 用)	yi4ji1duo1yong4
-(㊀ 機 多 用)	yi4ji1duo1yong4
 (一 櫪 兩 騾)	yi2li4liang3luo2
-(㊀ 櫪 兩 騾)	yi2li4liang3luo2
 (一 櫪 兩 騾)	yi2li4liang3luo2
-(㊀ 櫪 兩 騾)	yi2li4liang3luo2
 (一 此 为 甚)	yi4ci3wei2shen4
-(㊀ 此 为 甚)	yi4ci3wei2shen4
 (一 此 為 甚)	yi4ci3wei2shen4
-(㊀ 此 為 甚)	yi4ci3wei2shen4
 (一 步 一 印)	yi2bu4yi2yin4
-(㊀ 步 ㊀ 印)	yi2bu4yi2yin4
-(一 步 一 ㊞)	yi2bu4yi2yin4
 (一 步 一 挨)	yi2bu4yi4ai2
-(㊀ 步 ㊀ 挨)	yi2bu4yi4ai2
 (一 步 一 瘸)	yi2bu4yi4que2
-(㊀ 步 ㊀ 瘸)	yi2bu4yi4que2
 (一 步 一 看)	yi2bu4yi2kan4
-(㊀ 步 ㊀ 看)	yi2bu4yi2kan4
 (一 步 一 踱)	yi2bu4yi4duo2
-(㊀ 步 ㊀ 踱)	yi2bu4yi4duo2
 (一 步 一 顛)	yi2bu4yi4dian1
-(㊀ 步 ㊀ 顛)	yi2bu4yi4dian1
 (一 步 一 颠)	yi2bu4yi4dian1
-(㊀ 步 ㊀ 颠)	yi2bu4yi4dian1
 (一 步 一 鬼)	yi2bu4yi4gui3
-(㊀ 步 ㊀ 鬼)	yi2bu4yi4gui3
 (一 死 了 之)	yi4si3liao3zhi1
-(㊀ 死 了 之)	yi4si3liao3zhi1
 (一 死 了 之)	yi4si3liao3zhi1
-(㊀ 死 了 之)	yi4si3liao3zhi1
 (一 死 百 了)	yi4si3bai3liao3
-(㊀ 死 百 了)	yi4si3bai3liao3
 (一 死 百 了)	yi4si3bai3liao3
-(㊀ 死 百 了)	yi4si3bai3liao3
 (一 母 所 生)	yi4mu3suo3sheng1
-(㊀ 母 所 生)	yi4mu3suo3sheng1
 (一 气 呵 成)	yi2qi4he1cheng2
-(㊀ 气 呵 成)	yi2qi4he1cheng2
 (一 氣 呵 成)	yi2qi4he1cheng2
-(㊀ 氣 呵 成)	yi2qi4he1cheng2
 (一 氧 化 氮)	yi4yang3hua4dan4
-(㊀ 氧 化 氮)	yi4yang3hua4dan4
 (一 氧 化 碳)	yi4yang3hua4tan4
-(㊀ 氧 化 碳)	yi4yang3hua4tan4
 (一 氧 化 鉛)	yi4yang3hua4qian1
-(㊀ 氧 化 鉛)	yi4yang3hua4qian1
 (一 氧 化 铅)	yi4yang3hua4qian1
-(㊀ 氧 化 铅)	yi4yang3hua4qian1
 (一 水 之 隔)	yi4shui3zhi1ge2
-(一 ㊌ 之 隔)	yi4shui3zhi1ge2
-(㊀ 水 之 隔)	yi4shui3zhi1ge2
 (一 江 如 練)	yi4jiang1ru2lian4
-(㊀ 江 如 練)	yi4jiang1ru2lian4
 (一 江 如 練)	yi4jiang1ru2lian4
-(㊀ 江 如 練)	yi4jiang1ru2lian4
 (一 江 如 練)	yi4jiang1ru2lian4
-(㊀ 江 如 練)	yi4jiang1ru2lian4
 (一 江 如 練)	yi4jiang1ru2lian4
-(㊀ 江 如 練)	yi4jiang1ru2lian4
 (一 江 如 练)	yi4jiang1ru2lian4
-(㊀ 江 如 练)	yi4jiang1ru2lian4
 (一 汪 水 儿)	yi4wang1shui3r5
-(一 汪 ㊌ 儿)	yi4wang1shui3r5
-(㊀ 汪 水 儿)	yi4wang1shui3r5
 (一 決 雌 雄)	yi4jue2ci2xiong2
-(㊀ 決 雌 雄)	yi4jue2ci2xiong2
 (一 泓 清 碧)	yi4hong2qing1bi4
-(㊀ 泓 清 碧)	yi4hong2qing1bi4
 (一 泓 秋 水)	yi4hong2qiu1shui3
-(一 泓 秋 ㊌)	yi4hong2qiu1shui3
-(㊀ 泓 秋 水)	yi4hong2qiu1shui3
 (一 波 三 折)	yi4bo1san1zhe2
-(一 波 ㊂ 折)	yi4bo1san1zhe2
-(㊀ 波 三 折)	yi4bo1san1zhe2
 (一 波 三 摺)	yi4bo1san1zhe2
-(一 波 ㊂ 摺)	yi4bo1san1zhe2
-(㊀ 波 三 摺)	yi4bo1san1zhe2
 (一 波 不 兴)	yi4bo1bu4xing1
-(㊀ 波 不 兴)	yi4bo1bu4xing1
 (一 波 不 兴)	yi4bo1bu4xing1
-(㊀ 波 不 兴)	yi4bo1bu4xing1
 (一 波 不 興)	yi4bo1bu4xing1
-(㊀ 波 不 興)	yi4bo1bu4xing1
 (一 波 不 興)	yi4bo1bu4xing1
-(㊀ 波 不 興)	yi4bo1bu4xing1
 (一 泻 千 里)	yi2xie4qian1li3
-(㊀ 泻 千 里)	yi2xie4qian1li3
 (一 泻 千 里)	yi2xie4qian1li3
-(㊀ 泻 千 里)	yi2xie4qian1li3
 (一 派 大 好)	yi2pai4da4hao3
-(㊀ 派 大 好)	yi2pai4da4hao3
 (一 派 胡 言)	yi2pai4hu2yan2
-(㊀ 派 胡 言)	yi2pai4hu2yan2
 (一 派 謊 言)	yi2pai4huang3yan2
-(㊀ 派 謊 言)	yi2pai4huang3yan2
 (一 派 谎 言)	yi2pai4huang3yan2
-(㊀ 派 谎 言)	yi2pai4huang3yan2
 (一 清 二 楚)	yi4qing1er4chu3
-(㊀ 清 二 楚)	yi4qing1er4chu3
-(一 清 ㊁ 楚)	yi4qing1er4chu3
 (一 清 二 白)	yi4qing1er4bai2
-(㊀ 清 二 白)	yi4qing1er4bai2
-(一 清 ㊁ 白)	yi4qing1er4bai2
 (一 清 早 儿)	yi4qing1zao3r5
-(㊀ 清 早 儿)	yi4qing1zao3r5
 (一 溜 烟 儿)	yi2liu4yan1r5
-(㊀ 溜 烟 儿)	yi2liu4yan1r5
 (一 溜 烟 儿)	yi2liu4yan1r5
-(㊀ 溜 烟 儿)	yi2liu4yan1r5
 (一 滴 滴 儿)	yi4di1di1r5
-(㊀ 滴 滴 儿)	yi4di1di1r5
 (一 滴 滴 兒)	yi4di1di1r5
-(㊀ 滴 滴 兒)	yi4di1di1r5
 (一 潭 死 水)	yi4tan2si3shui3
-(一 潭 死 ㊌)	yi4tan2si3shui3
-(㊀ 潭 死 水)	yi4tan2si3shui3
 (一 瀉 千 里)	yi2xie4qian1li3
-(㊀ 瀉 千 里)	yi2xie4qian1li3
 (一 瀉 千 里)	yi2xie4qian1li3
-(㊀ 瀉 千 里)	yi2xie4qian1li3
 (一 灯 如 豆)	yi4deng1ru2dou4
-(㊀ 灯 如 豆)	yi4deng1ru2dou4
 (一 灵 真 性)	yi4ling2zhen1xing4
-(㊀ 灵 真 性)	yi4ling2zhen1xing4
 (一 炮 打 响)	yi2pao4da3xiang3
-(㊀ 炮 打 响)	yi2pao4da3xiang3
 (一 炮 打 響)	yi2pao4da3xiang3
-(㊀ 炮 打 響)	yi2pao4da3xiang3
 (一 炮 打 響)	yi2pao4da3xiang3
-(㊀ 炮 打 響)	yi2pao4da3xiang3
 (一 炮 打 響)	yi2pao4da3xiang3
-(㊀ 炮 打 響)	yi2pao4da3xiang3
 (一 炮 而 紅)	yi2pao4er2hong2
-(㊀ 炮 而 紅)	yi2pao4er2hong2
 (一 炮 而 红)	yi2pao4er2hong2
-(㊀ 炮 而 红)	yi2pao4er2hong2
 (一 点 一 滴)	yi4dian3yi4di1
-(㊀ 点 ㊀ 滴)	yi4dian3yi4di1
 (一 無 所 長)	yi4wu2suo3chang2
-(㊀ 無 所 長)	yi4wu2suo3chang2
 (一 燈 如 豆)	yi4deng1ru2dou4
-(㊀ 燈 如 豆)	yi4deng1ru2dou4
 (一 爭 短 長)	yi4zheng1duan3chang2
-(㊀ 爭 短 長)	yi4zheng1duan3chang2
 (一 牆 之 隔)	yi4qiang2zhi1ge2
-(㊀ 牆 之 隔)	yi4qiang2zhi1ge2
 (一 狐 之 腋)	yi4hu2zhi1ye4
-(㊀ 狐 之 腋)	yi4hu2zhi1ye4
 (一 猜 就 中)	yi4cai1jiu4zhong4
-(一 猜 就 🀄)	yi4cai1jiu4zhong4
-(一 猜 就 ㊥)	yi4cai1jiu4zhong4
-(㊀ 猜 就 中)	yi4cai1jiu4zhong4
-(㊀ 猜 就 🀄)	yi4cai1jiu4zhong4
 (一 琴 一 鶴)	yi4qin2yi2he4
-(㊀ 琴 ㊀ 鶴)	yi4qin2yi2he4
 (一 琴 一 鶴)	yi4qin2yi2he4
-(㊀ 琴 ㊀ 鶴)	yi4qin2yi2he4
 (一 琴 一 鹤)	yi4qin2yi2he4
-(㊀ 琴 ㊀ 鹤)	yi4qin2yi2he4
 (一 男 半 女)	yi4nan2ban4nv3
-(㊀ 男 半 女)	yi4nan2ban4nv3
-(一 ㊚ 半 女)	yi4nan2ban4nv3
-(一 男 半 ㊛)	yi4nan2ban4nv3
 (一 男 半 女)	yi4nan2ban4nv3
-(㊀ 男 半 女)	yi4nan2ban4nv3
-(一 ㊚ 半 女)	yi4nan2ban4nv3
 (一 疊 卡 片)	yi4die2ka3pian4
-(㊀ 疊 卡 片)	yi4die2ka3pian4
 (一 病 不 起)	yi2bing4bu4qi3
-(㊀ 病 不 起)	yi2bing4bu4qi3
 (一 病 不 起)	yi2bing4bu4qi3
-(㊀ 病 不 起)	yi2bing4bu4qi3
 (一 病 身 亡)	yi2bing4shen1wang2
-(㊀ 病 身 亡)	yi2bing4shen1wang2
 (一 瘸 一 拐)	yi4que2yi4guai3
-(㊀ 瘸 ㊀ 拐)	yi4que2yi4guai3
 (一 百 成 儿)	yi4bai3cheng2r5
-(㊀ 百 成 儿)	yi4bai3cheng2r5
 (一 目 了 然)	yi2mu4liao3ran2
-(㊀ 目 了 然)	yi2mu4liao3ran2
 (一 目 了 然)	yi2mu4liao3ran2
-(㊀ 目 了 然)	yi2mu4liao3ran2
 (一 目 十 行)	yi2mu4shi2hang2
-(一 目 ㊉ 行)	yi2mu4shi2hang2
-(㊀ 目 十 行)	yi2mu4shi2hang2
 (一 目 十 行)	yi2mu4shi2hang2
-(一 目 ㊉ 行)	yi2mu4shi2hang2
-(㊀ 目 十 行)	yi2mu4shi2hang2
 (一 目 瞭 然)	yi2mu4liao4ran2
-(㊀ 目 瞭 然)	yi2mu4liao4ran2
 (一 相 情 愿)	yi4xiang1qing2yuan4
-(㊀ 相 情 愿)	yi4xiang1qing2yuan4
 (一 相 情 願)	yi4xiang1qing2yuan4
-(㊀ 相 情 願)	yi4xiang1qing2yuan4
 (一 看 二 帮)	yi2kan4er4bang1
-(㊀ 看 二 帮)	yi2kan4er4bang1
-(一 看 ㊁ 帮)	yi2kan4er4bang1
 (一 看 二 幫)	yi2kan4er4bang1
-(㊀ 看 二 幫)	yi2kan4er4bang1
-(一 看 ㊁ 幫)	yi2kan4er4bang1
 (一 看 就 懂)	yi2kan4jiu4dong3
-(㊀ 看 就 懂)	yi2kan4jiu4dong3
 (一 眨 眼 儿)	yi4zha3yan3r5
-(㊀ 眨 眼 儿)	yi4zha3yan3r5
 (一 瞑 不 視)	yi4ming2bu2shi4
-(㊀ 瞑 不 視)	yi4ming2bu2shi4
 (一 瞑 不 視)	yi4ming2bu2shi4
-(㊀ 瞑 不 視)	yi4ming2bu2shi4
 (一 瞑 不 視)	yi4ming2bu2shi4
-(㊀ 瞑 不 視)	yi4ming2bu2shi4
 (一 瞑 不 視)	yi4ming2bu2shi4
-(㊀ 瞑 不 視)	yi4ming2bu2shi4
 (一 瞑 不 视)	yi4ming2bu2shi4
-(㊀ 瞑 不 视)	yi4ming2bu2shi4
 (一 瞑 不 视)	yi4ming2bu2shi4
-(㊀ 瞑 不 视)	yi4ming2bu2shi4
 (一 瞻 風 采)	yi4zhan1feng1cai3
-(㊀ 瞻 風 采)	yi4zhan1feng1cai3
 (一 瞻 风 采)	yi4zhan1feng1cai3
-(㊀ 瞻 风 采)	yi4zhan1feng1cai3
 (一 矢 之 地)	yi4shi3zhi1di4
-(㊀ 矢 之 地)	yi4shi3zhi1di4
 (一 知 半 解)	yi4zhi1ban4jie3
-(㊀ 知 半 解)	yi4zhi1ban4jie3
 (一 石 两 鸟)	yi4shi2liang3niao3
-(㊀ 石 两 鸟)	yi4shi2liang3niao3
 (一 石 二 鳥)	yi4shi2er4niao3
-(㊀ 石 二 鳥)	yi4shi2er4niao3
-(一 石 ㊁ 鳥)	yi4shi2er4niao3
 (一 石 二 鸟)	yi4shi2er4niao3
-(㊀ 石 二 鸟)	yi4shi2er4niao3
-(一 石 ㊁ 鸟)	yi4shi2er4niao3
 (一 石 兩 鳥)	yi4shi2liang3niao3
-(㊀ 石 兩 鳥)	yi4shi2liang3niao3
 (一 石 兩 鳥)	yi4shi2liang3niao3
-(㊀ 石 兩 鳥)	yi4shi2liang3niao3
 (一 码 儿 新)	yi4ma3r5xin1
-(㊀ 码 儿 新)	yi4ma3r5xin1
 (一 砍 两 半)	yi4kan3liang3ban4
-(㊀ 砍 两 半)	yi4kan3liang3ban4
 (一 砍 兩 半)	yi4kan3liang3ban4
-(㊀ 砍 兩 半)	yi4kan3liang3ban4
 (一 砍 兩 半)	yi4kan3liang3ban4
-(㊀ 砍 兩 半)	yi4kan3liang3ban4
 (一 砖 一 瓦)	yi4zhuan1yi4wa3
-(㊀ 砖 ㊀ 瓦)	yi4zhuan1yi4wa3
 (一 碼 兒 新)	yi4ma3r5xin1
-(㊀ 碼 兒 新)	yi4ma3r5xin1
 (一 磚 一 瓦)	yi4zhuan1yi4wa3
-(㊀ 磚 ㊀ 瓦)	yi4zhuan1yi4wa3
 (一 票 到 底)	yi2piao4dao4di3
-(㊀ 票 到 底)	yi2piao4dao4di3
 (一 秉 至 公)	yi4bing3zhi4gong1
-(㊀ 秉 至 公)	yi4bing3zhi4gong1
 (一 秉 虔 誠)	yi4bing3qian2cheng2
-(㊀ 秉 虔 誠)	yi4bing3qian2cheng2
 (一 秉 虔 诚)	yi4bing3qian2cheng2
-(㊀ 秉 虔 诚)	yi4bing3qian2cheng2
 (一 穷 二 白)	yi4qiong2er4bai2
-(㊀ 穷 二 白)	yi4qiong2er4bai2
-(一 穷 ㊁ 白)	yi4qiong2er4bai2
 (一 窍 不 通)	yi2qiao4bu4tong1
-(㊀ 窍 不 通)	yi2qiao4bu4tong1
 (一 窍 不 通)	yi2qiao4bu4tong1
-(㊀ 窍 不 通)	yi2qiao4bu4tong1
 (一 窝 风 吹)	yi4wo1feng1chui1
-(㊀ 窝 风 吹)	yi4wo1feng1chui1
 (一 窥 全 豹)	yi4kui1quan2bao4
-(㊀ 窥 全 豹)	yi4kui1quan2bao4
 (一 窥 全 豹)	yi4kui1quan2bao4
-(㊀ 窥 全 豹)	yi4kui1quan2bao4
 (一 窩 風 吹)	yi4wo1feng1chui1
-(㊀ 窩 風 吹)	yi4wo1feng1chui1
 (一 窮 二 白)	yi4qiong2er4bai2
-(㊀ 窮 二 白)	yi4qiong2er4bai2
-(一 窮 ㊁ 白)	yi4qiong2er4bai2
 (一 窺 全 豹)	yi4kui1quan2bao4
-(㊀ 窺 全 豹)	yi4kui1quan2bao4
 (一 窺 全 豹)	yi4kui1quan2bao4
-(㊀ 窺 全 豹)	yi4kui1quan2bao4
 (一 竅 不 通)	yi2qiao4bu4tong1
-(㊀ 竅 不 通)	yi2qiao4bu4tong1
 (一 竅 不 通)	yi2qiao4bu4tong1
-(㊀ 竅 不 通)	yi2qiao4bu4tong1
 (一 竿 到 底)	yi4gan1dao4di3
-(㊀ 竿 到 底)	yi4gan1dao4di3
 (一 笑 了 之)	yi2xiao4liao3zhi1
-(㊀ 笑 了 之)	yi2xiao4liao3zhi1
 (一 笑 了 之)	yi2xiao4liao3zhi1
-(㊀ 笑 了 之)	yi2xiao4liao3zhi1
 (一 笑 作 答)	yi2xiao4zuo4da2
-(㊀ 笑 作 答)	yi2xiao4zuo4da2
 (一 笑 倾 城)	yi2xiao4qing1cheng2
-(㊀ 笑 倾 城)	yi2xiao4qing1cheng2
 (一 笑 傾 城)	yi2xiao4qing1cheng2
-(㊀ 笑 傾 城)	yi2xiao4qing1cheng2
 (一 笑 千 金)	yi2xiao4qian1jin1
-(一 笑 千 ㊎)	yi2xiao4qian1jin1
-(㊀ 笑 千 金)	yi2xiao4qian1jin1
 (一 笑 千 金)	yi2xiao4qian1jin1
-(㊀ 笑 千 金)	yi2xiao4qian1jin1
 (一 笑 置 之)	yi2xiao4zhi4zhi1
-(㊀ 笑 置 之)	yi2xiao4zhi4zhi1
 (一 笑 而 去)	yi2xiao4er2qu4
-(㊀ 笑 而 去)	yi2xiao4er2qu4
 (一 笑 頓 釋)	yi2xiao4dun4shi4
-(㊀ 笑 頓 釋)	yi2xiao4dun4shi4
 (一 笑 顿 释)	yi2xiao4dun4shi4
-(㊀ 笑 顿 释)	yi2xiao4dun4shi4
 (一 笔 一 划)	yi4bi3yi2hua4
-(㊀ 笔 ㊀ 划)	yi4bi3yi2hua4
 (一 筆 一 劃)	yi4bi3yi2hua4
-(㊀ 筆 ㊀ 劃)	yi4bi3yi2hua4
 (一 箭 中 鵠)	yi2jian4zhong4gu3
-(一 箭 🀄 鵠)	yi2jian4zhong4gu3
-(一 箭 ㊥ 鵠)	yi2jian4zhong4gu3
-(㊀ 箭 中 鵠)	yi2jian4zhong4gu3
-(㊀ 箭 🀄 鵠)	yi2jian4zhong4gu3
 (一 箭 中 鹄)	yi2jian4zhong4gu3
-(一 箭 🀄 鹄)	yi2jian4zhong4gu3
-(一 箭 ㊥ 鹄)	yi2jian4zhong4gu3
-(㊀ 箭 中 鹄)	yi2jian4zhong4gu3
-(㊀ 箭 🀄 鹄)	yi2jian4zhong4gu3
 (一 箭 之 仇)	yi2jian4zhi1chou2
-(㊀ 箭 之 仇)	yi2jian4zhi1chou2
 (一 箭 之 地)	yi2jian4zhi1di4
-(㊀ 箭 之 地)	yi2jian4zhi1di4
 (一 箭 之 遙)	yi2jian4zhi1yao2
-(㊀ 箭 之 遙)	yi2jian4zhi1yao2
 (一 箭 之 遥)	yi2jian4zhi1yao2
-(㊀ 箭 之 遥)	yi2jian4zhi1yao2
 (一 箭 双 雕)	yi2jian4shuang1diao1
-(㊀ 箭 双 雕)	yi2jian4shuang1diao1
 (一 箭 双 鵰)	yi2jian4shuang1diao1
-(㊀ 箭 双 鵰)	yi2jian4shuang1diao1
 (一 箭 雙 雕)	yi2jian4shuang1diao1
-(㊀ 箭 雙 雕)	yi2jian4shuang1diao1
 (一 箭 雙 鵰)	yi2jian4shuang1diao1
-(㊀ 箭 雙 鵰)	yi2jian4shuang1diao1
 (一 篑 之 功)	yi2kui4zhi1gong1
-(㊀ 篑 之 功)	yi2kui4zhi1gong1
 (一 簣 之 功)	yi2kui4zhi1gong1
-(㊀ 簣 之 功)	yi2kui4zhi1gong1
 (一 粥 一 飯)	yi4zhou1yi2fan4
-(㊀ 粥 ㊀ 飯)	yi4zhou1yi2fan4
 (一 粥 一 飯)	yi4zhou1yi2fan4
-(㊀ 粥 ㊀ 飯)	yi4zhou1yi2fan4
 (一 粥 一 饭)	yi4zhou1yi2fan4
-(㊀ 粥 ㊀ 饭)	yi4zhou1yi2fan4
 (一 紙 休 書)	yi4zhi3xiu1shu1
-(一 紙 ㊡ 書)	yi4zhi3xiu1shu1
-(㊀ 紙 休 書)	yi4zhi3xiu1shu1
 (一 紙 具 文)	yi4zhi3ju4wen2
-(㊀ 紙 具 文)	yi4zhi3ju4wen2
 (一 紙 空 文)	yi4zhi3kong1wen2
-(㊀ 紙 空 文)	yi4zhi3kong1wen2
 (一 索 得 男)	yi4suo3de2nan2
-(㊀ 索 得 男)	yi4suo3de2nan2
-(一 索 得 ㊚)	yi4suo3de2nan2
 (一 索 得 男)	yi4suo3de2nan2
-(㊀ 索 得 男)	yi4suo3de2nan2
-(一 索 得 ㊚)	yi4suo3de2nan2
 (一 絲 一 毫)	yi4si1yi4hao2
-(㊀ 絲 ㊀ 毫)	yi4si1yi4hao2
 (一 絲 不 差)	yi4si1bu2cha4
-(㊀ 絲 不 差)	yi4si1bu2cha4
 (一 絲 不 差)	yi4si1bu2cha4
-(㊀ 絲 不 差)	yi4si1bu2cha4
 (一 絲 不 掛)	yi4si1bu2gua4
-(㊀ 絲 不 掛)	yi4si1bu2gua4
 (一 絲 不 掛)	yi4si1bu2gua4
-(㊀ 絲 不 掛)	yi4si1bu2gua4
 (一 絲 不 苟)	yi4si1bu4gou3
-(㊀ 絲 不 苟)	yi4si1bu4gou3
 (一 絲 不 苟)	yi4si1bu4gou3
-(㊀ 絲 不 苟)	yi4si1bu4gou3
 (一 絲 不 錯)	yi4si1bu2cuo4
-(㊀ 絲 不 錯)	yi4si1bu2cuo4
 (一 絲 不 錯)	yi4si1bu2cuo4
-(㊀ 絲 不 錯)	yi4si1bu2cuo4
 (一 絲 愁 雲)	yi4si1chou2yun2
-(㊀ 絲 愁 雲)	yi4si1chou2yun2
 (一 絲 春 意)	yi4si1chun1yi4
-(㊀ 絲 春 意)	yi4si1chun1yi4
 (一 絲 笑 意)	yi4si1xiao4yi4
-(㊀ 絲 笑 意)	yi4si1xiao4yi4
 (一 網 打 盡)	yi4wang3da3jin4
-(㊀ 網 打 盡)	yi4wang3da3jin4
 (一 綹 假 髮)	yi4liu3jia3fa4
-(㊀ 綹 假 髮)	yi4liu3jia3fa4
 (一 綹 青 絲)	yi4liu3qing1si1
-(㊀ 綹 青 絲)	yi4liu3qing1si1
 (一 綹 頭 髮)	yi4liu3tou2fa5
-(㊀ 綹 頭 髮)	yi4liu3tou2fa5
 (一 縷 幽 香)	yi4lv3you1xiang1
-(㊀ 縷 幽 香)	yi4lv3you1xiang1
 (一 縷 幽 香)	yi4lv3you1xiang1
-(㊀ 縷 幽 香)	yi4lv3you1xiang1
 (一 縷 青 煙)	yi4lv3qing1yan1
-(㊀ 縷 青 煙)	yi4lv3qing1yan1
 (一 縷 青 煙)	yi4lv3qing1yan1
-(㊀ 縷 青 煙)	yi4lv3qing1yan1
 (一 縷 頭 髮)	yi4lv3tou2fa5
-(㊀ 縷 頭 髮)	yi4lv3tou2fa5
 (一 縷 頭 髮)	yi4lv3tou2fa5
-(㊀ 縷 頭 髮)	yi4lv3tou2fa5
 (一 纸 休 书)	yi4zhi3xiu1shu1
-(一 纸 ㊡ 书)	yi4zhi3xiu1shu1
-(㊀ 纸 休 书)	yi4zhi3xiu1shu1
 (一 纸 具 文)	yi4zhi3ju4wen2
-(㊀ 纸 具 文)	yi4zhi3ju4wen2
 (一 纸 空 文)	yi4zhi3kong1wen2
-(㊀ 纸 空 文)	yi4zhi3kong1wen2
 (一 绺 假 发)	yi4liu3jia3fa4
-(㊀ 绺 假 发)	yi4liu3jia3fa4
 (一 绺 头 发)	yi4liu3tou2fa5
-(㊀ 绺 头 发)	yi4liu3tou2fa5
 (一 绺 青 丝)	yi4liu3qing1si1
-(㊀ 绺 青 丝)	yi4liu3qing1si1
 (一 缕 头 发)	yi4lv3tou2fa5
-(㊀ 缕 头 发)	yi4lv3tou2fa5
 (一 缕 幽 香)	yi4lv3you1xiang1
-(㊀ 缕 幽 香)	yi4lv3you1xiang1
 (一 缕 青 烟)	yi4lv3qing1yan1
-(㊀ 缕 青 烟)	yi4lv3qing1yan1
 (一 缰 四 马)	yi4jiang1si4ma3
-(一 缰 ㊃ 马)	yi4jiang1si4ma3
-(㊀ 缰 四 马)	yi4jiang1si4ma3
 (一 网 打 尽)	yi4wang3da3jin4
-(㊀ 网 打 尽)	yi4wang3da3jin4
 (一 聆 妙 音)	yi4ling2miao4yin1
-(㊀ 聆 妙 音)	yi4ling2miao4yin1
 (一 聆 妙 音)	yi4ling2miao4yin1
-(㊀ 聆 妙 音)	yi4ling2miao4yin1
 (一 股 劲 儿)	yi4gu3jin4r5
-(㊀ 股 劲 儿)	yi4gu3jin4r5
 (一 股 气 儿)	yi4gu3qi4r5
-(㊀ 股 气 儿)	yi4gu3qi4r5
 (一 胎 三 兒)	yi4tai1san1er2
-(一 胎 ㊂ 兒)	yi4tai1san1er2
-(㊀ 胎 三 兒)	yi4tai1san1er2
 (一 胎 三 子)	yi4tai1san1zi3
-(一 胎 ㊂ 子)	yi4tai1san1zi3
-(㊀ 胎 三 子)	yi4tai1san1zi3
 (一 胡 捋 儿)	yi4hu2luo1r5
-(㊀ 胡 捋 儿)	yi4hu2luo1r5
 (一 脈 相 傳)	yi2mai4xiang1chuan2
-(㊀ 脈 相 傳)	yi2mai4xiang1chuan2
 (一 脈 相 承)	yi2mai4xiang1cheng2
-(㊀ 脈 相 承)	yi2mai4xiang1cheng2
 (一 脈 相 通)	yi2mai4xiang1tong1
-(㊀ 脈 相 通)	yi2mai4xiang1tong1
 (一 脈 相 連)	yi2mai4xiang1lian2
-(㊀ 脈 相 連)	yi2mai4xiang1lian2
 (一 脈 相 連)	yi2mai4xiang1lian2
-(㊀ 脈 相 連)	yi2mai4xiang1lian2
 (一 脉 相 传)	yi2mai4xiang1chuan2
-(㊀ 脉 相 传)	yi2mai4xiang1chuan2
 (一 脉 相 承)	yi2mai4xiang1cheng2
-(㊀ 脉 相 承)	yi2mai4xiang1cheng2
 (一 脉 相 连)	yi2mai4xiang1lian2
-(㊀ 脉 相 连)	yi2mai4xiang1lian2
 (一 脉 相 通)	yi2mai4xiang1tong1
-(㊀ 脉 相 通)	yi2mai4xiang1tong1
 (一 脖 子 拐)	yi4bo2zi5guai3
-(㊀ 脖 子 拐)	yi4bo2zi5guai3
 (一 脸 死 相)	yi4lian3si3xiang4
-(㊀ 脸 死 相)	yi4lian3si3xiang4
 (一 脸 疙 瘩)	yi4lian3ge1da1
-(㊀ 脸 疙 瘩)	yi4lian3ge1da1
 (一 臂 之 力)	yi2bi4zhi1li4
-(㊀ 臂 之 力)	yi2bi4zhi1li4
 (一 臂 之 力)	yi2bi4zhi1li4
-(㊀ 臂 之 力)	yi2bi4zhi1li4
 (一 臉 死 相)	yi4lian3si3xiang4
-(㊀ 臉 死 相)	yi4lian3si3xiang4
 (一 臉 疙 瘩)	yi4lian3ge1da1
-(㊀ 臉 疙 瘩)	yi4lian3ge1da1
 (一 臧 一 否)	yi4zang1yi4pi3
-(㊀ 臧 ㊀ 否)	yi4zang1yi4pi3
 (一 致 联 系)	yi2zhi4lian2xi5
-(㊀ 致 联 系)	yi2zhi4lian2xi5
 (一 致 聯 繫)	yi2zhi4lian2xi5
-(㊀ 致 聯 繫)	yi2zhi4lian2xi5
 (一 致 聯 繫)	yi2zhi4lian2xi5
-(㊀ 致 聯 繫)	yi2zhi4lian2xi5
 (一 舉 兩 得)	yi4ju3liang3de2
-(㊀ 舉 兩 得)	yi4ju3liang3de2
 (一 舉 兩 得)	yi4ju3liang3de2
-(㊀ 舉 兩 得)	yi4ju3liang3de2
 (一 舉 多 得)	yi4ju3duo1de2
-(㊀ 舉 多 得)	yi4ju3duo1de2
 (一 舉 得 男)	yi4ju3de2nan2
-(㊀ 舉 得 男)	yi4ju3de2nan2
-(一 舉 得 ㊚)	yi4ju3de2nan2
 (一 花 独 放)	yi4hua1du2fang4
-(㊀ 花 独 放)	yi4hua1du2fang4
 (一 花 獨 放)	yi4hua1du2fang4
-(㊀ 花 獨 放)	yi4hua1du2fang4
 (一 草 一 木)	yi4cao3yi2mu4
-(一 草 一 ㊍)	yi4cao3yi2mu4
-(㊀ 草 ㊀ 木)	yi4cao3yi2mu4
 (一 荣 俱 荣)	yi4rong2ju4rong2
-(㊀ 荣 俱 荣)	yi4rong2ju4rong2
 (一 落 千 丈)	yi2luo4qian1zhang4
-(㊀ 落 千 丈)	yi2luo4qian1zhang4
 (一 落 千 丈)	yi2luo4qian1zhang4
-(㊀ 落 千 丈)	yi2luo4qian1zhang4
 (一 葉 扁 舟)	yi2ye4pian1zhou1
-(㊀ 葉 扁 舟)	yi2ye4pian1zhou1
 (一 葉 扁 舟)	yi2ye4pian1zhou1
-(㊀ 葉 扁 舟)	yi2ye4pian1zhou1
 (一 葉 知 秋)	yi2ye4zhi1qiu1
-(㊀ 葉 知 秋)	yi2ye4zhi1qiu1
 (一 葉 知 秋)	yi2ye4zhi1qiu1
-(㊀ 葉 知 秋)	yi2ye4zhi1qiu1
 (一 葉 蔽 目)	yi2ye4bi4mu4
-(㊀ 葉 蔽 目)	yi2ye4bi4mu4
 (一 葉 蔽 目)	yi2ye4bi4mu4
-(㊀ 葉 蔽 目)	yi2ye4bi4mu4
 (一 葉 障 目)	yi2ye4zhang4mu4
-(㊀ 葉 障 目)	yi2ye4zhang4mu4
 (一 葉 障 目)	yi2ye4zhang4mu4
-(㊀ 葉 障 目)	yi2ye4zhang4mu4
 (一 薰 一 莸)	yi4xun1yi4you2
-(㊀ 薰 ㊀ 莸)	yi4xun1yi4you2
 (一 薰 一 蕕)	yi4xun1yi4you2
-(㊀ 薰 ㊀ 蕕)	yi4xun1yi4you2
 (一 衣 带 水)	yi4yi1dai4shui3
-(一 衣 带 ㊌)	yi4yi1dai4shui3
-(㊀ 衣 带 水)	yi4yi1dai4shui3
 (一 衣 帶 水)	yi4yi1dai4shui3
-(一 衣 帶 ㊌)	yi4yi1dai4shui3
-(㊀ 衣 帶 水)	yi4yi1dai4shui3
 (一 表 非 俗)	yi4biao3fei1su2
-(㊀ 表 非 俗)	yi4biao3fei1su2
 (一 袋 把 烟)	yi2dai4ba3yan1
-(㊀ 袋 把 烟)	yi2dai4ba3yan1
 (一 袋 把 煙)	yi2dai4ba3yan1
-(㊀ 袋 把 煙)	yi2dai4ba3yan1
 (一 裹 脑 子)	yi4guo3nao3zi5
-(㊀ 裹 脑 子)	yi4guo3nao3zi5
 (一 裹 腦 子)	yi4guo3nao3zi5
-(㊀ 裹 腦 子)	yi4guo3nao3zi5
 (一 見 傾 心)	yi2jian4qing1xin1
-(㊀ 見 傾 心)	yi2jian4qing1xin1
 (一 見 傾 心)	yi2jian4qing1xin1
-(㊀ 見 傾 心)	yi2jian4qing1xin1
 (一 見 喪 膽)	yi2jian4sang4dan3
-(㊀ 見 喪 膽)	yi2jian4sang4dan3
 (一 見 喪 膽)	yi2jian4sang4dan3
-(㊀ 見 喪 膽)	yi2jian4sang4dan3
 (一 見 垂 涎)	yi2jian4chui2xian2
-(㊀ 見 垂 涎)	yi2jian4chui2xian2
 (一 見 垂 涎)	yi2jian4chui2xian2
-(㊀ 見 垂 涎)	yi2jian4chui2xian2
 (一 見 如 故)	yi2jian4ru2gu4
-(㊀ 見 如 故)	yi2jian4ru2gu4
 (一 見 如 故)	yi2jian4ru2gu4
-(㊀ 見 如 故)	yi2jian4ru2gu4
 (一 見 為 快)	yi2jian4wei2kuai4
-(㊀ 見 為 快)	yi2jian4wei2kuai4
 (一 見 為 快)	yi2jian4wei2kuai4
-(㊀ 見 為 快)	yi2jian4wei2kuai4
 (一 見 稱 心)	yi2jian4chen4xin1
-(㊀ 見 稱 心)	yi2jian4chen4xin1
 (一 見 稱 心)	yi2jian4chen4xin1
-(㊀ 見 稱 心)	yi2jian4chen4xin1
 (一 見 鐘 情)	yi2jian4zhong1qing2
-(㊀ 見 鐘 情)	yi2jian4zhong1qing2
 (一 見 鐘 情)	yi2jian4zhong1qing2
-(㊀ 見 鐘 情)	yi2jian4zhong1qing2
 (一 見 高 低)	yi2jian4gao1di1
-(㊀ 見 高 低)	yi2jian4gao1di1
 (一 見 高 低)	yi2jian4gao1di1
-(㊀ 見 高 低)	yi2jian4gao1di1
 (一 視 同 仁)	yi2shi4tong2ren2
-(㊀ 視 同 仁)	yi2shi4tong2ren2
 (一 視 同 仁)	yi2shi4tong2ren2
-(㊀ 視 同 仁)	yi2shi4tong2ren2
 (一 視 同 仁)	yi2shi4tong2ren2
-(㊀ 視 同 仁)	yi2shi4tong2ren2
 (一 親 芳 澤)	yi4qin1fang1ze2
-(㊀ 親 芳 澤)	yi4qin1fang1ze2
 (一 覺 醒 來)	yi2jiao4xing3lai2
-(㊀ 覺 醒 來)	yi2jiao4xing3lai2
 (一 覺 醒 來)	yi2jiao4xing3lai2
-(㊀ 覺 醒 來)	yi2jiao4xing3lai2
 (一 见 丧 胆)	yi2jian4sang4dan3
-(㊀ 见 丧 胆)	yi2jian4sang4dan3
 (一 见 为 快)	yi2jian4wei2kuai4
-(㊀ 见 为 快)	yi2jian4wei2kuai4
 (一 见 倾 心)	yi2jian4qing1xin1
-(㊀ 见 倾 心)	yi2jian4qing1xin1
 (一 见 垂 涎)	yi2jian4chui2xian2
-(㊀ 见 垂 涎)	yi2jian4chui2xian2
 (一 见 如 故)	yi2jian4ru2gu4
-(㊀ 见 如 故)	yi2jian4ru2gu4
 (一 见 称 心)	yi2jian4chen4xin1
-(㊀ 见 称 心)	yi2jian4chen4xin1
 (一 见 钟 情)	yi2jian4zhong1qing2
-(㊀ 见 钟 情)	yi2jian4zhong1qing2
 (一 见 高 低)	yi2jian4gao1di1
-(㊀ 见 高 低)	yi2jian4gao1di1
 (一 视 同 仁)	yi2shi4tong2ren2
-(㊀ 视 同 仁)	yi2shi4tong2ren2
 (一 觉 醒 来)	yi2jiao4xing3lai2
-(㊀ 觉 醒 来)	yi2jiao4xing3lai2
 (一 触 即 发)	yi2chu4ji2fa1
-(㊀ 触 即 发)	yi2chu4ji2fa1
 (一 触 即 溃)	yi2chu4ji2kui4
-(㊀ 触 即 溃)	yi2chu4ji2kui4
 (一 触 即 爆)	yi2chu4ji2bao4
-(㊀ 触 即 爆)	yi2chu4ji2bao4
 (一 觸 即 潰)	yi2chu4ji2kui4
-(㊀ 觸 即 潰)	yi2chu4ji2kui4
 (一 觸 即 爆)	yi2chu4ji2bao4
-(㊀ 觸 即 爆)	yi2chu4ji2bao4
 (一 觸 即 發)	yi2chu4ji2fa1
-(㊀ 觸 即 發)	yi2chu4ji2fa1
 (一 言 丧 邦)	yi4yan2sang1bang1
-(㊀ 言 丧 邦)	yi4yan2sang1bang1
 (一 言 为 定)	yi4yan2wei2ding4
-(㊀ 言 为 定)	yi4yan2wei2ding4
 (一 言 兴 邦)	yi4yan2xing1bang1
-(㊀ 言 兴 邦)	yi4yan2xing1bang1
 (一 言 喪 邦)	yi4yan2sang1bang1
-(㊀ 言 喪 邦)	yi4yan2sang1bang1
 (一 言 為 定)	yi4yan2wei2ding4
-(㊀ 言 為 定)	yi4yan2wei2ding4
 (一 言 興 邦)	yi4yan2xing1bang1
-(㊀ 言 興 邦)	yi4yan2xing1bang1
 (一 言 難 盡)	yi4yan2nan2jin4
-(㊀ 言 難 盡)	yi4yan2nan2jin4
 (一 言 難 盡)	yi4yan2nan2jin4
-(㊀ 言 難 盡)	yi4yan2nan2jin4
 (一 言 難 盡)	yi4yan2nan2jin4
-(㊀ 言 難 盡)	yi4yan2nan2jin4
 (一 記 耳 光)	yi2ji4er3guang1
-(㊀ 記 耳 光)	yi2ji4er3guang1
 (一 詞 多 義)	yi4ci2duo1yi4
-(㊀ 詞 多 義)	yi4ci2duo1yi4
 (一 詞 多 類)	yi4ci2duo1lei4
-(㊀ 詞 多 類)	yi4ci2duo1lei4
 (一 詞 多 類)	yi4ci2duo1lei4
-(㊀ 詞 多 類)	yi4ci2duo1lei4
 (一 試 身 手)	yi2shi4shen1shou3
-(㊀ 試 身 手)	yi2shi4shen1shou3
 (一 語 破 的)	yi4yu3po4di4
-(㊀ 語 破 的)	yi4yu3po4di4
 (一 誤 再 誤)	yi2wu4zai4wu4
-(㊀ 誤 再 誤)	yi2wu4zai4wu4
 (一 誤 而 誤)	yi2wu4er2wu4
-(㊀ 誤 而 誤)	yi2wu4er2wu4
 (一 諾 千 金)	yi2nuo4qian1jin1
-(一 諾 千 ㊎)	yi2nuo4qian1jin1
-(㊀ 諾 千 金)	yi2nuo4qian1jin1
 (一 諾 千 金)	yi2nuo4qian1jin1
-(㊀ 諾 千 金)	yi2nuo4qian1jin1
 (一 諾 千 金)	yi2nuo4qian1jin1
-(一 諾 千 ㊎)	yi2nuo4qian1jin1
-(㊀ 諾 千 金)	yi2nuo4qian1jin1
 (一 諾 千 金)	yi2nuo4qian1jin1
-(一 諾 千 ㊎)	yi2nuo4qian1jin1
-(㊀ 諾 千 金)	yi2nuo4qian1jin1
 (一 记 耳 光)	yi2ji4er3guang1
-(㊀ 记 耳 光)	yi2ji4er3guang1
 (一 词 多 义)	yi4ci2duo1yi4
-(㊀ 词 多 义)	yi4ci2duo1yi4
 (一 词 多 类)	yi4ci2duo1lei4
-(㊀ 词 多 类)	yi4ci2duo1lei4
 (一 词 多 类)	yi4ci2duo1lei4
-(㊀ 词 多 类)	yi4ci2duo1lei4
 (一 试 身 手)	yi2shi4shen1shou3
-(㊀ 试 身 手)	yi2shi4shen1shou3
 (一 语 破 的)	yi4yu3po4di4
-(㊀ 语 破 的)	yi4yu3po4di4
 (一 误 再 误)	yi2wu4zai4wu4
-(㊀ 误 再 误)	yi2wu4zai4wu4
 (一 误 而 误)	yi2wu4er2wu4
-(㊀ 误 而 误)	yi2wu4er2wu4
 (一 诺 千 金)	yi2nuo4qian1jin1
-(一 诺 千 ㊎)	yi2nuo4qian1jin1
-(㊀ 诺 千 金)	yi2nuo4qian1jin1
 (一 诺 千 金)	yi2nuo4qian1jin1
-(㊀ 诺 千 金)	yi2nuo4qian1jin1
 (一 貧 如 洗)	yi4pin2ru2xi3
-(㊀ 貧 如 洗)	yi4pin2ru2xi3
 (一 败 如 水)	yi2bai4ru2shui3
-(一 败 如 ㊌)	yi2bai4ru2shui3
-(㊀ 败 如 水)	yi2bai4ru2shui3
 (一 败 涂 地)	yi2bai4tu2di4
-(㊀ 败 涂 地)	yi2bai4tu2di4
 (一 贫 如 洗)	yi4pin2ru2xi3
-(㊀ 贫 如 洗)	yi4pin2ru2xi3
 (一 走 了 之)	yi4zou3liao3zhi1
-(㊀ 走 了 之)	yi4zou3liao3zhi1
 (一 走 了 之)	yi4zou3liao3zhi1
-(㊀ 走 了 之)	yi4zou3liao3zhi1
 (一 起 一 伏)	yi4qi3yi4fu2
-(㊀ 起 ㊀ 伏)	yi4qi3yi4fu2
 (一 跃 而 下)	yi2yue4er2xia4
-(一 跃 而 ㊦)	yi2yue4er2xia4
-(㊀ 跃 而 下)	yi2yue4er2xia4
 (一 跃 而 起)	yi2yue4er2qi3
-(㊀ 跃 而 起)	yi2yue4er2qi3
 (一 跃 而 过)	yi2yue4er2guo4
-(㊀ 跃 而 过)	yi2yue4er2guo4
 (一 跤 摔 倒)	yi4jiao1shuai1dao3
-(㊀ 跤 摔 倒)	yi4jiao1shuai1dao3
 (一 跨 而 过)	yi2kua4er2guo4
-(㊀ 跨 而 过)	yi2kua4er2guo4
 (一 跨 而 過)	yi2kua4er2guo4
-(㊀ 跨 而 過)	yi2kua4er2guo4
 (一 蹦 一 跳)	yi2beng4yi2tiao4
-(㊀ 蹦 ㊀ 跳)	yi2beng4yi2tiao4
 (一 蹦 三 跳)	yi2beng4san1tiao4
-(一 蹦 ㊂ 跳)	yi2beng4san1tiao4
-(㊀ 蹦 三 跳)	yi2beng4san1tiao4
 (一 蹴 而 几)	yi2cu4er2ji1
-(㊀ 蹴 而 几)	yi2cu4er2ji1
 (一 蹴 而 及)	yi2cu4er2ji2
-(㊀ 蹴 而 及)	yi2cu4er2ji2
 (一 蹴 而 就)	yi2cu4er2jiu4
-(㊀ 蹴 而 就)	yi2cu4er2jiu4
 (一 蹴 而 幾)	yi2cu4er2ji1
-(㊀ 蹴 而 幾)	yi2cu4er2ji1
 (一 蹶 不 振)	yi4jue2bu2zhen4
-(㊀ 蹶 不 振)	yi4jue2bu2zhen4
 (一 蹶 不 振)	yi4jue2bu2zhen4
-(㊀ 蹶 不 振)	yi4jue2bu2zhen4
 (一 躍 而 下)	yi2yue4er2xia4
-(一 躍 而 ㊦)	yi2yue4er2xia4
-(㊀ 躍 而 下)	yi2yue4er2xia4
 (一 躍 而 起)	yi2yue4er2qi3
-(㊀ 躍 而 起)	yi2yue4er2qi3
 (一 躍 而 過)	yi2yue4er2guo4
-(㊀ 躍 而 過)	yi2yue4er2guo4
 (一 身 囊 揣)	yi4shen1nang2chuai4
-(㊀ 身 囊 揣)	yi4shen1nang2chuai4
 (一 較 高 下)	yi4jiao3gao1xia4
-(一 較 高 ㊦)	yi4jiao3gao1xia4
-(㊀ 較 高 下)	yi4jiao3gao1xia4
 (一 较 高 下)	yi4jiao3gao1xia4
-(一 较 高 ㊦)	yi4jiao3gao1xia4
-(㊀ 较 高 下)	yi4jiao3gao1xia4
 (一 辞 莫 赞)	yi4ci2mo4zan4
-(㊀ 辞 莫 赞)	yi4ci2mo4zan4
 (一 辭 莫 贊)	yi4ci2mo4zan4
-(㊀ 辭 莫 贊)	yi4ci2mo4zan4
 (一 过 就 忘)	yi2guo4jiu4wang4
-(㊀ 过 就 忘)	yi2guo4jiu4wang4
 (一 还 一 报)	yi4huan2yi2bao4
-(㊀ 还 ㊀ 报)	yi4huan2yi2bao4
 (一 连 串 儿)	yi4lian2chuan4r5
-(㊀ 连 串 儿)	yi4lian2chuan4r5
 (一 连 串 儿)	yi4lian2chuan4r5
-(㊀ 连 串 儿)	yi4lian2chuan4r5
 (一 连 数 载)	yi4lian2shu4zai3
-(㊀ 连 数 载)	yi4lian2shu4zai3
 (一 连 气 儿)	yi4lian2qi4r5
-(㊀ 连 气 儿)	yi4lian2qi4r5
 (一 通 文 书)	yi4tong1wen2shu1
-(㊀ 通 文 书)	yi4tong1wen2shu1
 (一 通 文 書)	yi4tong1wen2shu1
-(㊀ 通 文 書)	yi4tong1wen2shu1
 (一 通 百 通)	yi4tong1bai3tong1
-(㊀ 通 百 通)	yi4tong1bai3tong1
 (一 連 數 載)	yi4lian2shu4zai3
-(㊀ 連 數 載)	yi4lian2shu4zai3
 (一 連 數 載)	yi4lian2shu4zai3
-(㊀ 連 數 載)	yi4lian2shu4zai3
 (一 連 數 載)	yi4lian2shu4zai3
-(㊀ 連 數 載)	yi4lian2shu4zai3
 (一 過 就 忘)	yi2guo4jiu4wang4
-(㊀ 過 就 忘)	yi2guo4jiu4wang4
 (一 還 一 報)	yi4huan2yi2bao4
-(㊀ 還 ㊀ 報)	yi4huan2yi2bao4
 (一 醉 方 休)	yi2zui4fang1xiu1
-(一 醉 方 ㊡)	yi2zui4fang1xiu1
-(㊀ 醉 方 休)	yi2zui4fang1xiu1
 (一 釘 釘 兒)	yi4ding1ding1r5
-(㊀ 釘 釘 兒)	yi4ding1ding1r5
 (一 針 一 線)	yi4zhen1yi2xian4
-(㊀ 針 ㊀ 線)	yi4zhen1yi2xian4
 (一 針 見 血)	yi4zhen1jian4xie3
-(㊀ 針 見 血)	yi4zhen1jian4xie3
 (一 針 見 血)	yi4zhen1jian4xie3
-(㊀ 針 見 血)	yi4zhen1jian4xie3
 (一 錐 之 地)	yi4zhui1zhi1di4
-(㊀ 錐 之 地)	yi4zhui1zhi1di4
 (一 錘 定 音)	yi4chui2ding4yin1
-(㊀ 錘 定 音)	yi4chui2ding4yin1
 (一 錢 不 值)	yi4qian2bu4zhi2
-(㊀ 錢 不 值)	yi4qian2bu4zhi2
 (一 錢 不 值)	yi4qian2bu4zhi2
-(㊀ 錢 不 值)	yi4qian2bu4zhi2
 (一 錢 如 命)	yi4qian2ru2ming4
-(㊀ 錢 如 命)	yi4qian2ru2ming4
 (一 錯 再 錯)	yi2cuo4zai4cuo4
-(㊀ 錯 再 錯)	yi2cuo4zai4cuo4
 (一 针 一 线)	yi4zhen1yi2xian4
-(㊀ 针 ㊀ 线)	yi4zhen1yi2xian4
 (一 针 见 血)	yi4zhen1jian4xie3
-(㊀ 针 见 血)	yi4zhen1jian4xie3
 (一 钉 钉 儿)	yi4ding1ding1r5
-(㊀ 钉 钉 儿)	yi4ding1ding1r5
 (一 钱 不 值)	yi4qian2bu4zhi2
-(㊀ 钱 不 值)	yi4qian2bu4zhi2
 (一 钱 不 值)	yi4qian2bu4zhi2
-(㊀ 钱 不 值)	yi4qian2bu4zhi2
 (一 钱 如 命)	yi4qian2ru2ming4
-(㊀ 钱 如 命)	yi4qian2ru2ming4
 (一 错 再 错)	yi2cuo4zai4cuo4
-(㊀ 错 再 错)	yi2cuo4zai4cuo4
 (一 锤 定 音)	yi4chui2ding4yin1
-(㊀ 锤 定 音)	yi4chui2ding4yin1
 (一 锥 之 地)	yi4zhui1zhi1di4
-(㊀ 锥 之 地)	yi4zhui1zhi1di4
 (一 長 兩 短)	yi4chang2liang3duan3
-(㊀ 長 兩 短)	yi4chang2liang3duan3
 (一 長 兩 短)	yi4chang2liang3duan3
-(㊀ 長 兩 短)	yi4chang2liang3duan3
 (一 长 两 短)	yi4chang2liang3duan3
-(㊀ 长 两 短)	yi4chang2liang3duan3
 (一 閃 一 閃)	yi4shan3yi4shan3
-(㊀ 閃 ㊀ 閃)	yi4shan3yi4shan3
 (一 閃 之 念)	yi4shan3zhi1nian4
-(㊀ 閃 之 念)	yi4shan3zhi1nian4
 (一 閃 之 念)	yi4shan3zhi1nian4
-(㊀ 閃 之 念)	yi4shan3zhi1nian4
 (一 閃 而 過)	yi4shan3er2guo4
-(㊀ 閃 而 過)	yi4shan3er2guo4
 (一 闪 一 闪)	yi4shan3yi4shan3
-(㊀ 闪 ㊀ 闪)	yi4shan3yi4shan3
 (一 闪 之 念)	yi4shan3zhi1nian4
-(㊀ 闪 之 念)	yi4shan3zhi1nian4
 (一 闪 之 念)	yi4shan3zhi1nian4
-(㊀ 闪 之 念)	yi4shan3zhi1nian4
 (一 闪 而 过)	yi4shan3er2guo4
-(㊀ 闪 而 过)	yi4shan3er2guo4
 (一 问 一 答)	yi2wen4yi4da2
-(㊀ 问 ㊀ 答)	yi2wen4yi4da2
 (一 隅 之 地)	yi4yu2zhi1di4
-(㊀ 隅 之 地)	yi4yu2zhi1di4
 (一 雄 多 雌)	yi4xiong2duo1ci2
-(㊀ 雄 多 雌)	yi4xiong2duo1ci2
 (一 雅 一 俗)	yi4ya3yi4su2
-(㊀ 雅 ㊀ 俗)	yi4ya3yi4su2
 (一 雌 多 雄)	yi4ci2duo1xiong2
-(㊀ 雌 多 雄)	yi4ci2duo1xiong2
 (一 雨 成 災)	yi4yu3cheng2zai1
-(㊀ 雨 成 災)	yi4yu3cheng2zai1
 (一 雨 成 灾)	yi4yu3cheng2zai1
-(㊀ 雨 成 灾)	yi4yu3cheng2zai1
 (一 雨 成 秋)	yi4yu3cheng2qiu1
-(㊀ 雨 成 秋)	yi4yu3cheng2qiu1
 (一 靈 真 性)	yi4ling2zhen1xing4
-(㊀ 靈 真 性)	yi4ling2zhen1xing4
 (一 靈 真 性)	yi4ling2zhen1xing4
-(㊀ 靈 真 性)	yi4ling2zhen1xing4
 (一 韁 四 馬)	yi4jiang1si4ma3
-(一 韁 ㊃ 馬)	yi4jiang1si4ma3
-(㊀ 韁 四 馬)	yi4jiang1si4ma3
 (一 頁 信 箋)	yi2ye4xin4jian1
-(㊀ 頁 信 箋)	yi2ye4xin4jian1
 (一 顯 身 手)	yi4xian3shen1shou3
-(㊀ 顯 身 手)	yi4xian3shen1shou3
 (一 顰 一 笑)	yi4pin2yi2xiao4
-(㊀ 顰 ㊀ 笑)	yi4pin2yi2xiao4
 (一 页 信 笺)	yi2ye4xin4jian1
-(㊀ 页 信 笺)	yi2ye4xin4jian1
 (一 颦 一 笑)	yi4pin2yi2xiao4
-(㊀ 颦 ㊀ 笑)	yi4pin2yi2xiao4
 (一 飛 沖 天)	yi4fei1chong1tian1
-(㊀ 飛 沖 天)	yi4fei1chong1tian1
 (一 飞 冲 天)	yi4fei1chong1tian1
-(㊀ 飞 冲 天)	yi4fei1chong1tian1
 (一 飯 之 恩)	yi2fan4zhi1en1
-(㊀ 飯 之 恩)	yi2fan4zhi1en1
 (一 飯 之 恩)	yi2fan4zhi1en1
-(㊀ 飯 之 恩)	yi2fan4zhi1en1
 (一 飯 千 金)	yi2fan4qian1jin1
-(一 飯 千 ㊎)	yi2fan4qian1jin1
-(㊀ 飯 千 金)	yi2fan4qian1jin1
 (一 飯 千 金)	yi2fan4qian1jin1
-(一 飯 千 ㊎)	yi2fan4qian1jin1
-(㊀ 飯 千 金)	yi2fan4qian1jin1
 (一 飯 千 金)	yi2fan4qian1jin1
-(㊀ 飯 千 金)	yi2fan4qian1jin1
 (一 飲 一 啄)	yi4yin3yi4zhuo2
-(㊀ 飲 ㊀ 啄)	yi4yin3yi4zhuo2
 (一 飲 而 盡)	yi4yin3er2jin4
-(㊀ 飲 而 盡)	yi4yin3er2jin4
 (一 飽 眼 福)	yi4bao3yan3fu2
-(㊀ 飽 眼 福)	yi4bao3yan3fu2
 (一 飽 眼 福)	yi4bao3yan3fu2
-(㊀ 飽 眼 福)	yi4bao3yan3fu2
 (一 饋 十 起)	yi2kui4shi2qi3
-(一 饋 ㊉ 起)	yi2kui4shi2qi3
-(㊀ 饋 十 起)	yi2kui4shi2qi3
 (一 饭 之 恩)	yi2fan4zhi1en1
-(㊀ 饭 之 恩)	yi2fan4zhi1en1
 (一 饭 千 金)	yi2fan4qian1jin1
-(一 饭 千 ㊎)	yi2fan4qian1jin1
-(㊀ 饭 千 金)	yi2fan4qian1jin1
 (一 饭 千 金)	yi2fan4qian1jin1
-(㊀ 饭 千 金)	yi2fan4qian1jin1
 (一 饮 一 啄)	yi4yin3yi4zhuo2
-(㊀ 饮 ㊀ 啄)	yi4yin3yi4zhuo2
 (一 饮 而 尽)	yi4yin3er2jin4
-(㊀ 饮 而 尽)	yi4yin3er2jin4
 (一 饱 眼 福)	yi4bao3yan3fu2
-(㊀ 饱 眼 福)	yi4bao3yan3fu2
 (一 饱 眼 福)	yi4bao3yan3fu2
-(㊀ 饱 眼 福)	yi4bao3yan3fu2
 (一 馈 十 起)	yi2kui4shi2qi3
-(一 馈 ㊉ 起)	yi2kui4shi2qi3
-(㊀ 馈 十 起)	yi2kui4shi2qi3
 (一 馬 平 川)	yi4ma3ping2chuan1
-(㊀ 馬 平 川)	yi4ma3ping2chuan1
 (一 馬 當 先)	yi4ma3dang1xian1
-(㊀ 馬 當 先)	yi4ma3dang1xian1
 (一 马 平 川)	yi4ma3ping2chuan1
-(㊀ 马 平 川)	yi4ma3ping2chuan1
 (一 马 当 先)	yi4ma3dang1xian1
-(㊀ 马 当 先)	yi4ma3dang1xian1
 (一 髮 千 鈞)	yi2fa4qian1jun1
-(㊀ 髮 千 鈞)	yi2fa4qian1jun1
 (一 鬍 捋 兒)	yi4hu2luo1r5
-(㊀ 鬍 捋 兒)	yi4hu2luo1r5
 (一 鱗 半 爪)	yi4lin2ban4zhao3
-(㊀ 鱗 半 爪)	yi4lin2ban4zhao3
 (一 鱗 半 爪)	yi4lin2ban4zhao3
-(㊀ 鱗 半 爪)	yi4lin2ban4zhao3
 (一 鳞 半 爪)	yi4lin2ban4zhao3
-(㊀ 鳞 半 爪)	yi4lin2ban4zhao3
 (一 鳴 驚 人)	yi4ming2jing1ren2
-(㊀ 鳴 驚 人)	yi4ming2jing1ren2
 (一 鸣 惊 人)	yi4ming2jing1ren2
-(㊀ 鸣 惊 人)	yi4ming2jing1ren2
 (一 點 一 滴)	yi4dian3yi4di1
-(㊀ 點 ㊀ 滴)	yi4dian3yi4di1
 (一 鼓 作 气)	yi4gu3zuo4qi4
-(㊀ 鼓 作 气)	yi4gu3zuo4qi4
 (一 鼓 作 氣)	yi4gu3zuo4qi4
-(㊀ 鼓 作 氣)	yi4gu3zuo4qi4
 (一 鼓 可 得)	yi4gu3ke3de2
-(㊀ 鼓 可 得)	yi4gu3ke3de2
 (一 鼓 而 下)	yi4gu3er2xia4
-(一 鼓 而 ㊦)	yi4gu3er2xia4
-(㊀ 鼓 而 下)	yi4gu3er2xia4
 (一 鼓 而 歼)	yi4gu3er2jian1
-(㊀ 鼓 而 歼)	yi4gu3er2jian1
 (一 鼓 而 殲)	yi4gu3er2jian1
-(㊀ 鼓 而 殲)	yi4gu3er2jian1
 (一 鼓 聚 歼)	yi4gu3ju4jian1
-(㊀ 鼓 聚 歼)	yi4gu3ju4jian1
 (一 鼓 聚 殲)	yi4gu3ju4jian1
-(㊀ 鼓 聚 殲)	yi4gu3ju4jian1
 (一 鼻 子 灰)	yi4bi2zi5hui1
-(㊀ 鼻 子 灰)	yi4bi2zi5hui1
 (一 龍 一 蛇)	yi4long2yi4she2
-(㊀ 龍 ㊀ 蛇)	yi4long2yi4she2
 (一 龍 一 蛇)	yi4long2yi4she2
-(㊀ 龍 ㊀ 蛇)	yi4long2yi4she2
 (一 龍 一 豬)	yi4long2yi4zhu1
-(㊀ 龍 ㊀ 豬)	yi4long2yi4zhu1
 (一 龍 一 豬)	yi4long2yi4zhu1
-(㊀ 龍 ㊀ 豬)	yi4long2yi4zhu1
 (一 龍 九 種)	yi4long2jiu3zhong3
-(一 龍 ㊈ 種)	yi4long2jiu3zhong3
-(㊀ 龍 九 種)	yi4long2jiu3zhong3
 (一 龍 九 種)	yi4long2jiu3zhong3
-(一 龍 ㊈ 種)	yi4long2jiu3zhong3
-(㊀ 龍 九 種)	yi4long2jiu3zhong3
 (一 龙 一 猪)	yi4long2yi4zhu1
-(㊀ 龙 ㊀ 猪)	yi4long2yi4zhu1
 (一 龙 一 猪)	yi4long2yi4zhu1
-(㊀ 龙 ㊀ 猪)	yi4long2yi4zhu1
 (一 龙 一 猪)	yi4long2yi4zhu1
-(㊀ 龙 ㊀ 猪)	yi4long2yi4zhu1
 (一 龙 一 蛇)	yi4long2yi4she2
-(㊀ 龙 ㊀ 蛇)	yi4long2yi4she2
 (一 龙 九 种)	yi4long2jiu3zhong3
-(一 龙 ㊈ 种)	yi4long2jiu3zhong3
-(㊀ 龙 九 种)	yi4long2jiu3zhong3
 (丁 一 卯 二)	ding1yi4mao3er4
-(丁 ㊀ 卯 二)	ding1yi4mao3er4
-(丁 一 卯 ㊁)	ding1yi4mao3er4
 (丁 一 确 二)	ding1yi2que4er4
-(丁 ㊀ 确 二)	ding1yi2que4er4
-(丁 一 确 ㊁)	ding1yi2que4er4
 (丁 一 確 二)	ding1yi2que4er4
-(丁 ㊀ 確 二)	ding1yi2que4er4
-(丁 一 確 ㊁)	ding1yi2que4er4
 (丁 零 当 啷)	ding1ling5dang1lang1
 (丁 零 当 啷)	ding1ling5dang1lang1
 (丁 零 當 啷)	ding1ling5dang1lang1
 (丁 零 當 啷)	ding1ling5dang1lang1
 (万 无 一 失)	wan4wu2yi4shi1
-(万 无 ㊀ 失)	wan4wu2yi4shi1
 (三 个 代 表)	san1ge4dai4biao3
-(㊂ 个 代 表)	san1ge4dai4biao3
 (三 個 代 表)	san1ge4dai4biao3
-(㊂ 個 代 表)	san1ge4dai4biao3
 (三 号 木 杆)	san1hao4mu4gan1
-(三 号 ㊍ 杆)	san1hao4mu4gan1
-(㊂ 号 木 杆)	san1hao4mu4gan1
 (三 地 門 鄉)	san1di4men2xiang1
-(㊂ 地 門 鄉)	san1di4men2xiang1
 (三 地 门 乡)	san1di4men2xiang1
-(㊂ 地 门 乡)	san1di4men2xiang1
 (三 號 木 桿)	san1hao4mu4gan1
-(三 號 ㊍ 桿)	san1hao4mu4gan1
-(㊂ 號 木 桿)	san1hao4mu4gan1
 (下 面 請 看)	xia4mian4qing3kan4
-(㊦ 面 請 看)	xia4mian4qing3kan4
 (下 面 請 看)	xia4mian4qing3kan4
-(㊦ 面 請 看)	xia4mian4qing3kan4
 (下 面 请 看)	xia4mian4qing3kan4
-(㊦ 面 请 看)	xia4mian4qing3kan4
 (不 一 会 儿)	bu4yi4hui3r5
-(不 ㊀ 会 儿)	bu4yi4hui3r5
 (不 一 会 儿)	bu4yi4hui3r5
-(不 ㊀ 会 儿)	bu4yi4hui3r5
 (不 一 會 兒)	bu4yi4hui3r5
-(不 ㊀ 會 兒)	bu4yi4hui3r5
 (不 一 會 兒)	bu4yi4hui3r5
-(不 ㊀ 會 兒)	bu4yi4hui3r5
 (不 一 而 足)	bu4yi4er2zu2
-(不 ㊀ 而 足)	bu4yi4er2zu2
 (不 一 而 足)	bu4yi4er2zu2
-(不 ㊀ 而 足)	bu4yi4er2zu2
 (不 上 一 頁)	bu2shang4yi2ye4
-(不 ㊤ 一 頁)	bu2shang4yi2ye4
-(不 上 ㊀ 頁)	bu2shang4yi2ye4
 (不 上 一 頁)	bu2shang4yi2ye4
-(不 ㊤ 一 頁)	bu2shang4yi2ye4
-(不 上 ㊀ 頁)	bu2shang4yi2ye4
 (不 上 一 页)	bu2shang4yi2ye4
-(不 ㊤ 一 页)	bu2shang4yi2ye4
-(不 上 ㊀ 页)	bu2shang4yi2ye4
 (不 上 一 页)	bu2shang4yi2ye4
-(不 ㊤ 一 页)	bu2shang4yi2ye4
-(不 上 ㊀ 页)	bu2shang4yi2ye4
 (不 上 个 月)	bu2shang4ge5yue4
-(不 ㊤ 个 月)	bu2shang4ge5yue4
-(不 上 个 ㊊)	bu2shang4ge5yue4
 (不 上 个 月)	bu2shang4ge5yue4
-(不 ㊤ 个 月)	bu2shang4ge5yue4
-(不 上 个 ㊊)	bu2shang4ge5yue4
 (不 上 個 月)	bu2shang4ge5yue4
-(不 ㊤ 個 月)	bu2shang4ge5yue4
-(不 上 個 ㊊)	bu2shang4ge5yue4
 (不 上 個 月)	bu2shang4ge5yue4
-(不 ㊤ 個 月)	bu2shang4ge5yue4
-(不 上 個 ㊊)	bu2shang4ge5yue4
 (不 上 边 儿)	bu2shang4bian5r5
-(不 ㊤ 边 儿)	bu2shang4bian5r5
 (不 上 边 儿)	bu2shang4bian5r5
-(不 ㊤ 边 儿)	bu2shang4bian5r5
 (不 下 一 頁)	bu2xia4yi2ye4
-(不 ㊦ 一 頁)	bu2xia4yi2ye4
-(不 下 ㊀ 頁)	bu2xia4yi2ye4
 (不 下 一 頁)	bu2xia4yi2ye4
-(不 ㊦ 一 頁)	bu2xia4yi2ye4
-(不 下 ㊀ 頁)	bu2xia4yi2ye4
 (不 下 一 页)	bu2xia4yi2ye4
-(不 ㊦ 一 页)	bu2xia4yi2ye4
-(不 下 ㊀ 页)	bu2xia4yi2ye4
 (不 下 一 页)	bu2xia4yi2ye4
-(不 ㊦ 一 页)	bu2xia4yi2ye4
-(不 下 ㊀ 页)	bu2xia4yi2ye4
 (不 下 边 儿)	bu2xia4bian5r5
-(不 ㊦ 边 儿)	bu2xia4bian5r5
 (不 下 边 儿)	bu2xia4bian5r5
-(不 ㊦ 边 儿)	bu2xia4bian5r5
 (不 丧 气 话)	bu2sang4qi4hua4
 (不 丧 气 话)	bu2sang4qi4hua4
 (不 丧 气 鬼)	bu2sang4qi4gui3
 (不 丧 气 鬼)	bu2sang4qi4gui3
 (不 中 圈 套)	bu2zhong4quan1tao4
-(不 🀄 圈 套)	bu2zhong4quan1tao4
-(不 ㊥ 圈 套)	bu2zhong4quan1tao4
 (不 中 圈 套)	bu2zhong4quan1tao4
-(不 🀄 圈 套)	bu2zhong4quan1tao4
-(不 ㊥ 圈 套)	bu2zhong4quan1tao4
 (不 为 人 知)	bu4wei2ren2zhi1
 (不 为 人 知)	bu4wei2ren2zhi1
 (不 为 已 甚)	bu4wei2yi3shen4
 (不 为 已 甚)	bu4wei2yi3shen4
 (不 乐 学 者)	bu2yue4xue2zhe3
-(不 乐 ㊫ 者)	bu2yue4xue2zhe3
 (不 乐 学 者)	bu2yue4xue2zhe3
-(不 乐 ㊫ 者)	bu2yue4xue2zhe3
 (不 乐 学 者)	bu2yue4xue2zhe3
-(不 乐 ㊫ 者)	bu2yue4xue2zhe3
 (不 乐 学 者)	bu2yue4xue2zhe3
-(不 乐 ㊫ 者)	bu2yue4xue2zhe3
 (不 乱 蓬 蓬)	bu2luan4peng1peng1
 (不 乱 蓬 蓬)	bu2luan4peng1peng1
 (不 乾 不 凈)	bu4gan1bu2jing4
@@ -76042,13 +70884,9 @@ $textmode
 (不 了 了 之)	bu4liao3liao3zhi1
 (不 了 了 之)	bu4liao3liao3zhi1
 (不 二 噁 英)	bu2er4e4ying1
-(不 ㊁ 噁 英)	bu2er4e4ying1
 (不 二 噁 英)	bu2er4e4ying1
-(不 ㊁ 噁 英)	bu2er4e4ying1
 (不 二 把 手)	bu2er4ba3shou3
-(不 ㊁ 把 手)	bu2er4ba3shou3
 (不 二 把 手)	bu2er4ba3shou3
-(不 ㊁ 把 手)	bu2er4ba3shou3
 (不 互 操 性)	bu2hu4cao4xing5
 (不 互 操 性)	bu2hu4cao4xing5
 (不 亦 乐 乎)	bu2yi4le4hu1
@@ -76070,49 +70908,27 @@ $textmode
 (不 借 字 儿)	bu2jie4zi4r5
 (不 借 字 儿)	bu2jie4zi4r5
 (不 值 一 提)	bu4zhi2yi4ti2
-(不 值 ㊀ 提)	bu4zhi2yi4ti2
 (不 值 一 提)	bu4zhi2yi4ti2
-(不 值 ㊀ 提)	bu4zhi2yi4ti2
 (不 值 一 文)	bu4zhi2yi4wen2
-(不 值 ㊀ 文)	bu4zhi2yi4wen2
 (不 值 一 文)	bu4zhi2yi4wen2
-(不 值 ㊀ 文)	bu4zhi2yi4wen2
 (不 值 一 笑)	bu4zhi2yi2xiao4
-(不 值 ㊀ 笑)	bu4zhi2yi2xiao4
 (不 值 一 笑)	bu4zhi2yi2xiao4
-(不 值 ㊀ 笑)	bu4zhi2yi2xiao4
 (不 值 一 談)	bu4zhi2yi4tan2
-(不 值 ㊀ 談)	bu4zhi2yi4tan2
 (不 值 一 談)	bu4zhi2yi4tan2
-(不 值 ㊀ 談)	bu4zhi2yi4tan2
 (不 值 一 谈)	bu4zhi2yi4tan2
-(不 值 ㊀ 谈)	bu4zhi2yi4tan2
 (不 值 一 谈)	bu4zhi2yi4tan2
-(不 值 ㊀ 谈)	bu4zhi2yi4tan2
 (不 值 一 錢)	bu4zhi2yi4qian2
-(不 值 ㊀ 錢)	bu4zhi2yi4qian2
 (不 值 一 錢)	bu4zhi2yi4qian2
-(不 值 ㊀ 錢)	bu4zhi2yi4qian2
 (不 值 一 钱)	bu4zhi2yi4qian2
-(不 值 ㊀ 钱)	bu4zhi2yi4qian2
 (不 值 一 钱)	bu4zhi2yi4qian2
-(不 值 ㊀ 钱)	bu4zhi2yi4qian2
 (不 值 一 顧)	bu4zhi2yi2gu4
-(不 值 ㊀ 顧)	bu4zhi2yi2gu4
 (不 值 一 顧)	bu4zhi2yi2gu4
-(不 值 ㊀ 顧)	bu4zhi2yi2gu4
 (不 值 一 顾)	bu4zhi2yi2gu4
-(不 值 ㊀ 顾)	bu4zhi2yi2gu4
 (不 值 一 顾)	bu4zhi2yi2gu4
-(不 值 ㊀ 顾)	bu4zhi2yi2gu4
 (不 值 一 駁)	bu4zhi2yi4bo2
-(不 值 ㊀ 駁)	bu4zhi2yi4bo2
 (不 值 一 駁)	bu4zhi2yi4bo2
-(不 值 ㊀ 駁)	bu4zhi2yi4bo2
 (不 值 一 驳)	bu4zhi2yi4bo2
-(不 值 ㊀ 驳)	bu4zhi2yi4bo2
 (不 值 一 驳)	bu4zhi2yi4bo2
-(不 值 ㊀ 驳)	bu4zhi2yi4bo2
 (不 做 不 到)	bu2zuo4bu5dao4
 (不 做 不 到)	bu2zuo4bu5dao4
 (不 做 买 卖)	bu2zuo4mai3mai5
@@ -76128,11 +70944,8 @@ $textmode
 (不 像 片 簿)	bu2xiang4pian4bu4
 (不 像 片 簿)	bu2xiang4pian4bu4
 (不 免 一 死)	bu4mian3yi4si3
-(不 免 ㊀ 死)	bu4mian3yi4si3
 (不 免 一 死)	bu4mian3yi4si3
-(不 免 ㊀ 死)	bu4mian3yi4si3
 (不 免 一 死)	bu4mian3yi4si3
-(不 免 ㊀ 死)	bu4mian3yi4si3
 (不 內 切 球)	bu2nei4qie1qiu2
 (不 內 切 球)	bu2nei4qie1qiu2
 (不 內 切 球)	bu2nei4qie1qiu2
@@ -76175,9 +70988,7 @@ $textmode
 (不 办 不 到)	bu2ban4bu5dao4
 (不 办 不 到)	bu2ban4bu5dao4
 (不 务 正 业)	bu2wu4zheng4ye4
-(不 务 ㊣ 业)	bu2wu4zheng4ye4
 (不 务 正 业)	bu2wu4zheng4ye4
-(不 务 ㊣ 业)	bu2wu4zheng4ye4
 (不 动 不 动)	bu2dong4bu5dong4
 (不 动 不 动)	bu2dong4bu5dong4
 (不 势 利 眼)	bu2shi4li5yan3
@@ -76186,9 +70997,7 @@ $textmode
 (不 動 不 動)	bu2dong4bu5dong4
 (不 動 不 動)	bu2dong4bu5dong4
 (不 務 正 業)	bu2wu4zheng4ye4
-(不 務 ㊣ 業)	bu2wu4zheng4ye4
 (不 務 正 業)	bu2wu4zheng4ye4
-(不 務 ㊣ 業)	bu2wu4zheng4ye4
 (不 勢 利 眼)	bu2shi4li5yan3
 (不 勢 利 眼)	bu2shi4li5yan3
 (不 勢 利 眼)	bu2shi4li5yan3
@@ -76201,9 +71010,7 @@ $textmode
 (不 卸 肩 儿)	bu2xie4jian1r5
 (不 卸 肩 儿)	bu2xie4jian1r5
 (不 历 史 上)	bu2li4shi3shang5
-(不 历 史 ㊤)	bu2li4shi3shang5
 (不 历 史 上)	bu2li4shi3shang5
-(不 历 史 ㊤)	bu2li4shi3shang5
 (不 受 不 了)	bu2shou4bu5liao3
 (不 受 不 了)	bu2shou4bu5liao3
 (不 受 不 了)	bu2shou4bu5liao3
@@ -76228,48 +71035,22 @@ $textmode
 (不 可 胜 数)	bu4ke3sheng4shu3
 (不 可 胜 数)	bu4ke3sheng4shu3
 (不 右 边 儿)	bu2you4bian5r5
-(不 ㊨ 边 儿)	bu2you4bian5r5
 (不 右 边 儿)	bu2you4bian5r5
-(不 ㊨ 边 儿)	bu2you4bian5r5
 (不 名 一 文)	bu4ming2yi4wen2
-(不 名 ㊀ 文)	bu4ming2yi4wen2
-(不 ㊔ 一 文)	bu4ming2yi4wen2
 (不 名 一 文)	bu4ming2yi4wen2
-(不 名 ㊀ 文)	bu4ming2yi4wen2
-(不 ㊔ 一 文)	bu4ming2yi4wen2
 (不 名 一 錢)	bu4ming2yi4qian2
-(不 名 ㊀ 錢)	bu4ming2yi4qian2
-(不 ㊔ 一 錢)	bu4ming2yi4qian2
 (不 名 一 錢)	bu4ming2yi4qian2
-(不 名 ㊀ 錢)	bu4ming2yi4qian2
-(不 ㊔ 一 錢)	bu4ming2yi4qian2
 (不 名 一 钱)	bu4ming2yi4qian2
-(不 名 ㊀ 钱)	bu4ming2yi4qian2
-(不 ㊔ 一 钱)	bu4ming2yi4qian2
 (不 名 一 钱)	bu4ming2yi4qian2
-(不 名 ㊀ 钱)	bu4ming2yi4qian2
-(不 ㊔ 一 钱)	bu4ming2yi4qian2
 (不 吐 苦 水)	bu2tu4ku3shui3
-(不 吐 苦 ㊌)	bu2tu4ku3shui3
 (不 吐 苦 水)	bu2tu4ku3shui3
-(不 吐 苦 ㊌)	bu2tu4ku3shui3
 (不 向 北 地)	bu2xiang4bei3di4
-(不 向 🀃 地)	bu2xiang4bei3di4
 (不 向 北 地)	bu2xiang4bei3di4
-(不 向 🀃 地)	bu2xiang4bei3di4
 (不 向 北 地)	bu2xiang4bei3di4
 (不 命 中 率)	bu2ming4zhong4lv4
-(不 命 🀄 率)	bu2ming4zhong4lv4
-(不 命 ㊥ 率)	bu2ming4zhong4lv4
 (不 命 中 率)	bu2ming4zhong4lv4
-(不 命 🀄 率)	bu2ming4zhong4lv4
-(不 命 ㊥ 率)	bu2ming4zhong4lv4
 (不 命 中 率)	bu2ming4zhong4lv4
-(不 命 🀄 率)	bu2ming4zhong4lv4
-(不 命 ㊥ 率)	bu2ming4zhong4lv4
 (不 命 中 率)	bu2ming4zhong4lv4
-(不 命 🀄 率)	bu2ming4zhong4lv4
-(不 命 ㊥ 率)	bu2ming4zhong4lv4
 (不 喝 倒 彩)	bu2he4dao4cai3
 (不 喝 倒 彩)	bu2he4dao4cai3
 (不 喝 倒 彩)	bu2he4dao4cai3
@@ -76280,13 +71061,9 @@ $textmode
 (不 喪 氣 鬼)	bu2sang4qi4gui3
 (不 喪 氣 鬼)	bu2sang4qi4gui3
 (不 四 部 曲)	bu2si4bu4qu3
-(不 ㊃ 部 曲)	bu2si4bu4qu3
 (不 四 部 曲)	bu2si4bu4qu3
-(不 ㊃ 部 曲)	bu2si4bu4qu3
 (不 在 下 面)	bu2zai4xia4mian4
-(不 在 ㊦ 面)	bu2zai4xia4mian4
 (不 在 下 面)	bu2zai4xia4mian4
-(不 在 ㊦ 面)	bu2zai4xia4mian4
 (不 地 平 線)	bu2di4ping2xian4
 (不 地 平 線)	bu2di4ping2xian4
 (不 地 平 线)	bu2di4ping2xian4
@@ -76316,28 +71093,19 @@ $textmode
 (不 墊 腳 石)	bu2dian4jiao3shi2
 (不 墊 腳 石)	bu2dian4jiao3shi2
 (不 墨 水 儿)	bu2mo4shui3r5
-(不 墨 ㊌ 儿)	bu2mo4shui3r5
 (不 墨 水 儿)	bu2mo4shui3r5
-(不 墨 ㊌ 儿)	bu2mo4shui3r5
 (不 墨 水 儿)	bu2mo4shui3r5
-(不 墨 ㊌ 儿)	bu2mo4shui3r5
 (不 夜 宵 儿)	bu2ye4xiao1r5
-(不 ㊰ 宵 儿)	bu2ye4xiao1r5
 (不 夜 宵 儿)	bu2ye4xiao1r5
-(不 ㊰ 宵 儿)	bu2ye4xiao1r5
 (不 大 不 了)	bu2da4bu5liao3
 (不 大 不 了)	bu2da4bu5liao3
 (不 大 不 了)	bu2da4bu5liao3
 (不 大 体 上)	bu2da4ti3shang5
-(不 大 体 ㊤)	bu2da4ti3shang5
 (不 大 体 上)	bu2da4ti3shang5
-(不 大 体 ㊤)	bu2da4ti3shang5
 (不 大 分 子)	bu2da4fen1zi3
 (不 大 分 子)	bu2da4fen1zi3
 (不 大 学 生)	bu2da4xue2sheng1
-(不 大 ㊫ 生)	bu2da4xue2sheng1
 (不 大 学 生)	bu2da4xue2sheng1
-(不 大 ㊫ 生)	bu2da4xue2sheng1
 (不 大 學 生)	bu2da4xue2sheng1
 (不 大 學 生)	bu2da4xue2sheng1
 (不 大 拇 指)	bu2da4mu5zhi3
@@ -76355,9 +71123,7 @@ $textmode
 (不 大 都 會)	bu2da4du1hui4
 (不 大 都 會)	bu2da4du1hui4
 (不 大 體 上)	bu2da4ti3shang5
-(不 大 體 ㊤)	bu2da4ti3shang5
 (不 大 體 上)	bu2da4ti3shang5
-(不 大 體 ㊤)	bu2da4ti3shang5
 (不 大 麥 地)	bu2da4mai4di4
 (不 大 麥 地)	bu2da4mai4di4
 (不 大 麦 地)	bu2da4mai4di4
@@ -76396,9 +71162,7 @@ $textmode
 (不 室 内 乐)	bu2shi4nei4yue4
 (不 室 内 乐)	bu2shi4nei4yue4
 (不 对 不 上)	bu2dui4bu5shang4
-(不 对 不 ㊤)	bu2dui4bu5shang4
 (不 对 不 上)	bu2dui4bu5shang4
-(不 对 不 ㊤)	bu2dui4bu5shang4
 (不 对 不 住)	bu2dui4bu5zhu4
 (不 对 不 住)	bu2dui4bu5zhu4
 (不 对 不 起)	bu2dui4bu5qi3
@@ -76419,9 +71183,7 @@ $textmode
 (不 对 茬 儿)	bu2dui4cha2r5
 (不 对 茬 儿)	bu2dui4cha2r5
 (不 對 不 上)	bu2dui4bu5shang4
-(不 對 不 ㊤)	bu2dui4bu5shang4
 (不 對 不 上)	bu2dui4bu5shang4
-(不 對 不 ㊤)	bu2dui4bu5shang4
 (不 對 不 住)	bu2dui4bu5zhu4
 (不 對 不 住)	bu2dui4bu5zhu4
 (不 對 不 起)	bu2dui4bu5qi3
@@ -76429,13 +71191,9 @@ $textmode
 (不 屁 眼 儿)	bu2pi4yan3r5
 (不 屁 眼 儿)	bu2pi4yan3r5
 (不 屑 一 顧)	bu2xie4yi2gu4
-(不 屑 ㊀ 顧)	bu2xie4yi2gu4
 (不 屑 一 顧)	bu2xie4yi2gu4
-(不 屑 ㊀ 顧)	bu2xie4yi2gu4
 (不 屑 一 顾)	bu2xie4yi2gu4
-(不 屑 ㊀ 顾)	bu2xie4yi2gu4
 (不 屑 一 顾)	bu2xie4yi2gu4
-(不 屑 ㊀ 顾)	bu2xie4yi2gu4
 (不 差 不 多)	bu2cha4bu5duo1
 (不 差 不 多)	bu2cha4bu5duo1
 (不 差 不 离)	bu2cha4bu5li2
@@ -76508,17 +71266,11 @@ $textmode
 (不 恶 势 力)	bu2e4shi4li4
 (不 恶 势 力)	bu2e4shi4li4
 (不 恶 名 儿)	bu2e4ming2r5
-(不 恶 ㊔ 儿)	bu2e4ming2r5
 (不 恶 名 儿)	bu2e4ming2r5
-(不 恶 ㊔ 儿)	bu2e4ming2r5
 (不 惜 一 战)	bu4xi1yi2zhan4
-(不 惜 ㊀ 战)	bu4xi1yi2zhan4
 (不 惜 一 战)	bu4xi1yi2zhan4
-(不 惜 ㊀ 战)	bu4xi1yi2zhan4
 (不 惜 一 戰)	bu4xi1yi2zhan4
-(不 惜 ㊀ 戰)	bu4xi1yi2zhan4
 (不 惜 一 戰)	bu4xi1yi2zhan4
-(不 惜 ㊀ 戰)	bu4xi1yi2zhan4
 (不 惡 勢 力)	bu2e4shi4li4
 (不 惡 勢 力)	bu2e4shi4li4
 (不 惡 勢 力)	bu2e4shi4li4
@@ -76546,9 +71298,7 @@ $textmode
 (不 担 担 面)	bu2dan4dan4mian4
 (不 担 担 面)	bu2dan4dan4mian4
 (不 拘 一 格)	bu4ju1yi4ge2
-(不 拘 ㊀ 格)	bu4ju1yi4ge2
 (不 拘 一 格)	bu4ju1yi4ge2
-(不 拘 ㊀ 格)	bu4ju1yi4ge2
 (不 拜 把 子)	bu2bai4ba3zi5
 (不 拜 把 子)	bu2bai4ba3zi5
 (不 括 弧 裡)	bu2kuo4hu2li3
@@ -76573,9 +71323,7 @@ $textmode
 (不 擔 擔 麵)	bu2dan4dan4mian4
 (不 擔 擔 麵)	bu2dan4dan4mian4
 (不 放 不 下)	bu2fang4bu5xia4
-(不 放 不 ㊦)	bu2fang4bu5xia4
 (不 放 不 下)	bu2fang4bu5xia4
-(不 放 不 ㊦)	bu2fang4bu5xia4
 (不 故 事 片)	bu2gu4shi5pian1
 (不 故 事 片)	bu2gu4shi5pian1
 (不 敗 之 地)	bu2bai4zhi1di4
@@ -76612,9 +71360,7 @@ $textmode
 (不 替 角 儿)	bu2ti4jue2r5
 (不 替 角 儿)	bu2ti4jue2r5
 (不 木 棉 花)	bu2mu4mian2hua1
-(不 ㊍ 棉 花)	bu2mu4mian2hua1
 (不 木 棉 花)	bu2mu4mian2hua1
-(不 ㊍ 棉 花)	bu2mu4mian2hua1
 (不 未 婚 夫)	bu2wei4hun1fu1
 (不 未 婚 夫)	bu2wei4hun1fu1
 (不 未 成 冠)	bu2wei4cheng2guan1
@@ -76634,21 +71380,14 @@ $textmode
 (不 歡 而 散)	bu4huan1er2san4
 (不 歡 而 散)	bu4huan1er2san4
 (不 歷 史 上)	bu2li4shi3shang5
-(不 歷 史 ㊤)	bu2li4shi3shang5
 (不 歷 史 上)	bu2li4shi3shang5
-(不 歷 史 ㊤)	bu2li4shi3shang5
 (不 歷 史 上)	bu2li4shi3shang5
-(不 歷 史 ㊤)	bu2li4shi3shang5
 (不 毛 之 地)	bu4mao2zhi1di4
 (不 毛 之 地)	bu4mao2zhi1di4
 (不 气 头 上)	bu2qi4tou2shang5
-(不 气 头 ㊤)	bu2qi4tou2shang5
 (不 气 头 上)	bu2qi4tou2shang5
-(不 气 头 ㊤)	bu2qi4tou2shang5
 (不 氣 頭 上)	bu2qi4tou2shang5
-(不 氣 頭 ㊤)	bu2qi4tou2shang5
 (不 氣 頭 上)	bu2qi4tou2shang5
-(不 氣 頭 ㊤)	bu2qi4tou2shang5
 (不 求 甚 解)	bu4qiu2shen4jie3
 (不 求 甚 解)	bu4qiu2shen4jie3
 (不 汇 出 行)	bu2hui4chu1hang2
@@ -76661,9 +71400,7 @@ $textmode
 (不 法 分 子)	bu4fa3fen4zi3
 (不 法 分 子)	bu4fa3fen4zi3
 (不 混 名 儿)	bu2hun4ming2r5
-(不 混 ㊔ 儿)	bu2hun4ming2r5
 (不 混 名 儿)	bu2hun4ming2r5
-(不 混 ㊔ 儿)	bu2hun4ming2r5
 (不 混 混 儿)	bu2hun4hun4r5
 (不 混 混 儿)	bu2hun4hun4r5
 (不 混 血 兒)	bu2hun4xue4er2
@@ -76693,13 +71430,9 @@ $textmode
 (不 父 母 親)	bu2fu4mu3qin1
 (不 父 母 親)	bu2fu4mu3qin1
 (不 特 別 是)	bu2te4bie2shi5
-(不 ㊕ 別 是)	bu2te4bie2shi5
 (不 特 別 是)	bu2te4bie2shi5
-(不 ㊕ 別 是)	bu2te4bie2shi5
 (不 特 别 是)	bu2te4bie2shi5
-(不 ㊕ 别 是)	bu2te4bie2shi5
 (不 特 别 是)	bu2te4bie2shi5
-(不 ㊕ 别 是)	bu2te4bie2shi5
 (不 犯 不 着)	bu2fan4bu5zhao2
 (不 犯 不 着)	bu2fan4bu5zhao2
 (不 犯 不 着)	bu2fan4bu5zhao2
@@ -76709,11 +71442,8 @@ $textmode
 (不 犯 不 著)	bu2fan4bu5zhao2
 (不 犯 不 著)	bu2fan4bu5zhao2
 (不 犯 得 上)	bu2fan4de5shang4
-(不 犯 得 ㊤)	bu2fan4de5shang4
 (不 犯 得 上)	bu2fan4de5shang4
-(不 犯 得 ㊤)	bu2fan4de5shang4
 (不 犯 得 上)	bu2fan4de5shang4
-(不 犯 得 ㊤)	bu2fan4de5shang4
 (不 犯 得 着)	bu2fan4de5zhao2
 (不 犯 得 着)	bu2fan4de5zhao2
 (不 犯 得 着)	bu2fan4de5zhao2
@@ -76792,15 +71522,9 @@ $textmode
 (不 省 人 事)	bu4xing3ren2shi4
 (不 省 人 事)	bu4xing3ren2shi4
 (不 看 上 去)	bu2kan4shang5qu5
-(不 看 ㊤ 去)	bu2kan4shang5qu5
 (不 看 上 去)	bu2kan4shang5qu5
-(不 看 ㊤ 去)	bu2kan4shang5qu5
 (不 看 不 中)	bu2kan4bu5zhong4
-(不 看 不 🀄)	bu2kan4bu5zhong4
-(不 看 不 ㊥)	bu2kan4bu5zhong4
 (不 看 不 中)	bu2kan4bu5zhong4
-(不 看 不 🀄)	bu2kan4bu5zhong4
-(不 看 不 ㊥)	bu2kan4bu5zhong4
 (不 看 不 出)	bu2kan4bu5chu1
 (不 看 不 出)	bu2kan4bu5chu1
 (不 看 不 惯)	bu2kan4bu5guan4
@@ -76819,11 +71543,7 @@ $textmode
 (不 看 不 起)	bu2kan4bu5qi3
 (不 看 不 起)	bu2kan4bu5qi3
 (不 看 得 中)	bu2kan4de5zhong4
-(不 看 得 🀄)	bu2kan4de5zhong4
-(不 看 得 ㊥)	bu2kan4de5zhong4
 (不 看 得 中)	bu2kan4de5zhong4
-(不 看 得 🀄)	bu2kan4de5zhong4
-(不 看 得 ㊥)	bu2kan4de5zhong4
 (不 看 起 來)	bu2kan4qi5lai5
 (不 看 起 來)	bu2kan4qi5lai5
 (不 看 起 來)	bu2kan4qi5lai5
@@ -76868,13 +71588,9 @@ $textmode
 (不 禁 制 令)	bu2jin4zhi4ling4
 (不 禁 制 令)	bu2jin4zhi4ling4
 (不 秘 书 长)	bu2mi4shu1zhang3
-(不 ㊙ 书 长)	bu2mi4shu1zhang3
 (不 秘 书 长)	bu2mi4shu1zhang3
-(不 ㊙ 书 长)	bu2mi4shu1zhang3
 (不 秘 書 長)	bu2mi4shu1zhang3
-(不 ㊙ 書 長)	bu2mi4shu1zhang3
 (不 秘 書 長)	bu2mi4shu1zhang3
-(不 ㊙ 書 長)	bu2mi4shu1zhang3
 (不 窍 门 儿)	bu2qiao4men2r5
 (不 窍 门 儿)	bu2qiao4men2r5
 (不 笑 脸 儿)	bu2xiao4lian3r5
@@ -76895,13 +71611,9 @@ $textmode
 (不 绿 油 油)	bu2lv4you1you1
 (不 绿 油 油)	bu2lv4you1you1
 (不 置 一 詞)	bu2zhi4yi4ci2
-(不 置 ㊀ 詞)	bu2zhi4yi4ci2
 (不 置 一 詞)	bu2zhi4yi4ci2
-(不 置 ㊀ 詞)	bu2zhi4yi4ci2
 (不 置 一 词)	bu2zhi4yi4ci2
-(不 置 ㊀ 词)	bu2zhi4yi4ci2
 (不 置 一 词)	bu2zhi4yi4ci2
-(不 置 ㊀ 词)	bu2zhi4yi4ci2
 (不 聚 居 地)	bu2ju4ju1di4
 (不 聚 居 地)	bu2ju4ju1di4
 (不 背 地 風)	bu2bei4di4feng1
@@ -76943,9 +71655,7 @@ $textmode
 (不 芥 子 氣)	bu2jie4zi3qi4
 (不 芥 子 氣)	bu2jie4zi3qi4
 (不 药 水 儿)	bu2yao4shui3r5
-(不 药 ㊌ 儿)	bu2yao4shui3r5
 (不 药 水 儿)	bu2yao4shui3r5
-(不 药 ㊌ 儿)	bu2yao4shui3r5
 (不 荳 角 儿)	bu2dou4jiao3r5
 (不 荳 角 儿)	bu2dou4jiao3r5
 (不 菟 丝 子)	bu2tu4si1zi3
@@ -77014,19 +71724,14 @@ $textmode
 (不 記 不 住)	bu2ji4bu5zhu4
 (不 記 不 住)	bu2ji4bu5zhu4
 (不 試 一 試)	bu2shi4yi2shi4
-(不 試 ㊀ 試)	bu2shi4yi2shi4
 (不 試 一 試)	bu2shi4yi2shi4
-(不 試 ㊀ 試)	bu2shi4yi2shi4
 (不 試 試 看)	bu2shi4shi5kan4
 (不 試 試 看)	bu2shi4shi5kan4
 (不 謀 而 得)	bu4mou2er2de2
 (不 謀 而 得)	bu4mou2er2de2
 (不 識 一 丁)	bu4shi2yi4ding1
-(不 識 ㊀ 丁)	bu4shi2yi4ding1
 (不 識 一 丁)	bu4shi2yi4ding1
-(不 識 ㊀ 丁)	bu4shi2yi4ding1
 (不 識 一 丁)	bu4shi2yi4ding1
-(不 識 ㊀ 丁)	bu4shi2yi4ding1
 (不 識 大 體)	bu4shi2da4ti3
 (不 識 大 體)	bu4shi2da4ti3
 (不 識 大 體)	bu4shi2da4ti3
@@ -77058,9 +71763,7 @@ $textmode
 (不 记 不 住)	bu2ji4bu5zhu4
 (不 记 不 住)	bu2ji4bu5zhu4
 (不 识 一 丁)	bu4shi2yi4ding1
-(不 识 ㊀ 丁)	bu4shi2yi4ding1
 (不 识 一 丁)	bu4shi2yi4ding1
-(不 识 ㊀ 丁)	bu4shi2yi4ding1
 (不 识 大 体)	bu4shi2da4ti3
 (不 识 大 体)	bu4shi2da4ti3
 (不 识 好 歹)	bu4shi2hao3dai3
@@ -77077,9 +71780,7 @@ $textmode
 (不 识 高 低)	bu4shi2gao1di1
 (不 识 高 低)	bu4shi2gao1di1
 (不 试 一 试)	bu2shi4yi2shi4
-(不 试 ㊀ 试)	bu2shi4yi2shi4
 (不 试 一 试)	bu2shi4yi2shi4
-(不 试 ㊀ 试)	bu2shi4yi2shi4
 (不 试 试 看)	bu2shi4shi5kan4
 (不 试 试 看)	bu2shi4shi5kan4
 (不 话 茬 儿)	bu2hua4cha2r5
@@ -77093,9 +71794,7 @@ $textmode
 (不 賦 格 曲)	bu2fu4ge2qu3
 (不 賦 格 曲)	bu2fu4ge2qu3
 (不 贊 一 詞)	bu2zan4yi4ci2
-(不 贊 ㊀ 詞)	bu2zan4yi4ci2
 (不 贊 一 詞)	bu2zan4yi4ci2
-(不 贊 ㊀ 詞)	bu2zan4yi4ci2
 (不 贝 壳 儿)	bu2bei4ke2r5
 (不 贝 壳 儿)	bu2bei4ke2r5
 (不 负 重 担)	bu2fu4zhong4dan1
@@ -77111,9 +71810,7 @@ $textmode
 (不 赋 格 曲)	bu2fu4ge2qu3
 (不 赋 格 曲)	bu2fu4ge2qu3
 (不 赞 一 词)	bu2zan4yi4ci2
-(不 赞 ㊀ 词)	bu2zan4yi4ci2
 (不 赞 一 词)	bu2zan4yi4ci2
-(不 赞 ㊀ 词)	bu2zan4yi4ci2
 (不 赤 睛 魚)	bu2chi4jing1yu2
 (不 赤 睛 魚)	bu2chi4jing1yu2
 (不 赤 睛 鱼)	bu2chi4jing1yu2
@@ -77127,27 +71824,18 @@ $textmode
 (不 足 為 訓)	bu4zu2wei2xun4
 (不 足 為 訓)	bu4zu2wei2xun4
 (不 跪 下 來)	bu2gui4xia4lai5
-(不 跪 ㊦ 來)	bu2gui4xia4lai5
 (不 跪 下 來)	bu2gui4xia4lai5
-(不 跪 ㊦ 來)	bu2gui4xia4lai5
 (不 跪 下 來)	bu2gui4xia4lai5
-(不 跪 ㊦ 來)	bu2gui4xia4lai5
 (不 跪 下 来)	bu2gui4xia4lai5
-(不 跪 ㊦ 来)	bu2gui4xia4lai5
 (不 跪 下 来)	bu2gui4xia4lai5
-(不 跪 ㊦ 来)	bu2gui4xia4lai5
 (不 蹦 高 儿)	bu2beng4gao1r5
 (不 蹦 高 儿)	bu2beng4gao1r5
 (不 轉 一 趟)	bu2zhuan4yi2tang4
-(不 轉 ㊀ 趟)	bu2zhuan4yi2tang4
 (不 轉 一 趟)	bu2zhuan4yi2tang4
-(不 轉 ㊀ 趟)	bu2zhuan4yi2tang4
 (不 轉 字 鎖)	bu2zhuan4zi4suo3
 (不 轉 字 鎖)	bu2zhuan4zi4suo3
 (不 转 一 趟)	bu2zhuan4yi2tang4
-(不 转 ㊀ 趟)	bu2zhuan4yi2tang4
 (不 转 一 趟)	bu2zhuan4yi2tang4
-(不 转 ㊀ 趟)	bu2zhuan4yi2tang4
 (不 转 字 锁)	bu2zhuan4zi4suo3
 (不 转 字 锁)	bu2zhuan4zi4suo3
 (不 转 轴 儿)	bu2zhuan4zhou2r5
@@ -77163,9 +71851,7 @@ $textmode
 (不 过 不 去)	bu2guo4bu5qu4
 (不 过 不 去)	bu2guo4bu5qu4
 (不 这 个 月)	bu2zhei4ge4yue4
-(不 这 个 ㊊)	bu2zhei4ge4yue4
 (不 这 个 月)	bu2zhei4ge4yue4
-(不 这 个 ㊊)	bu2zhei4ge4yue4
 (不 这 些 个)	bu2zhe4xie1ge5
 (不 这 些 个)	bu2zhe4xie1ge5
 (不 这 边 儿)	bu2zhe4bian1r5
@@ -77182,9 +71868,7 @@ $textmode
 (不 這 些 個)	bu2zhe4xie1ge5
 (不 這 些 個)	bu2zhe4xie1ge5
 (不 這 個 月)	bu2zhei4ge4yue4
-(不 這 個 ㊊)	bu2zhei4ge4yue4
 (不 這 個 月)	bu2zhei4ge4yue4
-(不 這 個 ㊊)	bu2zhei4ge4yue4
 (不 速 調 管)	bu2su4tiao2guan3
 (不 速 調 管)	bu2su4tiao2guan3
 (不 速 調 管)	bu2su4tiao2guan3
@@ -77200,9 +71884,7 @@ $textmode
 (不 那 個 人)	bu2na4ge4ren2
 (不 那 個 人)	bu2na4ge4ren2
 (不 配 得 上)	bu2pei4de5shang4
-(不 配 得 ㊤)	bu2pei4de5shang4
 (不 配 得 上)	bu2pei4de5shang4
-(不 配 得 ㊤)	bu2pei4de5shang4
 (不 釘 書 針)	bu2ding4shu1zhen1
 (不 釘 書 針)	bu2ding4shu1zhen1
 (不 錮 漏 鍋)	bu2gu4lou5guo1
@@ -77221,11 +71903,8 @@ $textmode
 (不 電 荷 量)	bu2dian4he2liang4
 (不 電 荷 量)	bu2dian4he2liang4
 (不 露 一 手)	bu2lou4yi4shou3
-(不 露 ㊀ 手)	bu2lou4yi4shou3
 (不 露 一 手)	bu2lou4yi4shou3
-(不 露 ㊀ 手)	bu2lou4yi4shou3
 (不 露 一 手)	bu2lou4yi4shou3
-(不 露 ㊀ 手)	bu2lou4yi4shou3
 (不 露 馅 儿)	bu2lou4xian4r5
 (不 露 馅 儿)	bu2lou4xian4r5
 (不 露 馅 儿)	bu2lou4xian4r5
@@ -77236,15 +71915,11 @@ $textmode
 (不 露 马 脚)	bu2lou4ma3jiao3
 (不 露 马 脚)	bu2lou4ma3jiao3
 (不 静 一 静)	bu2jing4yi2jing4
-(不 静 ㊀ 静)	bu2jing4yi2jing4
 (不 静 一 静)	bu2jing4yi2jing4
-(不 静 ㊀ 静)	bu2jing4yi2jing4
 (不 静 悄 悄)	bu2jing4qiao1qiao1
 (不 静 悄 悄)	bu2jing4qiao1qiao1
 (不 靜 一 靜)	bu2jing4yi2jing4
-(不 靜 ㊀ 靜)	bu2jing4yi2jing4
 (不 靜 一 靜)	bu2jing4yi2jing4
-(不 靜 ㊀ 靜)	bu2jing4yi2jing4
 (不 靜 悄 悄)	bu2jing4qiao1qiao1
 (不 靜 悄 悄)	bu2jing4qiao1qiao1
 (不 靠 不 住)	bu2kao4bu5zhu4
@@ -77265,105 +71940,50 @@ $textmode
 (不 鳳 仙 花)	bu2feng4xian1hua1
 (与 时 俱 进)	yu3shi2ju1jin4
 (专 心 一 志)	zhuan1xin1yi2zhi4
-(专 心 ㊀ 志)	zhuan1xin1yi2zhi4
 (且 得 不 了)	qie3de2bu5liao3
 (且 得 不 了)	qie3de2bu5liao3
 (且 得 不 了)	qie3de2bu5liao3
 (东 倒 西 歪)	dong1dao3xi1wai1
-(东 倒 🀂 歪)	dong1dao3xi1wai1
-(🀀 倒 西 歪)	dong1dao3xi1wai1
 (东 奔 西 走)	dong1ben1xi1zou3
-(东 奔 🀂 走)	dong1ben1xi1zou3
-(🀀 奔 西 走)	dong1ben1xi1zou3
 (东 奔 西 走)	dong1ben1xi1zou3
-(东 奔 🀂 走)	dong1ben1xi1zou3
-(🀀 奔 西 走)	dong1ben1xi1zou3
 (东 奔 西 跑)	dong1ben1xi1pao3
-(东 奔 🀂 跑)	dong1ben1xi1pao3
-(🀀 奔 西 跑)	dong1ben1xi1pao3
 (东 奔 西 跑)	dong1ben1xi1pao3
-(东 奔 🀂 跑)	dong1ben1xi1pao3
-(🀀 奔 西 跑)	dong1ben1xi1pao3
 (东 巴 文 化)	dong1ba1wen2hua4
-(🀀 巴 文 化)	dong1ba1wen2hua4
 (东 张 西 望)	dong1zhang1xi1wang4
-(东 张 🀂 望)	dong1zhang1xi1wang4
-(🀀 张 西 望)	dong1zhang1xi1wang4
 (东 张 西 望)	dong1zhang1xi1wang4
-(东 张 🀂 望)	dong1zhang1xi1wang4
-(🀀 张 西 望)	dong1zhang1xi1wang4
 (东 征 西 怨)	dong1zheng1xi1yuan4
-(东 征 🀂 怨)	dong1zheng1xi1yuan4
-(🀀 征 西 怨)	dong1zheng1xi1yuan4
 (东 征 西 讨)	dong1zheng1xi1tao3
-(东 征 🀂 讨)	dong1zheng1xi1tao3
-(🀀 征 西 讨)	dong1zheng1xi1tao3
 (东 拉 西 扯)	dong1la1xi1che3
-(东 拉 🀂 扯)	dong1la1xi1che3
-(🀀 拉 西 扯)	dong1la1xi1che3
 (东 拉 西 扯)	dong1la1xi1che3
-(东 拉 🀂 扯)	dong1la1xi1che3
-(🀀 拉 西 扯)	dong1la1xi1che3
 (丟 不 開 手)	diu1bu5kai1shou3
 (丟 不 開 手)	diu1bu5kai1shou3
 (丢 不 开 手)	diu1bu5kai1shou3
 (丢 不 开 手)	diu1bu5kai1shou3
 (两 个 中 国)	liang3ge4zhong1guo2
-(两 个 🀄 国)	liang3ge4zhong1guo2
-(两 个 ㊥ 国)	liang3ge4zhong1guo2
 (两 定 一 奖)	liang3ding4yi4jiang3
-(两 定 ㊀ 奖)	liang3ding4yi4jiang3
 (两 得 其 便)	liang3de2qi2bian4
 (两 得 其 便)	liang3de2qi2bian4
 (两 手 一 摊)	liang3shou3yi4tan1
-(两 手 ㊀ 摊)	liang3shou3yi4tan1
 (两 报 一 刊)	liang3bao4yi4kan1
-(两 报 ㊀ 刊)	liang3bao4yi4kan1
 (两 饱 一 倒)	liang3bao3yi4dao3
-(两 饱 ㊀ 倒)	liang3bao3yi4dao3
 (中 不 溜 儿)	zhong1bu5liu1r5
-(🀄 不 溜 儿)	zhong1bu5liu1r5
-(㊥ 不 溜 儿)	zhong1bu5liu1r5
 (中 不 溜 儿)	zhong1bu5liu1r5
-(🀄 不 溜 儿)	zhong1bu5liu1r5
-(㊥ 不 溜 儿)	zhong1bu5liu1r5
 (中 不 溜 儿)	zhong1bu5liu1r5
-(🀄 不 溜 儿)	zhong1bu5liu1r5
-(㊥ 不 溜 儿)	zhong1bu5liu1r5
 (中 俄 关 系)	zhong1e2guan1xi4
-(🀄 俄 关 系)	zhong1e2guan1xi4
-(㊥ 俄 关 系)	zhong1e2guan1xi4
 (中 俄 關 係)	zhong1e2guan1xi4
-(🀄 俄 關 係)	zhong1e2guan1xi4
-(㊥ 俄 關 係)	zhong1e2guan1xi4
 (中 坚 分 子)	zhong1jian1fen4zi3
-(🀄 坚 分 子)	zhong1jian1fen4zi3
-(㊥ 坚 分 子)	zhong1jian1fen4zi3
 (中 堅 分 子)	zhong1jian1fen4zi3
-(🀄 堅 分 子)	zhong1jian1fen4zi3
-(㊥ 堅 分 子)	zhong1jian1fen4zi3
 (中 山 狼 传)	zhong1shan1lang2zhuan4
-(🀄 山 狼 传)	zhong1shan1lang2zhuan4
-(㊥ 山 狼 传)	zhong1shan1lang2zhuan4
 (中 山 狼 传)	zhong1shan1lang2zhuan4
-(🀄 山 狼 传)	zhong1shan1lang2zhuan4
-(㊥ 山 狼 传)	zhong1shan1lang2zhuan4
 (中 山 狼 傳)	zhong1shan1lang2zhuan4
-(🀄 山 狼 傳)	zhong1shan1lang2zhuan4
-(㊥ 山 狼 傳)	zhong1shan1lang2zhuan4
 (中 山 狼 傳)	zhong1shan1lang2zhuan4
-(🀄 山 狼 傳)	zhong1shan1lang2zhuan4
-(㊥ 山 狼 傳)	zhong1shan1lang2zhuan4
 (串 亲 访 友)	chuan4qin1fang3you3
 (串 亲 访 友)	chuan4qin1fang3you3
 (串 親 訪 友)	chuan4qin1fang3you3
 (串 親 訪 友)	chuan4qin1fang3you3
 (临 门 一 脚)	lin2men2yi4jiao3
-(临 门 ㊀ 脚)	lin2men2yi4jiao3
 (为 之 一 振)	wei4zhi1yi2zhen4
-(为 之 ㊀ 振)	wei4zhi1yi2zhen4
 (为 之 一 新)	wei2zhi1yi4xin1
-(为 之 ㊀ 新)	wei2zhi1yi4xin1
 (为 仁 不 富)	wei2ren2bu2fu4
 (为 仁 不 富)	wei2ren2bu2fu4
 (为 富 不 仁)	wei2fu4bu4ren2
@@ -77376,94 +71996,57 @@ $textmode
 (为 非 作 歹)	wei2fei1zuo4dai3
 (为 非 作 歹)	wei2fei1zuo4dai3
 (丽 水 地 区)	li4shui3di4qu1
-(丽 ㊌ 地 区)	li4shui3di4qu1
 (举 一 废 百)	ju3yi2fei4bai3
-(举 ㊀ 废 百)	ju3yi2fei4bai3
 (举 一 赅 百)	ju3yi4gai1bai3
-(举 ㊀ 赅 百)	ju3yi4gai1bai3
 (之 乎 者 也)	zhi1hu1zhe3ye3
 (之 乎 者 也)	zhi1hu1zhe3ye3
 (之 乎 者 也)	zhi1hu1zhe3ye3
 (乌 兰 巴 托)	wu1lan2ba1tuo1
 (乍 眼 一 看)	zha4yan3yi2kan4
-(乍 眼 ㊀ 看)	zha4yan3yi2kan4
 (乐 善 好 施)	le4shan4hao4shi1
 (乞 免 一 死)	qi3mian3yi4si3
-(乞 免 ㊀ 死)	qi3mian3yi4si3
 (乞 免 一 死)	qi3mian3yi4si3
-(乞 免 ㊀ 死)	qi3mian3yi4si3
 (乞 浆 得 酒)	qi3jiang1de2jiu3
 (乞 漿 得 酒)	qi3jiang1de2jiu3
 (买 一 送 一)	mai3yi2song4yi1
-(买 ㊀ 送 ㊀)	mai3yi2song4yi1
 (乱 打 一 通)	luan4da3yi4tong1
-(乱 打 ㊀ 通)	luan4da3yi4tong1
 (乱 说 一 通)	luan4shuo1yi4tong1
-(乱 说 ㊀ 通)	luan4shuo1yi4tong1
 (乳 臭 未 乾)	ru3xiu4wei4gan1
 (乳 臭 未 乾)	ru3xiu4wei4gan1
 (乳 臭 未 干)	ru3xiu4wei4gan1
 (乳 臭 未 干)	ru3xiu4wei4gan1
 (乾 巴 得 慌)	gan1ba1de5huang1
 (亂 打 一 通)	luan4da3yi4tong1
-(亂 打 ㊀ 通)	luan4da3yi4tong1
 (亂 打 一 通)	luan4da3yi4tong1
-(亂 打 ㊀ 通)	luan4da3yi4tong1
 (亂 說 一 通)	luan4shuo1yi4tong1
-(亂 說 ㊀ 通)	luan4shuo1yi4tong1
 (亂 說 一 通)	luan4shuo1yi4tong1
-(亂 說 ㊀ 通)	luan4shuo1yi4tong1
 (亂 說 一 通)	luan4shuo1yi4tong1
-(亂 說 ㊀ 通)	luan4shuo1yi4tong1
 (亂 說 一 通)	luan4shuo1yi4tong1
-(亂 說 ㊀ 通)	luan4shuo1yi4tong1
 (了 如 指 掌)	liao3ru2zhi3zhang3
 (了 如 指 掌)	liao3ru2zhi3zhang3
 (了 此 一 生)	liao3ci3yi4sheng1
-(了 此 ㊀ 生)	liao3ci3yi4sheng1
 (了 此 一 生)	liao3ci3yi4sheng1
-(了 此 ㊀ 生)	liao3ci3yi4sheng1
 (事 危 累 卵)	shi4wei1lei3luan3
 (事 危 累 卵)	shi4wei1lei3luan3
 (事 危 累 卵)	shi4wei1lei3luan3
 (事 非 得 已)	shi4fei1de2yi3
 (二 十 一 条)	er4shi2yi1tiao2
-(二 ㊉ 一 条)	er4shi2yi1tiao2
-(二 十 ㊀ 条)	er4shi2yi1tiao2
-(㊁ 十 一 条)	er4shi2yi1tiao2
 (二 十 一 條)	er4shi2yi1tiao2
-(二 ㊉ 一 條)	er4shi2yi1tiao2
-(二 十 ㊀ 條)	er4shi2yi1tiao2
-(㊁ 十 一 條)	er4shi2yi1tiao2
 (二 十 八 宿)	er4shi2ba1xiu4
-(二 ㊉ 八 宿)	er4shi2ba1xiu4
-(㊁ 十 八 宿)	er4shi2ba1xiu4
-(二 十 ㊇ 宿)	er4shi2ba1xiu4
 (二 馬 一 虎)	er4ma3yi4hu3
-(二 馬 ㊀ 虎)	er4ma3yi4hu3
-(㊁ 馬 一 虎)	er4ma3yi4hu3
 (二 马 一 虎)	er4ma3yi4hu3
-(二 马 ㊀ 虎)	er4ma3yi4hu3
-(㊁ 马 一 虎)	er4ma3yi4hu3
 (互 为 因 果)	hu4wei2yin1guo3
 (互 為 因 果)	hu4wei2yin1guo3
 (五 体 投 地)	wu3ti3tou2di4
-(㊄ 体 投 地)	wu3ti3tou2di4
 (五 行 八 作)	wu3hang2ba1zuo4
-(五 行 ㊇ 作)	wu3hang2ba1zuo4
-(㊄ 行 八 作)	wu3hang2ba1zuo4
 (五 行 八 作)	wu3hang2ba1zuo4
-(五 行 ㊇ 作)	wu3hang2ba1zuo4
-(㊄ 行 八 作)	wu3hang2ba1zuo4
 (五 體 投 地)	wu3ti3tou2di4
-(㊄ 體 投 地)	wu3ti3tou2di4
 (亚 得 米 勒)	ya4de2mi3le4
 (亚 得 米 勒)	ya4de2mi3le4
 (亚 斯 那 巴)	ya4si1na4ba1
 (亚 略 巴 古)	ya4lve4ba1gu3
 (亚 略 巴 古)	ya4lve4ba1gu3
 (亚 达 薛 西)	ya4da2xue1xi1
-(亚 达 薛 🀂)	ya4da2xue1xi1
 (亚 隆 巴 古)	ya4long2ba1gu3
 (亚 隆 巴 古)	ya4long2ba1gu3
 (亞 得 米 勒)	ya4de2mi3le4
@@ -77472,7 +72055,6 @@ $textmode
 (亞 略 巴 古)	ya4lve4ba1gu3
 (亞 略 巴 古)	ya4lve4ba1gu3
 (亞 達 薛 西)	ya4da2xue1xi1
-(亞 達 薛 🀂)	ya4da2xue1xi1
 (亞 隆 巴 古)	ya4long2ba1gu3
 (亞 隆 巴 古)	ya4long2ba1gu3
 (亡 羊 得 牛)	wang2yang2de2niu2
@@ -77488,15 +72070,10 @@ $textmode
 (人 給 家 足)	ren2ji3jia1zu2
 (人 给 家 足)	ren2ji3jia1zu2
 (什 一 奉 献)	shi2yi2feng4xian4
-(什 ㊀ 奉 献)	shi2yi2feng4xian4
 (什 一 奉 献)	shi2yi2feng4xian4
-(什 ㊀ 奉 献)	shi2yi2feng4xian4
 (什 一 奉 獻)	shi2yi2feng4xian4
-(什 ㊀ 奉 獻)	shi2yi2feng4xian4
 (什 一 奉 獻)	shi2yi2feng4xian4
-(什 ㊀ 奉 獻)	shi2yi2feng4xian4
 (从 一 而 终)	cong2yi4er2zhong1
-(从 ㊀ 而 终)	cong2yi4er2zhong1
 (从 那 时 侯)	cong2na4shi2hou4
 (他 得 不 到)	ta1de2bu5dao4
 (他 得 不 到)	ta1de2bu5dao4
@@ -77513,7 +72090,6 @@ $textmode
 (他 得 便 宜)	ta1de2pian2yi5
 (他 得 劲 儿)	ta1de2jin4r5
 (他 得 天 下)	ta1de2tian1xia4
-(他 得 天 ㊦)	ta1de2tian1xia4
 (他 得 数 儿)	ta1de2shu4r5
 (他 得 样 儿)	ta1de2yang4r5
 (他 得 樣 兒)	ta1de2yang4r5
@@ -77526,59 +72102,34 @@ $textmode
 (他 得 空 儿)	ta1de2kong4r5
 (他 得 罪 人)	ta1de2zui4ren2
 (付 之 一 叹)	fu4zhi1yi2tan4
-(付 之 ㊀ 叹)	fu4zhi1yi2tan4
 (付 之 一 嘆)	fu4zhi1yi2tan4
-(付 之 ㊀ 嘆)	fu4zhi1yi2tan4
 (付 之 一 嘆)	fu4zhi1yi2tan4
-(付 之 ㊀ 嘆)	fu4zhi1yi2tan4
 (付 之 一 歎)	fu4zhi1yi2tan4
-(付 之 ㊀ 歎)	fu4zhi1yi2tan4
 (付 之 一 炬)	fu4zhi1yi2ju4
-(付 之 ㊀ 炬)	fu4zhi1yi2ju4
 (付 之 一 笑)	fu4zhi1yi2xiao4
-(付 之 ㊀ 笑)	fu4zhi1yi2xiao4
 (付 諸 一 炬)	fu4zhu1yi2ju4
-(付 諸 ㊀ 炬)	fu4zhu1yi2ju4
 (付 諸 一 炬)	fu4zhu1yi2ju4
-(付 諸 ㊀ 炬)	fu4zhu1yi2ju4
 (付 諸 一 炬)	fu4zhu1yi2ju4
-(付 諸 ㊀ 炬)	fu4zhu1yi2ju4
 (付 诸 一 炬)	fu4zhu1yi2ju4
-(付 诸 ㊀ 炬)	fu4zhu1yi2ju4
 (令 人 发 指)	ling4ren2fa4zhi3
 (令 人 发 指)	ling4ren2fa4zhi3
 (以 一 奉 百)	yi3yi2feng4bai3
-(以 ㊀ 奉 百)	yi3yi2feng4bai3
 (以 一 当 十)	yi3yi4dang1shi2
-(以 一 当 ㊉)	yi3yi4dang1shi2
-(以 ㊀ 当 十)	yi3yi4dang1shi2
 (以 一 当 百)	yi3yi4dang1bai3
-(以 ㊀ 当 百)	yi3yi4dang1bai3
 (以 一 持 万)	yi3yi4chi2wan4
-(以 ㊀ 持 万)	yi3yi4chi2wan4
 (以 一 持 萬)	yi3yi4chi2wan4
-(以 ㊀ 持 萬)	yi3yi4chi2wan4
 (以 一 當 十)	yi3yi4dang1shi2
-(以 一 當 ㊉)	yi3yi4dang1shi2
-(以 ㊀ 當 十)	yi3yi4dang1shi2
 (以 一 當 百)	yi3yi4dang1bai3
-(以 ㊀ 當 百)	yi3yi4dang1bai3
 (以 一 警 百)	yi3yi4jing3bai3
-(以 ㊀ 警 百)	yi3yi4jing3bai3
 (以 决 一 战)	yi3jue2yi2zhan4
-(以 决 ㊀ 战)	yi3jue2yi2zhan4
 (以 博 一 笑)	yi3bo2yi2xiao4
-(以 博 ㊀ 笑)	yi3bo2yi2xiao4
 (以 博 一 粲)	yi3bo2yi2can4
-(以 博 ㊀ 粲)	yi3bo2yi2can4
 (以 慎 为 键)	yi3shen4wei2jian4
 (以 慎 为 键)	yi3shen4wei2jian4
 (以 慎 為 鍵)	yi3shen4wei2jian4
 (以 慎 為 鍵)	yi3shen4wei2jian4
 (以 求 一 逞)	yi3qiu2yi4cheng3
-(以 求 ㊀ 逞)	yi3qiu2yi4cheng3
 (以 決 一 戰)	yi3jue2yi2zhan4
-(以 決 ㊀ 戰)	yi3jue2yi2zhan4
 (以 牙 还 牙)	yi3ya2huan2ya2
 (以 牙 還 牙)	yi3ya2huan2ya2
 (以 眼 还 眼)	yi3yan3huan2yan3
@@ -77600,7 +72151,6 @@ $textmode
 (们 得 便 宜)	men5de2pian2yi5
 (们 得 劲 儿)	men5de2jin4r5
 (们 得 天 下)	men5de2tian1xia4
-(们 得 天 ㊦)	men5de2tian1xia4
 (们 得 数 儿)	men5de2shu4r5
 (们 得 样 儿)	men5de2yang4r5
 (们 得 樣 兒)	men5de2yang4r5
@@ -77620,10 +72170,8 @@ $textmode
 (伊 裡 格 瑞)	yi1li3ge2rui4
 (伍 德 豪 斯)	wu3de2hao2si1
 (众 口 一 词)	zhong4kou3yi4ci2
-(众 口 ㊀ 词)	zhong4kou3yi4ci2
 (众 矢 之 的)	zhong4shi3zhi1di4
 (会 心 一 笑)	hui4xin1yi2xiao4
-(会 心 ㊀ 笑)	hui4xin1yi2xiao4
 (伯 拉 斯 都)	bo2la1si1du1
 (伯 拉 斯 都)	bo2la1si1du1
 (伯 拉 斯 都)	bo2la1si1du1
@@ -77665,7 +72213,6 @@ $textmode
 (你 得 便 宜)	ni3de2pian2yi5
 (你 得 劲 儿)	ni3de2jin4r5
 (你 得 天 下)	ni3de2tian1xia4
-(你 得 天 ㊦)	ni3de2tian1xia4
 (你 得 数 儿)	ni3de2shu4r5
 (你 得 样 儿)	ni3de2yang4r5
 (你 得 樣 兒)	ni3de2yang4r5
@@ -77696,10 +72243,7 @@ $textmode
 (俄 巴 底 亚)	e2ba1di3ya4
 (俄 巴 底 亞)	e2ba1di3ya4
 (俨 然 一 色)	yan3ran2yi2se4
-(俨 然 ㊀ 色)	yan3ran2yi2se4
 (修 短 得 中)	xiu1duan3de2zhong1
-(修 短 得 🀄)	xiu1duan3de2zhong1
-(修 短 得 ㊥)	xiu1duan3de2zhong1
 (們 得 不 到)	men5de2bu5dao4
 (們 得 不 到)	men5de2bu5dao4
 (們 得 不 着)	men5de2bu5zhao2
@@ -77715,7 +72259,6 @@ $textmode
 (們 得 便 宜)	men5de2pian2yi5
 (們 得 劲 儿)	men5de2jin4r5
 (們 得 天 下)	men5de2tian1xia4
-(們 得 天 ㊦)	men5de2tian1xia4
 (們 得 数 儿)	men5de2shu4r5
 (們 得 样 儿)	men5de2yang4r5
 (們 得 樣 兒)	men5de2yang4r5
@@ -77734,25 +72277,18 @@ $textmode
 (倒 不 過 來)	dao3bu5guo4lai5
 (倒 买 倒 卖)	dao3mai3dao3mai4
 (倒 打 一 耙)	dao4da3yi4pa2
-(倒 打 ㊀ 耙)	dao4da3yi4pa2
 (倒 果 为 因)	dao4guo3wei2yin1
 (倒 果 為 因)	dao4guo3wei2yin1
 (倒 海 翻 江)	dao3hai3fan1jiang1
 (倒 海 翻 江)	dao3hai3fan1jiang1
 (倒 背 手 儿)	dao4bei4shou3r5
 (倒 腾 一 夜)	dao3teng5yi2ye4
-(倒 腾 一 ㊰)	dao3teng5yi2ye4
-(倒 腾 ㊀ 夜)	dao3teng5yi2ye4
 (倒 買 倒 賣)	dao3mai3dao3mai4
 (倒 騰 一 夜)	dao3teng5yi2ye4
-(倒 騰 一 ㊰)	dao3teng5yi2ye4
-(倒 騰 ㊀ 夜)	dao3teng5yi2ye4
 (借 花 献 佛)	jie4hua1xian4fo2
 (借 花 獻 佛)	jie4hua1xian4fo2
 (值 得 一 提)	zhi2de5yi4ti2
-(值 得 ㊀ 提)	zhi2de5yi4ti2
 (值 得 一 看)	zhi2de5yi2kan4
-(值 得 ㊀ 看)	zhi2de5yi2kan4
 (倾 箱 倒 箧)	qing1xiang1dao3qie4
 (偃 旗 息 鼓)	yan3qi2xi1gu3
 (假 性 近 視)	jia3xing4jin4shi4
@@ -77765,24 +72301,15 @@ $textmode
 (停 車 位 置)	ting2che1wei4zhi4
 (停 车 位 置)	ting2che1wei4zhi4
 (停 頓 下 來)	ting2dun4xia4lai2
-(停 頓 ㊦ 來)	ting2dun4xia4lai2
 (停 頓 下 來)	ting2dun4xia4lai2
-(停 頓 ㊦ 來)	ting2dun4xia4lai2
 (停 顿 下 来)	ting2dun4xia4lai2
-(停 顿 ㊦ 来)	ting2dun4xia4lai2
 (偶 一 不 慎)	ou3yi2bu2shen4
-(偶 ㊀ 不 慎)	ou3yi2bu2shen4
 (偶 一 不 慎)	ou3yi2bu2shen4
-(偶 ㊀ 不 慎)	ou3yi2bu2shen4
 (偶 一 不 慎)	ou3yi2bu2shen4
-(偶 ㊀ 不 慎)	ou3yi2bu2shen4
 (偶 一 为 之)	ou3yi4wei2zhi1
-(偶 ㊀ 为 之)	ou3yi4wei2zhi1
 (偶 一 為 之)	ou3yi4wei2zhi1
-(偶 ㊀ 為 之)	ou3yi4wei2zhi1
 (偷 偷 摸 摸)	tou1tou1mo1mo1
 (備 於 萬 一)	bei4yu2wan4yi1
-(備 於 萬 ㊀)	bei4yu2wan4yi1
 (傭 人 領 班)	yong4ren5ling3ban1
 (傭 人 領 班)	yong4ren5ling3ban1
 (傻 不 楞 登)	sha3bu5leng1deng1
@@ -77793,11 +72320,8 @@ $textmode
 (僵 不 吃 兒)	jiang1bu5chi1r5
 (僵 不 吃 兒)	jiang1bu5chi1r5
 (僵 持 不 下)	jiang1chi2bu5xia4
-(僵 持 不 ㊦)	jiang1chi2bu5xia4
 (僵 持 不 下)	jiang1chi2bu5xia4
-(僵 持 不 ㊦)	jiang1chi2bu5xia4
 (儼 然 一 色)	yan3ran2yi2se4
-(儼 然 ㊀ 色)	yan3ran2yi2se4
 (先 王 之 乐)	xian1wang2zhi1yue4
 (先 王 之 樂)	xian1wang2zhi1yue4
 (先 王 之 樂)	xian1wang2zhi1yue4
@@ -77826,39 +72350,23 @@ $textmode
 (克 裡 米 亞)	ke4li3mi3ya4
 (克 裡 米 亞)	ke4li3mi3ya4
 (兜 头 一 拳)	dou1tou2yi4quan2
-(兜 头 ㊀ 拳)	dou1tou2yi4quan2
 (兜 頭 一 拳)	dou1tou2yi4quan2
-(兜 頭 ㊀ 拳)	dou1tou2yi4quan2
 (入 土 为 安)	ru4tu3wei2an1
-(入 ㊏ 为 安)	ru4tu3wei2an1
 (入 土 為 安)	ru4tu3wei2an1
-(入 ㊏ 為 安)	ru4tu3wei2an1
 (內 懮 外 患)	nei4you1wai4huan4
 (兩 報 一 刊)	liang3bao4yi4kan1
-(兩 報 ㊀ 刊)	liang3bao4yi4kan1
 (兩 報 一 刊)	liang3bao4yi4kan1
-(兩 報 ㊀ 刊)	liang3bao4yi4kan1
 (兩 定 一 獎)	liang3ding4yi4jiang3
-(兩 定 ㊀ 獎)	liang3ding4yi4jiang3
 (兩 定 一 獎)	liang3ding4yi4jiang3
-(兩 定 ㊀ 獎)	liang3ding4yi4jiang3
 (兩 得 其 便)	liang3de2qi2bian4
 (兩 得 其 便)	liang3de2qi2bian4
 (兩 得 其 便)	liang3de2qi2bian4
 (兩 手 一 攤)	liang3shou3yi4tan1
-(兩 手 ㊀ 攤)	liang3shou3yi4tan1
 (兩 手 一 攤)	liang3shou3yi4tan1
-(兩 手 ㊀ 攤)	liang3shou3yi4tan1
 (兩 飽 一 倒)	liang3bao3yi4dao3
-(兩 飽 ㊀ 倒)	liang3bao3yi4dao3
 (兩 飽 一 倒)	liang3bao3yi4dao3
-(兩 飽 ㊀ 倒)	liang3bao3yi4dao3
 (八 紘 一 宇)	ba1hong2yi4yu3
-(八 紘 ㊀ 宇)	ba1hong2yi4yu3
-(㊇ 紘 一 宇)	ba1hong2yi4yu3
 (八 纮 一 宇)	ba1hong2yi4yu3
-(八 纮 ㊀ 宇)	ba1hong2yi4yu3
-(㊇ 纮 一 宇)	ba1hong2yi4yu3
 (公 諸 同 好)	gong1zhu1tong2hao4
 (公 諸 同 好)	gong1zhu1tong2hao4
 (公 諸 同 好)	gong1zhu1tong2hao4
@@ -77867,15 +72375,9 @@ $textmode
 (公 諸 於 世)	gong1zhu1yu2shi4
 (公 诸 同 好)	gong1zhu1tong2hao4
 (六 枝 特 区)	lu4zhi1te4qu1
-(㊅ 枝 特 区)	lu4zhi1te4qu1
-(六 枝 ㊕ 区)	lu4zhi1te4qu1
 (六 枝 特 区)	lu4zhi1te4qu1
-(六 枝 ㊕ 区)	lu4zhi1te4qu1
 (六 枝 特 區)	lu4zhi1te4qu1
-(㊅ 枝 特 區)	lu4zhi1te4qu1
-(六 枝 ㊕ 區)	lu4zhi1te4qu1
 (六 枝 特 區)	lu4zhi1te4qu1
-(六 枝 ㊕ 區)	lu4zhi1te4qu1
 (兴 业 银 行)	xing1ye4yin2hang2
 (兴 业 银 行)	xing1ye4yin2hang2
 (兴 得 起 来)	xing1de5qi3lai5
@@ -77888,9 +72390,7 @@ $textmode
 (内 懮 外 患)	nei4you1wai4huan4
 (冒 冒 失 失)	mao4mao5shi1shi1
 (冒 险 一 试)	mao4xian3yi2shi4
-(冒 险 ㊀ 试)	mao4xian3yi2shi4
 (冒 險 一 試)	mao4xian3yi2shi4
-(冒 險 ㊀ 試)	mao4xian3yi2shi4
 (冠 状 动 脉)	guan1zhuang4dong4mai4
 (冠 狀 動 脈)	guan1zhuang4dong4mai4
 (冠 狀 動 脈)	guan1zhuang4dong4mai4
@@ -77900,11 +72400,8 @@ $textmode
 (冤 家 路 窄)	yuan1jia1lu4zhai3
 (冰 天 雪 地)	bing1tian1xue3di4
 (决 一 死 战)	jue2yi4si3zhan4
-(决 ㊀ 死 战)	jue2yi4si3zhan4
 (决 一 胜 负)	jue2yi2sheng4fu4
-(决 ㊀ 胜 负)	jue2yi2sheng4fu4
 (决 一 雌 雄)	jue2yi4ci2xiong2
-(决 ㊀ 雌 雄)	jue2yi4ci2xiong2
 (冷 得 邪 活)	leng3de5xie2huo5
 (冷 得 邪 活)	leng3de5xie2huo5
 (冷 热 度 数)	leng3re4du4shu4
@@ -77915,24 +72412,17 @@ $textmode
 (冷 熱 度 數)	leng3re4du4shu4
 (冷 熱 度 數)	leng3re4du4shu4
 (凉 在 一 边)	liang4zai4yi4bian1
-(凉 在 ㊀ 边)	liang4zai4yi4bian1
 (凉 在 一 边)	liang4zai4yi4bian1
-(凉 在 ㊀ 边)	liang4zai4yi4bian1
 (凝 神 一 志)	ning2shen2yi2zhi4
-(凝 神 ㊀ 志)	ning2shen2yi2zhi4
 (凝 神 一 志)	ning2shen2yi2zhi4
-(凝 神 ㊀ 志)	ning2shen2yi2zhi4
 (凡 夫 俗 子)	fan2fu1su2zi3
 (出 人 头 地)	chu1ren2tou2di4
 (出 人 頭 地)	chu1ren2tou2di4
 (出 生 日 期)	chu1sheng1ri4qi1
-(出 生 ㊐ 期)	chu1sheng1ri4qi1
 (分 不 清 楚)	fen1bu5qing1chu5
 (分 不 清 楚)	fen1bu5qing1chu5
 (分 外 恩 典)	fen1wai4en1dian3
 (分 子 医 学)	fen1zi3yi1xue2
-(分 子 医 ㊫)	fen1zi3yi1xue2
-(分 子 ㊩ 学)	fen1zi3yi1xue2
 (分 子 杂 交)	fen1zi3za2jiao1
 (分 子 醫 學)	fen1zi3yi1xue2
 (分 子 雜 交)	fen1zi3za2jiao1
@@ -77940,11 +72430,7 @@ $textmode
 (切 分 信 息)	qie1fen1xin4xi1
 (切 分 信 息)	qie1fen1xin4xi1
 (划 一 不 二)	hua4yi2bu2er4
-(划 ㊀ 不 二)	hua4yi2bu2er4
-(划 一 不 ㊁)	hua4yi2bu2er4
 (划 一 不 二)	hua4yi2bu2er4
-(划 ㊀ 不 二)	hua4yi2bu2er4
-(划 一 不 ㊁)	hua4yi2bu2er4
 (列 別 傑 夫)	lie4bie4jie2fu1
 (列 別 傑 夫)	lie4bie4jie2fu1
 (列 别 杰 夫)	lie4bie4jie2fu1
@@ -77955,17 +72441,11 @@ $textmode
 (初 露 頭 角)	chu1lu4tou2jiao3
 (初 露 頭 角)	chu1lu4tou2jiao3
 (別 具 一 格)	bie2ju4yi4ge2
-(別 具 ㊀ 格)	bie2ju4yi4ge2
 (別 樹 一 幟)	bie2shu4yi2zhi4
-(別 樹 ㊀ 幟)	bie2shu4yi2zhi4
 (别 具 一 格)	bie2ju4yi4ge2
-(别 具 ㊀ 格)	bie2ju4yi4ge2
 (别 树 一 帜)	bie2shu4yi2zhi4
-(别 树 ㊀ 帜)	bie2shu4yi2zhi4
 (到 处 一 游)	dao4chu4yi4you2
-(到 处 ㊀ 游)	dao4chu4yi4you2
 (到 處 一 游)	dao4chu4yi4you2
-(到 處 ㊀ 游)	dao4chu4yi4you2
 (削 职 为 民)	xue1zhi2wei2min2
 (削 職 為 民)	xue1zhi2wei2min2
 (前 仆 后 繼)	qian2pu1hou4ji4
@@ -77977,30 +72457,19 @@ $textmode
 (剥 得 精 光)	bao1de5jing1guang1
 (創 巨 痛 深)	chuang1ju4tong4shen1
 (劃 一 不 二)	hua4yi2bu2er4
-(劃 ㊀ 不 二)	hua4yi2bu2er4
-(劃 一 不 ㊁)	hua4yi2bu2er4
 (劃 一 不 二)	hua4yi2bu2er4
-(劃 ㊀ 不 二)	hua4yi2bu2er4
-(劃 一 不 ㊁)	hua4yi2bu2er4
 (劃 圓 防 守)	hua4yuan2fang2shou3
 (劈 一 字 腿)	pi3yi2zi4tui3
-(劈 ㊀ 字 腿)	pi3yi2zi4tui3
 (劈 裡 啪 啦)	pi1li5pa1la1
 (劈 裡 啪 啦)	pi1li5pa1la1
 (劈 里 啪 啦)	pi1li5pa1la1
 (劈 里 啪 啦)	pi1li5pa1la1
 (力 有 未 逮)	li4you3wei4dai4
-(力 ㊒ 未 逮)	li4you3wei4dai4
 (力 有 未 逮)	li4you3wei4dai4
-(力 ㊒ 未 逮)	li4you3wei4dai4
 (力 求 一 逞)	li4qiu2yi4cheng3
-(力 求 ㊀ 逞)	li4qiu2yi4cheng3
 (力 求 一 逞)	li4qiu2yi4cheng3
-(力 求 ㊀ 逞)	li4qiu2yi4cheng3
 (功 亏 一 篑)	gong1kui1yi2kui4
-(功 亏 ㊀ 篑)	gong1kui1yi2kui4
 (功 虧 一 簣)	gong1kui1yi2kui4
-(功 虧 ㊀ 簣)	gong1kui1yi2kui4
 (加 德 满 都)	jia1de2man3du1
 (加 德 满 都)	jia1de2man3du1
 (加 德 滿 都)	jia1de2man3du1
@@ -78012,20 +72481,14 @@ $textmode
 (动 弹 不 得)	dong4tan5bu5de5
 (动 辄 得 咎)	dong4zhe2de2jiu4
 (助 以 一 臂)	zhu4yi3yi2bi4
-(助 以 ㊀ 臂)	zhu4yi3yi2bi4
 (助 紂 為 虐)	zhu4zhou4wei2nve4
 (助 纣 为 虐)	zhu4zhou4wei2nve4
 (劳 雇 关 系)	lao2gu4guan1xi4
-(㊘ 雇 关 系)	lao2gu4guan1xi4
 (势 在 必 得)	shi4zai4bi4de2
 (勉 強 一 笑)	mian3qiang3yi2xiao4
-(勉 強 ㊀ 笑)	mian3qiang3yi2xiao4
 (勉 強 一 笑)	mian3qiang3yi2xiao4
-(勉 強 ㊀ 笑)	mian3qiang3yi2xiao4
 (勉 强 一 笑)	mian3qiang3yi2xiao4
-(勉 强 ㊀ 笑)	mian3qiang3yi2xiao4
 (勉 强 一 笑)	mian3qiang3yi2xiao4
-(勉 强 ㊀ 笑)	mian3qiang3yi2xiao4
 (動 彈 不 得)	dong4tan5bu5de5
 (動 彈 不 得)	dong4tan5bu5de5
 (動 輒 得 咎)	dong4zhe2de2jiu4
@@ -78048,117 +72511,60 @@ $textmode
 (化 险 为 夷)	hua4xian3wei2yi2
 (化 險 為 夷)	hua4xian3wei2yi2
 (十 一 級 風)	shi2yi1ji2feng1
-(㊉ 一 級 風)	shi2yi1ji2feng1
-(十 ㊀ 級 風)	shi2yi1ji2feng1
 (十 一 级 风)	shi2yi1ji2feng1
-(㊉ 一 级 风)	shi2yi1ji2feng1
-(十 ㊀ 级 风)	shi2yi1ji2feng1
 (十 四 行 詩)	shi2si4hang2shi1
-(㊉ 四 行 詩)	shi2si4hang2shi1
-(十 ㊃ 行 詩)	shi2si4hang2shi1
 (十 四 行 詩)	shi2si4hang2shi1
-(㊉ 四 行 詩)	shi2si4hang2shi1
-(十 ㊃ 行 詩)	shi2si4hang2shi1
 (十 四 行 诗)	shi2si4hang2shi1
-(㊉ 四 行 诗)	shi2si4hang2shi1
-(十 ㊃ 行 诗)	shi2si4hang2shi1
 (十 四 行 诗)	shi2si4hang2shi1
-(㊉ 四 行 诗)	shi2si4hang2shi1
-(十 ㊃ 行 诗)	shi2si4hang2shi1
 (千 差 万 别)	qian1cha1wan4bie2
 (千 差 萬 別)	qian1cha1wan4bie2
 (千 慮 一 失)	qian1lv4yi4shi1
-(千 慮 ㊀ 失)	qian1lv4yi4shi1
 (千 經 萬 卷)	qian1jing1wan4juan4
 (千 经 万 卷)	qian1jing1wan4juan4
 (千 虑 一 失)	qian1lv4yi4shi1
-(千 虑 ㊀ 失)	qian1lv4yi4shi1
 (千 載 一 時)	qian1zai3yi4shi2
-(千 載 ㊀ 時)	qian1zai3yi4shi2
 (千 載 一 遇)	qian1zai3yi2yu4
-(千 載 ㊀ 遇)	qian1zai3yi2yu4
 (千 載 難 逢)	qian1zai3nan2feng2
 (千 載 難 逢)	qian1zai3nan2feng2
 (千 載 難 逢)	qian1zai3nan2feng2
 (千 载 一 时)	qian1zai3yi4shi2
-(千 载 ㊀ 时)	qian1zai3yi4shi2
 (千 载 一 遇)	qian1zai3yi2yu4
-(千 载 ㊀ 遇)	qian1zai3yi2yu4
 (千 载 难 逢)	qian1zai3nan2feng2
 (千 金 一 掷)	qian1jin1yi2zhi4
-(千 ㊎ 一 掷)	qian1jin1yi2zhi4
-(千 金 ㊀ 掷)	qian1jin1yi2zhi4
 (千 金 一 掷)	qian1jin1yi2zhi4
-(千 金 ㊀ 掷)	qian1jin1yi2zhi4
 (千 金 一 擲)	qian1jin1yi2zhi4
-(千 ㊎ 一 擲)	qian1jin1yi2zhi4
-(千 金 ㊀ 擲)	qian1jin1yi2zhi4
 (千 金 一 擲)	qian1jin1yi2zhi4
-(千 金 ㊀ 擲)	qian1jin1yi2zhi4
 (千 金 一 笑)	qian1jin1yi2xiao4
-(千 ㊎ 一 笑)	qian1jin1yi2xiao4
-(千 金 ㊀ 笑)	qian1jin1yi2xiao4
 (千 金 一 笑)	qian1jin1yi2xiao4
-(千 金 ㊀ 笑)	qian1jin1yi2xiao4
 (千 金 一 諾)	qian1jin1yi2nuo4
-(千 ㊎ 一 諾)	qian1jin1yi2nuo4
-(千 金 ㊀ 諾)	qian1jin1yi2nuo4
 (千 金 一 諾)	qian1jin1yi2nuo4
-(千 金 ㊀ 諾)	qian1jin1yi2nuo4
 (千 金 一 諾)	qian1jin1yi2nuo4
-(千 ㊎ 一 諾)	qian1jin1yi2nuo4
-(千 金 ㊀ 諾)	qian1jin1yi2nuo4
 (千 金 一 諾)	qian1jin1yi2nuo4
-(千 ㊎ 一 諾)	qian1jin1yi2nuo4
-(千 金 ㊀ 諾)	qian1jin1yi2nuo4
 (千 金 一 诺)	qian1jin1yi2nuo4
-(千 ㊎ 一 诺)	qian1jin1yi2nuo4
-(千 金 ㊀ 诺)	qian1jin1yi2nuo4
 (千 金 一 诺)	qian1jin1yi2nuo4
-(千 金 ㊀ 诺)	qian1jin1yi2nuo4
 (千 鈞 一 髮)	qian1jun1yi2fa4
-(千 鈞 ㊀ 髮)	qian1jun1yi2fa4
 (千 钧 一 发)	qian1jun1yi2fa4
-(千 钧 ㊀ 发)	qian1jun1yi2fa4
 (半 半 拉 拉)	ban4ban5la1la1
 (半 半 拉 拉)	ban4ban5la1la1
 (半 夜 三 更)	ban4ye4san1geng1
-(半 ㊰ 三 更)	ban4ye4san1geng1
-(半 夜 ㊂ 更)	ban4ye4san1geng1
 (半 夜 三 更)	ban4ye4san1geng1
-(半 ㊰ 三 更)	ban4ye4san1geng1
-(半 夜 ㊂ 更)	ban4ye4san1geng1
 (半 开 门 儿)	ban4kai1men2r5
 (华 纳 兄 弟)	hua4na4xiong1di4
 (卓 乎 不 群)	zhuo2hu1bu4qun2
 (卓 乎 不 群)	zhuo2hu1bu4qun2
 (单 一 种 植)	dan1yi2zhong4zhi2
-(单 ㊀ 种 植)	dan1yi2zhong4zhi2
 (单 一 翻 译)	dan1yi4fan1yi4
-(单 ㊀ 翻 译)	dan1yi4fan1yi4
 (单 一 转 换)	dan1yi4zhuan3huan4
-(单 ㊀ 转 换)	dan1yi4zhuan3huan4
 (单 一 隐 喻)	dan1yi4yin3yu4
-(单 ㊀ 隐 喻)	dan1yi4yin3yu4
 (单 亲 家 庭)	dan1qin1jia1ting2
 (卖 不 出 去)	mai4bu5chu1qu5
 (卖 不 出 去)	mai4bu5chu1qu5
 (南 奥 塞 梯)	nan2ao4sai1ti1
-(🀁 奥 塞 梯)	nan2ao4sai1ti1
 (南 奥 塞 梯)	nan2ao4sai1ti1
-(🀁 奥 塞 梯)	nan2ao4sai1ti1
 (南 奧 塞 梯)	nan2ao4sai1ti1
-(🀁 奧 塞 梯)	nan2ao4sai1ti1
 (南 奧 塞 梯)	nan2ao4sai1ti1
-(🀁 奧 塞 梯)	nan2ao4sai1ti1
 (南 柯 一 夢)	nan2ke1yi2meng4
-(🀁 柯 一 夢)	nan2ke1yi2meng4
-(南 柯 ㊀ 夢)	nan2ke1yi2meng4
-(🀁 柯 ㊀ 夢)	nan2ke1yi2meng4
 (南 柯 一 梦)	nan2ke1yi2meng4
-(🀁 柯 一 梦)	nan2ke1yi2meng4
-(南 柯 ㊀ 梦)	nan2ke1yi2meng4
-(🀁 柯 ㊀ 梦)	nan2ke1yi2meng4
 (博 聞 多 識)	bo2wen2duo1shi2
 (博 聞 多 識)	bo2wen2duo1shi2
 (博 聞 強 識)	bo2wen2qiang2shi2
@@ -78166,9 +72572,7 @@ $textmode
 (博 闻 多 识)	bo2wen2duo1shi2
 (博 闻 强 识)	bo2wen2qiang2shi2
 (卜 昼 卜 夜)	bu3zhou4bu3ye4
-(卜 昼 卜 ㊰)	bu3zhou4bu3ye4
 (卜 晝 卜 夜)	bu3zhou4bu3ye4
-(卜 晝 卜 ㊰)	bu3zhou4bu3ye4
 (卡 尔 扎 伊)	ka3er3za1yi1
 (卡 拉 O K)	ka3la1ou1kei1
 (卡 拉 O K)	ka3la1ou1kei1
@@ -78180,11 +72584,8 @@ $textmode
 (卡 文 迪 什)	ka3wen2di2shi2
 (卡 爾 扎 伊)	ka3er3za1yi1
 (卡 西 莫 夫)	ka3xi1mo4fu1
-(卡 🀂 莫 夫)	ka3xi1mo4fu1
 (印 地 安 納)	yin4di4an1na4
-(㊞ 地 安 納)	yin4di4an1na4
 (印 地 安 纳)	yin4di4an1na4
-(㊞ 地 安 纳)	yin4di4an1na4
 (危 地 馬 拉)	wei1di4ma3la1
 (危 地 馬 拉)	wei1di4ma3la1
 (危 地 马 拉)	wei1di4ma3la1
@@ -78200,16 +72601,13 @@ $textmode
 (厚 此 薄 彼)	hou4ci3bo2bi3
 (厚 養 薄 葬)	hou4yang3bo2zang4
 (又 是 一 个)	you4shi4yi2ge4
-(又 是 ㊀ 个)	you4shi4yi2ge4
 (又 是 一 個)	you4shi4yi2ge4
-(又 是 ㊀ 個)	you4shi4yi2ge4
 (友 拉 革 罗)	you3la1ge2luo2
 (友 拉 革 罗)	you3la1ge2luo2
 (友 拉 革 羅)	you3la1ge2luo2
 (友 拉 革 羅)	you3la1ge2luo2
 (友 拉 革 羅)	you3la1ge2luo2
 (双 膝 跪 下)	shuang1xi1gui4xia4
-(双 膝 跪 ㊦)	shuang1xi1gui4xia4
 (反 手 可 得)	fan3shou3ke3de2
 (反 敗 為 勝)	fan3bai4wei2sheng4
 (反 败 为 胜)	fan3bai4wei2sheng4
@@ -78229,9 +72627,7 @@ $textmode
 (口 齒 清 楚)	kou3chi3qing1chu3
 (口 齿 清 楚)	kou3chi3qing1chu3
 (古 今 一 轍)	gu3jin1yi4zhe2
-(古 今 ㊀ 轍)	gu3jin1yi4zhe2
 (古 今 一 辙)	gu3jin1yi4zhe2
-(古 今 ㊀ 辙)	gu3jin1yi4zhe2
 (只 言 片 语)	zhi1yan2pian4yu3
 (只 雞 斗 酒)	zhi1ji1dou3jiu3
 (只 鸡 斗 酒)	zhi1ji1dou3jiu3
@@ -78244,30 +72640,21 @@ $textmode
 (史 傳 小 說)	shi3zhuan4xiao3shuo2
 (史 傳 小 說)	shi3zhuan4xiao3shuo2
 (右 派 分 子)	you4pai4fen4zi3
-(㊨ 派 分 子)	you4pai4fen4zi3
 (叹 为 观 止)	tan4wei2guan1zhi3
 (叽 叽 喳 喳)	ji1ji5zha1zha1
 (叽 叽 嘎 嘎)	ji1ji5ga1ga1
 (吃 不 下 去)	chi1bu5xia4qu5
-(吃 不 ㊦ 去)	chi1bu5xia4qu5
 (吃 不 下 去)	chi1bu5xia4qu5
-(吃 不 ㊦ 去)	chi1bu5xia4qu5
 (吃 盡 苦 頭)	chi1jin4ku3tou5
 (各 執 一 見)	ge4zhi2yi2jian4
-(各 執 ㊀ 見)	ge4zhi2yi2jian4
 (各 執 一 見)	ge4zhi2yi2jian4
-(各 執 ㊀ 見)	ge4zhi2yi2jian4
 (各 執 一 詞)	ge4zhi2yi4ci2
-(各 執 ㊀ 詞)	ge4zhi2yi4ci2
 (各 奔 前 程)	ge4ben4qian2cheng2
 (各 奔 前 程)	ge4ben4qian2cheng2
 (各 得 其 所)	ge4de2qi2suo3
 (各 执 一 见)	ge4zhi2yi2jian4
-(各 执 ㊀ 见)	ge4zhi2yi2jian4
 (各 执 一 词)	ge4zhi2yi4ci2
-(各 执 ㊀ 词)	ge4zhi2yi4ci2
 (各 有 所 好)	ge4you3suo3hao4
-(各 ㊒ 所 好)	ge4you3suo3hao4
 (各 盡 所 能)	ge4jin4suo3neng2
 (各 行 各 业)	ge4hang2ge4ye4
 (各 行 各 业)	ge4hang2ge4ye4
@@ -78277,43 +72664,25 @@ $textmode
 (合 乎 邏 輯)	he2hu1luo2ji2
 (合 乎 邏 輯)	he2hu1luo2ji2
 (合 二 为 一)	he2er4wei2yi1
-(合 二 为 ㊀)	he2er4wei2yi1
-(合 ㊁ 为 一)	he2er4wei2yi1
 (合 二 為 一)	he2er4wei2yi1
-(合 二 為 ㊀)	he2er4wei2yi1
-(合 ㊁ 為 一)	he2er4wei2yi1
 (合 众 为 一)	he2zhong4wei2yi1
-(合 众 为 ㊀)	he2zhong4wei2yi1
 (合 眾 為 一)	he2zhong4wei2yi1
-(合 眾 為 ㊀)	he2zhong4wei2yi1
 (合 而 为 一)	he2er2wei2yi1
-(合 而 为 ㊀)	he2er2wei2yi1
 (合 而 為 一)	he2er2wei2yi1
-(合 而 為 ㊀)	he2er2wei2yi1
 (吊 儿 郎 当)	diao4r5lang2dang1
 (吊 儿 郎 当)	diao4r5lang2dang1
 (同 出 一 軌)	tong2chu1yi4gui3
-(同 出 ㊀ 軌)	tong2chu1yi4gui3
 (同 出 一 轍)	tong2chu1yi4zhe2
-(同 出 ㊀ 轍)	tong2chu1yi4zhe2
 (同 出 一 轨)	tong2chu1yi4gui3
-(同 出 ㊀ 轨)	tong2chu1yi4gui3
 (同 出 一 辙)	tong2chu1yi4zhe2
-(同 出 ㊀ 辙)	tong2chu1yi4zhe2
 (同 声 一 哭)	tong2sheng1yi4ku1
-(同 声 ㊀ 哭)	tong2sheng1yi4ku1
 (同 工 同 酬)	tong2gong1tong2chou2
 (同 歸 於 盡)	tong2gui1yu2jin4
 (同 聲 一 哭)	tong2sheng1yi4ku1
-(同 聲 ㊀ 哭)	tong2sheng1yi4ku1
 (同 行 一 莫)	tong2hang2yi2mo4
-(同 行 ㊀ 莫)	tong2hang2yi2mo4
 (同 行 一 莫)	tong2hang2yi2mo4
-(同 行 ㊀ 莫)	tong2hang2yi2mo4
 (名 誉 扫 地)	ming2yu4sao3di4
-(㊔ 誉 扫 地)	ming2yu4sao3di4
 (名 譽 掃 地)	ming2yu4sao3di4
-(㊔ 譽 掃 地)	ming2yu4sao3di4
 (吐 露 心 事)	tu3lu4xin1shi4
 (吐 露 心 事)	tu3lu4xin1shi4
 (向 巴 平 措)	xiang4ba1ping2cuo4
@@ -78328,9 +72697,7 @@ $textmode
 (含 糊 不 清)	han2hu2bu4qing1
 (含 糊 不 清)	han2hu2bu4qing1
 (听 不 下 去)	ting1bu5xia4qu4
-(听 不 ㊦ 去)	ting1bu5xia4qu4
 (听 不 下 去)	ting1bu5xia4qu4
-(听 不 ㊦ 去)	ting1bu5xia4qu4
 (听 不 明 白)	ting1bu5ming2bai5
 (听 不 明 白)	ting1bu5ming2bai5
 (听 不 清 楚)	ting1bu5qing1chu3
@@ -78346,9 +72713,7 @@ $textmode
 (吹 得 譜 兒)	chui1de2pu3r5
 (吹 得 谱 儿)	chui1de2pu3r5
 (呵 一 口 气)	he1yi4kou3qi4
-(呵 ㊀ 口 气)	he1yi4kou3qi4
 (呵 一 口 氣)	he1yi4kou3qi4
-(呵 ㊀ 口 氣)	he1yi4kou3qi4
 (呼 來 喝 去)	hu1lai2he4qu4
 (呼 來 喝 去)	hu1lai2he4qu4
 (呼 來 喝 去)	hu1lai2he4qu4
@@ -78362,7 +72727,6 @@ $textmode
 (和 气 致 祥)	he2qi4zhi4xiang2
 (和 气 致 祥)	he2qi4zhi4xiang2
 (和 氣 生 財)	he2qi4sheng1cai2
-(和 氣 生 ㊖)	he2qi4sheng1cai2
 (和 氣 致 祥)	he2qi4zhi4xiang2
 (和 氣 致 祥)	he2qi4zhi4xiang2
 (咖 啡 馆 儿)	ka1fei1guan3r5
@@ -78378,7 +72742,6 @@ $textmode
 (哈 裡 斯 堡)	ha1li3si1bao3
 (哈 裡 斯 堡)	ha1li3si1bao3
 (哈 西 努 雅)	ha1xi1nu3ya3
-(哈 🀂 努 雅)	ha1xi1nu3ya3
 (哗 众 取 宠)	hua2zhong4qu3chong3
 (哩 哩 啦 啦)	li1li1la1la1
 (哩 哩 罗 罗)	li1li5luo1luo1
@@ -78428,13 +72791,9 @@ $textmode
 (喜 怒 哀 樂)	xi3nu4ai1le4
 (喪 失 殆 盡)	sang4shi1dai4jin4
 (單 一 種 植)	dan1yi2zhong4zhi2
-(單 ㊀ 種 植)	dan1yi2zhong4zhi2
 (單 一 翻 譯)	dan1yi4fan1yi4
-(單 ㊀ 翻 譯)	dan1yi4fan1yi4
 (單 一 轉 換)	dan1yi4zhuan3huan4
-(單 ㊀ 轉 換)	dan1yi4zhuan3huan4
 (單 一 隱 喻)	dan1yi4yin3yu4
-(單 ㊀ 隱 喻)	dan1yi4yin3yu4
 (單 親 家 庭)	dan1qin1jia1ting2
 (嘁 嘁 喳 喳)	qi1qi5cha1cha1
 (嘆 為 觀 止)	tan4wei2guan1zhi3
@@ -78443,7 +72802,6 @@ $textmode
 (嘉 柏 隆 里)	jia1bo2long2li3
 (嘉 柏 隆 里)	jia1bo2long2li3
 (嘗 鼎 一 臠)	chang2ding3yi4luan2
-(嘗 鼎 ㊀ 臠)	chang2ding3yi4luan2
 (嘩 眾 取 寵)	hua2zhong4qu3chong3
 (嘰 嘰 喳 喳)	ji1ji5zha1zha1
 (嘰 嘰 嘎 嘎)	ji1ji5ga1ga1
@@ -78457,27 +72815,16 @@ $textmode
 (噙 不 住 淚)	qin2bu5zhu4lei4
 (噙 不 住 淚)	qin2bu5zhu4lei4
 (四 个 小 时)	si4ge4xiao3shi2
-(㊃ 个 小 时)	si4ge4xiao3shi2
 (四 個 小 時)	si4ge4xiao3shi2
-(㊃ 個 小 時)	si4ge4xiao3shi2
 (四 号 电 池)	si1hao4dian4chi2
-(㊃ 号 电 池)	si1hao4dian4chi2
 (四 子 王 旗)	si4zi3wang2qi2
-(㊃ 子 王 旗)	si4zi3wang2qi2
 (四 季 豆 腐)	si4ji4dou4fu3
-(㊃ 季 豆 腐)	si4ji4dou4fu3
 (四 號 電 池)	si1hao4dian4chi2
-(㊃ 號 電 池)	si1hao4dian4chi2
 (四 面 楚 歌)	si4mian4chu3ge1
-(㊃ 面 楚 歌)	si4mian4chu3ge1
 (回 头 一 想)	hui2tou2yi4xiang3
-(回 头 ㊀ 想)	hui2tou2yi4xiang3
 (回 头 一 看)	hui2tou2yi2kan4
-(回 头 ㊀ 看)	hui2tou2yi2kan4
 (回 頭 一 想)	hui2tou2yi4xiang3
-(回 頭 ㊀ 想)	hui2tou2yi4xiang3
 (回 頭 一 看)	hui2tou2yi2kan4
-(回 頭 ㊀ 看)	hui2tou2yi2kan4
 (因 地 制 宜)	yin1di4zhi4yi2
 (因 时 制 宜)	yin1shi2zhi4yi2
 (因 時 制 宜)	yin1shi2zhi4yi2
@@ -78492,17 +72839,13 @@ $textmode
 (图 波 列 夫)	tu2bo1lie4fu1
 (图 波 列 夫)	tu2bo1lie4fu1
 (囿 於 一 時)	you4yu2yi4shi2
-(囿 於 ㊀ 時)	you4yu2yi4shi2
 (囿 於 一 隅)	you4yu2yi4yu2
-(囿 於 ㊀ 隅)	you4yu2yi4yu2
 (國 務 委 員)	guo2wu4wei3yuan2
 (國 務 次 卿)	guo2wu4ci4qing1
 (圖 波 列 夫)	tu2bo1lie4fu1
 (圖 波 列 夫)	tu2bo1lie4fu1
 (土 生 土 長)	tu3sheng1tu3zhang3
-(㊏ 生 ㊏ 長)	tu3sheng1tu3zhang3
 (土 生 土 长)	tu3sheng1tu3zhang3
-(㊏ 生 ㊏ 长)	tu3sheng1tu3zhang3
 (圣 经 外 传)	sheng4jing1wai4zhuan4
 (圣 经 贤 传)	sheng4jing1xian2zhuan4
 (圣 赫 勒 拿)	sheng4he4lei1na2
@@ -78533,7 +72876,6 @@ $textmode
 (坑 坑 洼 洼)	keng1keng5wa1wa1
 (坑 坑 窪 窪)	keng1keng5wa1wa1
 (块 儿 八 毛)	kuai4r5ba1mao2
-(块 儿 ㊇ 毛)	kuai4r5ba1mao2
 (垂 头 丧 气)	chui2tou2sang4qi4
 (垂 手 可 得)	chui2shou3ke3de2
 (垂 手 而 得)	chui2shou3er2de2
@@ -78541,25 +72883,16 @@ $textmode
 (埃 夫 伯 里)	ai1fu1bo2li3
 (埃 夫 伯 里)	ai1fu1bo2li3
 (基 烈 西 費)	ji1lie4xi1fei4
-(基 烈 🀂 費)	ji1lie4xi1fei4
 (基 烈 西 費)	ji1lie4xi1fei4
-(基 烈 🀂 費)	ji1lie4xi1fei4
 (基 烈 西 费)	ji1lie4xi1fei4
-(基 烈 🀂 费)	ji1lie4xi1fei4
 (基 烈 西 费)	ji1lie4xi1fei4
-(基 烈 🀂 费)	ji1lie4xi1fei4
 (堆 案 盈 几)	dui1an4ying2ji1
 (報 以 一 笑)	bao4yi3yi2xiao4
-(報 以 ㊀ 笑)	bao4yi3yi2xiao4
 (場 外 應 急)	chang3wai4ying1ji2
 (塌 成 一 摊)	ta1cheng2yi4tan1
-(塌 成 ㊀ 摊)	ta1cheng2yi4tan1
 (塌 成 一 攤)	ta1cheng2yi4tan1
-(塌 成 ㊀ 攤)	ta1cheng2yi4tan1
 (塔 裡 木 河)	ta3li3mu4he2
-(塔 裡 ㊍ 河)	ta3li3mu4he2
 (塔 裡 木 河)	ta3li3mu4he2
-(塔 裡 ㊍ 河)	ta3li3mu4he2
 (塞 內 加 爾)	sai4nei4jia1er3
 (塞 內 加 爾)	sai4nei4jia1er3
 (塞 内 加 尔)	sai4nei4jia1er3
@@ -78571,9 +72904,7 @@ $textmode
 (塞 尔 维 亚)	se4er3wei2ya4
 (塞 尔 维 亚)	se4er3wei2ya4
 (塞 尔 维 特)	se4er3wei2te4
-(塞 尔 维 ㊕)	se4er3wei2te4
 (塞 尔 维 特)	se4er3wei2te4
-(塞 尔 维 ㊕)	se4er3wei2te4
 (塞 拉 利 昂)	sai4la1li4ang2
 (塞 拉 利 昂)	sai4la1li4ang2
 (塞 拉 利 昂)	sai4la1li4ang2
@@ -78584,21 +72915,13 @@ $textmode
 (塞 爾 維 亞)	se4er3wei2ya4
 (塞 爾 維 亞)	se4er3wei2ya4
 (塞 爾 維 特)	se4er3wei2te4
-(塞 爾 維 ㊕)	se4er3wei2te4
 (塞 爾 維 特)	se4er3wei2te4
-(塞 爾 維 ㊕)	se4er3wei2te4
 (塞 琉 西 亚)	se4liu2xi1ya4
-(塞 琉 🀂 亚)	se4liu2xi1ya4
 (塞 琉 西 亚)	se4liu2xi1ya4
-(塞 琉 🀂 亚)	se4liu2xi1ya4
 (塞 琉 西 亚)	se4liu2xi1ya4
-(塞 琉 🀂 亚)	se4liu2xi1ya4
 (塞 琉 西 亞)	se4liu2xi1ya4
-(塞 琉 🀂 亞)	se4liu2xi1ya4
 (塞 琉 西 亞)	se4liu2xi1ya4
-(塞 琉 🀂 亞)	se4liu2xi1ya4
 (塞 琉 西 亞)	se4liu2xi1ya4
-(塞 琉 🀂 亞)	se4liu2xi1ya4
 (塞 翁 失 馬)	sai4weng1shi1ma3
 (塞 翁 失 馬)	sai4weng1shi1ma3
 (塞 翁 失 马)	sai4weng1shi1ma3
@@ -78615,21 +72938,17 @@ $textmode
 (壽 數 已 盡)	shou4shu5yi3jin4
 (处 之 泰 然)	chu3zhi1tai4ran2
 (外 甥 女 婿)	wai4sheng1nv3xu4
-(外 甥 ㊛ 婿)	wai4sheng1nv3xu4
 (外 甥 女 婿)	wai4sheng1nv3xu4
 (外 甥 媳 妇)	wai4sheng1xi2fu5
 (外 甥 媳 婦)	wai4sheng1xi2fu5
 (夙 兴 夜 寐)	su4xing1ye4mei4
-(夙 兴 ㊰ 寐)	su4xing1ye4mei4
 (夙 興 夜 寐)	su4xing1ye4mei4
-(夙 興 ㊰ 寐)	su4xing1ye4mei4
 (多 不 勝 數)	duo1bu2sheng4shu3
 (多 不 勝 數)	duo1bu2sheng4shu3
 (多 不 勝 數)	duo1bu2sheng4shu3
 (多 不 胜 数)	duo1bu2sheng4shu3
 (多 不 胜 数)	duo1bu2sheng4shu3
 (多 劳 多 得)	duo1lao2duo1de2
-(多 ㊘ 多 得)	duo1lao2duo1de2
 (多 勞 多 得)	duo1lao2duo1de2
 (多 勞 多 得)	duo1lao2duo1de2
 (多 子 多 孙)	duo1zi3duo1sun1
@@ -78643,54 +72962,32 @@ $textmode
 (大 不 列 蹀)	da4bu5lie5die5
 (大 不 列 蹀)	da4bu5lie5die5
 (大 中 学 生)	da4zhong1xue2sheng5
-(大 🀄 学 生)	da4zhong1xue2sheng5
-(大 中 ㊫ 生)	da4zhong1xue2sheng5
-(大 🀄 ㊫ 生)	da4zhong1xue2sheng5
-(大 ㊥ 学 生)	da4zhong1xue2sheng5
 (大 中 學 生)	da4zhong1xue2sheng5
-(大 🀄 學 生)	da4zhong1xue2sheng5
-(大 ㊥ 學 生)	da4zhong1xue2sheng5
 (大 发 牢 骚)	da4fa1lao2sao5
 (大 发 牢 骚)	da4fa1lao2sao5
 (大 可 一 試)	da4ke3yi2shi4
-(大 可 ㊀ 試)	da4ke3yi2shi4
 (大 可 一 试)	da4ke3yi2shi4
-(大 可 ㊀ 试)	da4ke3yi2shi4
 (大 可 不 必)	da4ke3bu2bi4
 (大 可 不 必)	da4ke3bu2bi4
 (大 吹 大 擂)	da4chui1da4lei2
 (大 喝 一 声)	da4he4yi4sheng1
-(大 喝 ㊀ 声)	da4he4yi4sheng1
 (大 喝 一 声)	da4he4yi4sheng1
-(大 喝 ㊀ 声)	da4he4yi4sheng1
 (大 喝 一 声)	da4he4yi4sheng1
-(大 喝 ㊀ 声)	da4he4yi4sheng1
 (大 喝 一 聲)	da4he4yi4sheng1
-(大 喝 ㊀ 聲)	da4he4yi4sheng1
 (大 喝 一 聲)	da4he4yi4sheng1
-(大 喝 ㊀ 聲)	da4he4yi4sheng1
 (大 喝 一 聲)	da4he4yi4sheng1
-(大 喝 ㊀ 聲)	da4he4yi4sheng1
 (大 干 一 场)	da4gan4yi4chang3
-(大 干 ㊀ 场)	da4gan4yi4chang3
 (大 干 一 票)	da4gan4yi2piao4
-(大 干 ㊀ 票)	da4gan4yi2piao4
 (大 幹 一 場)	da4gan4yi4chang3
-(大 幹 ㊀ 場)	da4gan4yi4chang3
 (大 幹 一 票)	da4gan4yi2piao4
-(大 幹 ㊀ 票)	da4gan4yi2piao4
 (大 戶 人 家)	da4hu4ren2jia1
 (大 户 人 家)	da4hu4ren2jia1
 (大 有 可 为)	da4you3ke3wei2
-(大 ㊒ 可 为)	da4you3ke3wei2
 (大 有 可 為)	da4you3ke3wei2
-(大 ㊒ 可 為)	da4you3ke3wei2
 (大 發 牢 騷)	da4fa1lao2sao5
 (大 發 牢 騷)	da4fa1lao2sao5
 (大 闹 一 场)	da4nao4yi4chang3
-(大 闹 ㊀ 场)	da4nao4yi4chang3
 (大 鬧 一 場)	da4nao4yi4chang3
-(大 鬧 ㊀ 場)	da4nao4yi4chang3
 (天 不 作 美)	tian1bu5zuo4mei3
 (天 不 作 美)	tian1bu5zuo4mei3
 (天 主 教 徒)	tian1zhu3jiao1tu2
@@ -78719,21 +73016,16 @@ $textmode
 (夷 为 平 地)	yi2wei2ping2di4
 (夷 為 平 地)	yi2wei2ping2di4
 (奄 奄 一 息)	yan3yan3yi4xi1
-(奄 奄 ㊀ 息)	yan3yan3yi4xi1
 (奄 奄 一 息)	yan3yan3yi4xi1
-(奄 奄 ㊀ 息)	yan3yan3yi4xi1
 (奉 承 討 好)	feng4cheng2tao3hao3
 (奉 承 讨 好)	feng4cheng2tao3hao3
 (奋 臂 一 呼)	fen4bi4yi4hu1
-(奋 臂 ㊀ 呼)	fen4bi4yi4hu1
 (奥 切 诺 斯)	ao4qie1nuo4si1
 (奥 切 诺 斯)	ao4qie1nuo4si1
 (奥 古 斯 都)	ao4gu3si1du1
 (奥 古 斯 都)	ao4gu3si1du1
 (奥 尼 西 慕)	ao4ni2xi1mu4
-(奥 尼 🀂 慕)	ao4ni2xi1mu4
 (奥 西 娜 斯)	ao4xi1na4si1
-(奥 🀂 娜 斯)	ao4xi1na4si1
 (奧 切 諾 斯)	ao4qie1nuo4si1
 (奧 切 諾 斯)	ao4qie1nuo4si1
 (奧 切 諾 斯)	ao4qie1nuo4si1
@@ -78741,11 +73033,8 @@ $textmode
 (奧 古 斯 都)	ao4gu3si1du1
 (奧 古 斯 都)	ao4gu3si1du1
 (奧 尼 西 慕)	ao4ni2xi1mu4
-(奧 尼 🀂 慕)	ao4ni2xi1mu4
 (奧 西 娜 斯)	ao4xi1na4si1
-(奧 🀂 娜 斯)	ao4xi1na4si1
 (奮 臂 一 呼)	fen4bi4yi4hu1
-(奮 臂 ㊀ 呼)	fen4bi4yi4hu1
 (她 得 不 到)	ta1de2bu5dao4
 (她 得 不 到)	ta1de2bu5dao4
 (她 得 不 着)	ta1de2bu5zhao2
@@ -78761,7 +73050,6 @@ $textmode
 (她 得 便 宜)	ta1de2pian2yi5
 (她 得 劲 儿)	ta1de2jin4r5
 (她 得 天 下)	ta1de2tian1xia4
-(她 得 天 ㊦)	ta1de2tian1xia4
 (她 得 数 儿)	ta1de2shu4r5
 (她 得 样 儿)	ta1de2yang4r5
 (她 得 樣 兒)	ta1de2yang4r5
@@ -78785,9 +73073,7 @@ $textmode
 (好 管 閑 事)	hao4guan3xian2shi4
 (好 管 闲 事)	hao4guan3xian2shi4
 (如 出 一 轍)	ru2chu1yi4zhe2
-(如 出 ㊀ 轍)	ru2chu1yi4zhe2
 (如 出 一 辙)	ru2chu1yi4zhe2
-(如 出 ㊀ 辙)	ru2chu1yi4zhe2
 (如 得 甘 露)	ru2de2gan1lu4
 (如 得 甘 露)	ru2de2gan1lu4
 (如 虎 得 翼)	ru2hu3de2yi4
@@ -78796,24 +73082,17 @@ $textmode
 (如 蠅 逐 臭)	ru2ying2zhu2chou4
 (如 蠅 逐 臭)	ru2ying2zhu2chou4
 (如 魚 得 水)	ru2yu2de2shui3
-(如 魚 得 ㊌)	ru2yu2de2shui3
 (如 鱼 得 水)	ru2yu2de2shui3
-(如 鱼 得 ㊌)	ru2yu2de2shui3
 (妄 自 菲 薄)	wang4zi4fei3bo2
 (威 信 扫 地)	wei1xin4sao3di4
 (威 信 掃 地)	wei1xin4sao3di4
 (威 凤 一 羽)	wei1feng4yi4yu3
-(威 凤 ㊀ 羽)	wei1feng4yi4yu3
 (威 凤 一 羽)	wei1feng4yi4yu3
-(威 凤 ㊀ 羽)	wei1feng4yi4yu3
 (威 鳳 一 羽)	wei1feng4yi4yu3
-(威 鳳 ㊀ 羽)	wei1feng4yi4yu3
 (威 鳳 一 羽)	wei1feng4yi4yu3
-(威 鳳 ㊀ 羽)	wei1feng4yi4yu3
 (嫁 禍 於 人)	jia4huo4yu2ren2
 (嫁 禍 於 人)	jia4huo4yu2ren2
 (嫣 然 一 笑)	yan1ran2yi2xiao4
-(嫣 然 ㊀ 笑)	yan1ran2yi2xiao4
 (子 子 孙 孙)	zi3zi3sun1sun1
 (子 子 孫 孫)	zi3zi3sun1sun1
 (子 母 炮 弹)	zi3mu3pao4dan4
@@ -78830,11 +73109,7 @@ $textmode
 (孤 儿 寡 妇)	gu1er2gua3fu4
 (孤 兒 寡 婦)	gu1er2gua3fu4
 (孤 注 一 掷)	gu1zhu4yi2zhi4
-(孤 注 ㊀ 掷)	gu1zhu4yi2zhi4
-(孤 ㊟ 一 掷)	gu1zhu4yi2zhi4
 (孤 注 一 擲)	gu1zhu4yi2zhi4
-(孤 注 ㊀ 擲)	gu1zhu4yi2zhi4
-(孤 ㊟ 一 擲)	gu1zhu4yi2zhi4
 (孫 子 定 理)	sun1zi5ding4li3
 (孫 子 定 理)	sun1zi5ding4li3
 (宁 死 不 屈)	ning4si3bu4qu1
@@ -78850,21 +73125,15 @@ $textmode
 (审 时 度 势)	shen3shi2duo2shi4
 (审 时 度 势)	shen3shi2duo2shi4
 (客 西 馬 尼)	ke4xi1ma3ni2
-(客 🀂 馬 尼)	ke4xi1ma3ni2
 (客 西 马 尼)	ke4xi1ma3ni2
-(客 🀂 马 尼)	ke4xi1ma3ni2
 (家 給 人 足)	jia1ji3ren2zu2
 (家 给 人 足)	jia1ji3ren2zu2
 (宽 心 丸 儿)	kuan1xin1wan2r5
 (宿 弊 一 清)	su4bi4yi4qing1
-(宿 弊 ㊀ 清)	su4bi4yi4qing1
 (密 密 麻 麻)	mi4mi5ma2ma2
 (密 西 拿 經)	mi4xi1na2jing1
-(密 🀂 拿 經)	mi4xi1na2jing1
 (密 西 拿 经)	mi4xi1na2jing1
-(密 🀂 拿 经)	mi4xi1na2jing1
 (密 西 西 比)	mi4xi1xi1bi3
-(密 🀂 🀂 比)	mi4xi1xi1bi3
 (寓 意 深 長)	yu4yi4shen1zhang3
 (寓 意 深 长)	yu4yi4shen1zhang3
 (察 微 知 著)	cha2wei1zhi1zhu4
@@ -78880,26 +73149,19 @@ $textmode
 (審 時 度 勢)	shen3shi2duo2shi4
 (審 時 度 勢)	shen3shi2duo2shi4
 (寻 思 一 计)	xin2si5yi2ji4
-(寻 思 ㊀ 计)	xin2si5yi2ji4
 (寻 欢 作 乐)	xun2huan1zuo4le4
 (專 心 一 志)	zhuan1xin1yi2zhi4
-(專 心 ㊀ 志)	zhuan1xin1yi2zhi4
 (尋 思 一 計)	xin2si5yi2ji4
-(尋 思 ㊀ 計)	xin2si5yi2ji4
 (尋 歡 作 樂)	xun2huan1zuo4le4
 (尋 歡 作 樂)	xun2huan1zuo4le4
 (尋 歡 作 樂)	xun2huan1zuo4le4
 (尋 歡 作 樂)	xun2huan1zuo4le4
 (小 一 会 儿)	xiao3yi4hui3r5
-(小 ㊀ 会 儿)	xiao3yi4hui3r5
 (小 一 會 兒)	xiao3yi4hui3r5
-(小 ㊀ 會 兒)	xiao3yi4hui3r5
 (小 不 点 儿)	xiao3bu5dian3r5
 (小 不 点 儿)	xiao3bu5dian3r5
 (小 事 一 桩)	xiao3shi4yi4zhuang1
-(小 事 ㊀ 桩)	xiao3shi4yi4zhuang1
 (小 事 一 樁)	xiao3shi4yi4zhuang1
-(小 事 ㊀ 樁)	xiao3shi4yi4zhuang1
 (小 兒 麻 痺)	xiao3er2ma2bi4
 (小 时 候 儿)	xiao3shi2hou5r5
 (小 白 脸 儿)	xiao3bai2lian3r5
@@ -78907,35 +73169,25 @@ $textmode
 (小 紅 蘿 蔔)	xiao3hong2luo2bo5
 (小 红 萝 蔔)	xiao3hong2luo2bo5
 (小 菜 一 碟)	xiao3cai4yi4die2
-(小 菜 ㊀ 碟)	xiao3cai4yi4die2
 (小 西 葫 芦)	xiao3xi1hu2lu2
-(小 🀂 葫 芦)	xiao3xi1hu2lu2
 (小 西 葫 蘆)	xiao3xi1hu2lu2
-(小 🀂 葫 蘆)	xiao3xi1hu2lu2
 (小 西 葫 蘆)	xiao3xi1hu2lu2
-(小 🀂 葫 蘆)	xiao3xi1hu2lu2
 (少 劳 少 得)	shao3lao2shao3de2
-(少 ㊘ 少 得)	shao3lao2shao3de2
 (少 勞 少 得)	shao3lao2shao3de2
 (少 勞 少 得)	shao3lao2shao3de2
 (尝 鼎 一 脔)	chang2ding3yi4luan2
-(尝 鼎 ㊀ 脔)	chang2ding3yi4luan2
 (尤 利 西 斯)	you2li4xi1si1
-(尤 利 🀂 斯)	you2li4xi1si1
 (尤 利 西 斯)	you2li4xi1si1
-(尤 利 🀂 斯)	you2li4xi1si1
 (尽 力 而 为)	jin4li4er2wei2
 (尽 力 而 为)	jin4li4er2wei2
 (尽 欢 而 散)	jin4huan1er2san4
 (屠 格 涅 夫)	tu2ge2nie4fu1
 (山 窮 水 盡)	shan1qiong2shui3jin4
-(山 窮 ㊌ 盡)	shan1qiong2shui3jin4
 (崭 露 头 角)	zhan3lu4tou2jiao3
 (崭 露 头 角)	zhan3lu4tou2jiao3
 (嶄 露 頭 角)	zhan3lu4tou2jiao3
 (嶄 露 頭 角)	zhan3lu4tou2jiao3
 (差 一 点 儿)	cha1yi4dian3r5
-(差 ㊀ 点 儿)	cha1yi4dian3r5
 (差 不 点 儿)	cha4bu5dian3r5
 (差 不 点 儿)	cha4bu5dian3r5
 (差 不 离 儿)	cha4bu5li2r5
@@ -78947,11 +73199,7 @@ $textmode
 (已 得 代 价)	yi3de2dai4jia4
 (已 得 代 價)	yi3de2dai4jia4
 (巴 三 覽 四)	ba1san1lan3si4
-(巴 ㊂ 覽 四)	ba1san1lan3si4
-(巴 三 覽 ㊃)	ba1san1lan3si4
 (巴 三 览 四)	ba1san1lan3si4
-(巴 ㊂ 览 四)	ba1san1lan3si4
-(巴 三 览 ㊃)	ba1san1lan3si4
 (巴 不 能 够)	ba1bu4neng2gou4
 (巴 不 能 够)	ba1bu4neng2gou4
 (巴 不 能 夠)	ba1bu4neng2gou4
@@ -78963,14 +73211,11 @@ $textmode
 (巴 伦 支 海)	ba1lun2zhi1hai3
 (巴 伦 支 海)	ba1lun2zhi1hai3
 (巴 伦 西 亚)	ba1lun2xi1ya4
-(巴 伦 🀂 亚)	ba1lun2xi1ya4
 (巴 倫 支 海)	ba1lun2zhi1hai3
 (巴 倫 支 海)	ba1lun2zhi1hai3
 (巴 倫 支 海)	ba1lun2zhi1hai3
 (巴 倫 西 亞)	ba1lun2xi1ya4
-(巴 倫 🀂 亞)	ba1lun2xi1ya4
 (巴 倫 西 亞)	ba1lun2xi1ya4
-(巴 倫 🀂 亞)	ba1lun2xi1ya4
 (巴 克 夏 猪)	ba1ke4xia4zhu1
 (巴 克 夏 猪)	ba1ke4xia4zhu1
 (巴 克 夏 猪)	ba1ke4xia4zhu1
@@ -78979,9 +73224,7 @@ $textmode
 (巴 前 算 后)	ba1qian2suan4hou4
 (巴 前 算 後)	ba1qian2suan4hou4
 (巴 力 西 卜)	ba1li4xi1bu3
-(巴 力 🀂 卜)	ba1li4xi1bu3
 (巴 力 西 卜)	ba1li4xi1bu3
-(巴 力 🀂 卜)	ba1li4xi1bu3
 (巴 哈 摩 押)	ba1ha1mo2ya1
 (巴 哈 魯 米)	ba1ha1lu3mi3
 (巴 哈 魯 米)	ba1ha1lu3mi3
@@ -79005,20 +73248,14 @@ $textmode
 (巴 施 户 珥)	ba1shi1hu4er3
 (巴 爾 的 摩)	ba1er3di4mo2
 (巴 答 一 声)	ba1da1yi4sheng1
-(巴 答 ㊀ 声)	ba1da1yi4sheng1
 (巴 答 一 聲)	ba1da1yi4sheng1
-(巴 答 ㊀ 聲)	ba1da1yi4sheng1
 (巴 耶 利 巴)	ba1ye1li4ba1
 (巴 耶 利 巴)	ba1ye1li4ba1
 (巴 頭 探 腦)	ba1tou2tan4nao3
 (巴 高 望 上)	ba1gao1wang4shang4
-(巴 高 望 ㊤)	ba1gao1wang4shang4
 (巴 高 望 上)	ba1gao1wang4shang4
-(巴 高 望 ㊤)	ba1gao1wang4shang4
 (布 林 迪 西)	bu4lin2di2xi1
-(布 林 迪 🀂)	bu4lin2di2xi1
 (布 林 迪 西)	bu4lin2di2xi1
-(布 林 迪 🀂)	bu4lin2di2xi1
 (布 琼 布 拉)	bu4qiong2bu4la5
 (布 琼 布 拉)	bu4qiong2bu4la5
 (布 瓊 布 拉)	bu4qiong2bu4la5
@@ -79033,24 +73270,15 @@ $textmode
 (布 鲁 塞 尔)	bu4lu3sai4er3
 (布 鲁 塞 尔)	bu4lu3sai4er3
 (帕 尼 巴 特)	pa4ni2pa1te4
-(帕 尼 巴 ㊕)	pa4ni2pa1te4
 (干 得 过 儿)	gan4de5guo4r5
 (平 一 宇 內)	ping2yi4yu3nei4
-(平 ㊀ 宇 內)	ping2yi4yu3nei4
 (平 一 宇 内)	ping2yi4yu3nei4
-(平 ㊀ 宇 内)	ping2yi4yu3nei4
 (年 長 日 久)	nian2chang2ri4jiu3
-(年 長 ㊐ 久)	nian2chang2ri4jiu3
 (年 長 日 久)	nian2chang2ri4jiu3
-(年 長 ㊐ 久)	nian2chang2ri4jiu3
 (年 长 日 久)	nian2chang2ri4jiu3
-(年 长 ㊐ 久)	nian2chang2ri4jiu3
 (年 长 日 久)	nian2chang2ri4jiu3
-(年 长 ㊐ 久)	nian2chang2ri4jiu3
 (幸 免 一 死)	xing4mian3yi4si3
-(幸 免 ㊀ 死)	xing4mian3yi4si3
 (幸 免 一 死)	xing4mian3yi4si3
-(幸 免 ㊀ 死)	xing4mian3yi4si3
 (幸 免 于 难)	xing4mian3yu2nan4
 (幸 免 于 难)	xing4mian3yu2nan4
 (幸 免 於 難)	xing4mian3yu2nan4
@@ -79059,7 +73287,6 @@ $textmode
 (幸 免 於 難)	xing4mian3yu2nan4
 (应 付 帐 款)	ying1fu4zhang4kuan3
 (应 县 木 塔)	ying4xian4mu4ta3
-(应 县 ㊍ 塔)	ying4xian4mu4ta3
 (应 许 之 地)	ying1xu3zhi1di4
 (应 试 教 育)	ying4shi4jiao4yu4
 (应 运 而 生)	ying4yun4er2sheng1
@@ -79086,13 +73313,11 @@ $textmode
 (強 詞 奪 理)	qiang3ci2duo2li3
 (弹 冠 相 庆)	tan2guan1xiang1qing4
 (弹 指 一 挥)	tan2zhi3yi4hui1
-(弹 指 ㊀ 挥)	tan2zhi3yi4hui1
 (弹 指 可 得)	tan2zhi3ke3de2
 (强 词 夺 理)	qiang3ci2duo2li3
 (强 词 夺 理)	qiang3ci2duo2li3
 (彈 冠 相 慶)	tan2guan1xiang1qing4
 (彈 指 一 揮)	tan2zhi3yi4hui1
-(彈 指 ㊀ 揮)	tan2zhi3yi4hui1
 (彈 指 可 得)	tan2zhi3ke3de2
 (彈 盡 援 絕)	dan4jin4yuan2jue2
 (彈 盡 糧 絕)	dan4jin4liang2jue2
@@ -79101,7 +73326,6 @@ $textmode
 (当 务 之 急)	dang1wu4zhi1ji2
 (当 回 事 儿)	dang4hui2shi4r5
 (当 头 一 棒)	dang1tou2yi2bang4
-(当 头 ㊀ 棒)	dang1tou2yi2bang4
 (形 容 不 出)	xing2rong2bu5chu1
 (形 容 不 出)	xing2rong2bu5chu1
 (彰 善 瘅 恶)	zhang1shan4dan4e4
@@ -79118,15 +73342,9 @@ $textmode
 (往 泥 里 踩)	wang3ni4li3cai3
 (往 泥 里 踩)	wang3ni4li3cai3
 (得 一 望 二)	de2yi2wang4er4
-(得 ㊀ 望 二)	de2yi2wang4er4
-(得 一 望 ㊁)	de2yi2wang4er4
 (得 一 望 二)	de2yi2wang4er4
-(得 ㊀ 望 二)	de2yi2wang4er4
-(得 一 望 ㊁)	de2yi2wang4er4
 (得 一 枝 栖)	de2yi4zhi1qi1
-(得 ㊀ 枝 栖)	de2yi4zhi1qi1
 (得 一 枝 棲)	de2yi4zhi1qi1
-(得 ㊀ 枝 棲)	de2yi4zhi1qi1
 (得 不 偿 失)	de2bu4chang2shi1
 (得 不 偿 失)	de2bu4chang2shi1
 (得 不 償 失)	de2bu4chang2shi1
@@ -79159,17 +73377,14 @@ $textmode
 (得 新 厌 旧)	de2xin1yan4jiu4
 (得 新 厭 舊)	de2xin1yan4jiu4
 (得 未 曾 有)	de2wei4ceng2you3
-(得 未 曾 ㊒)	de2wei4ceng2you3
 (得 此 失 彼)	de2ci3shi1bi3
 (得 步 进 步)	de2bu4jin4bu4
 (得 步 進 步)	de2bu4jin4bu4
 (得 窥 一 斑)	de2kui1yi4ban1
-(得 窥 ㊀ 斑)	de2kui1yi4ban1
 (得 窥 全 豹)	de2kui1quan2bao4
 (得 窥 全 豹)	de2kui1quan2bao4
 (得 窥 门 径)	de2kui1men2jing4
 (得 窺 一 斑)	de2kui1yi4ban1
-(得 窺 ㊀ 斑)	de2kui1yi4ban1
 (得 窺 全 豹)	de2kui1quan2bao4
 (得 窺 全 豹)	de2kui1quan2bao4
 (得 窺 門 徑)	de2kui1men2jing4
@@ -79198,14 +73413,11 @@ $textmode
 (得 魚 忘 筌)	de2yu2wang4quan2
 (得 鱼 忘 筌)	de2yu2wang4quan2
 (從 一 而 終)	cong2yi4er2zhong1
-(從 ㊀ 而 終)	cong2yi4er2zhong1
 (從 那 時 侯)	cong2na4shi2hou4
 (循 規 蹈 矩)	xun2gui1dao3ju3
 (循 规 蹈 矩)	xun2gui1dao3ju3
 (微 微 一 笑)	wei1wei1yi2xiao4
-(微 微 ㊀ 笑)	wei1wei1yi2xiao4
 (徵 名 責 實)	zheng1ming2ze2shi2
-(徵 ㊔ 責 實)	zheng1ming2ze2shi2
 (德 勒 巴 克)	de2le4ba1ke4
 (德 勒 巴 克)	de2le4ba1ke4
 (德 薄 能 鮮)	de2bo2neng2xian3
@@ -79215,17 +73427,11 @@ $textmode
 (心 宽 体 胖)	xin1kuan1ti3pan2
 (心 寬 體 胖)	xin1kuan1ti3pan2
 (心 急 火 燎)	xin1ji2huo3liao3
-(心 急 ㊋ 燎)	xin1ji2huo3liao3
 (心 急 火 燎)	xin1ji2huo3liao3
-(心 急 ㊋ 燎)	xin1ji2huo3liao3
 (心 生 一 計)	xin1sheng1yi2ji4
-(心 生 ㊀ 計)	xin1sheng1yi2ji4
 (心 生 一 计)	xin1sheng1yi2ji4
-(心 生 ㊀ 计)	xin1sheng1yi2ji4
 (心 裡 一 愣)	xin1li3yi2leng4
-(心 裡 ㊀ 愣)	xin1li3yi2leng4
 (心 裡 一 愣)	xin1li3yi2leng4
-(心 裡 ㊀ 愣)	xin1li3yi2leng4
 (心 裡 悲 痛)	xin1li3bei1tong4
 (心 裡 悲 痛)	xin1li3bei1tong4
 (心 裡 明 白)	xin1li3ming2bai5
@@ -79237,9 +73443,7 @@ $textmode
 (心 裡 難 過)	xin1li3nan2guo4
 (心 裡 難 過)	xin1li3nan2guo4
 (心 里 一 愣)	xin1li3yi2leng4
-(心 里 ㊀ 愣)	xin1li3yi2leng4
 (心 里 一 愣)	xin1li3yi2leng4
-(心 里 ㊀ 愣)	xin1li3yi2leng4
 (心 里 悲 痛)	xin1li3bei1tong4
 (心 里 悲 痛)	xin1li3bei1tong4
 (心 里 明 白)	xin1li3ming2bai5
@@ -79299,8 +73503,6 @@ $textmode
 (恰 如 其 分)	qia4ru2qi2fen4
 (恶 恶 实 实)	e4e5shi1shi1
 (恶 意 中 伤)	e4yi4zhong1shang1
-(恶 意 🀄 伤)	e4yi4zhong1shang1
-(恶 意 ㊥ 伤)	e4yi4zhong1shang1
 (患 得 患 失)	huan4de2huan4shi1
 (悲 欢 离 合)	bei1huan1li2he2
 (悲 歡 離 合)	bei1huan1li2he2
@@ -79311,13 +73513,8 @@ $textmode
 (惡 惡 實 實)	e4e5shi1shi1
 (惡 惡 實 實)	e4e5shi1shi1
 (惡 意 中 傷)	e4yi4zhong1shang1
-(惡 意 🀄 傷)	e4yi4zhong1shang1
-(惡 意 ㊥ 傷)	e4yi4zhong1shang1
 (惡 意 中 傷)	e4yi4zhong1shang1
-(惡 意 🀄 傷)	e4yi4zhong1shang1
-(惡 意 ㊥ 傷)	e4yi4zhong1shang1
 (惩 一 警 百)	cheng2yi4jing3bai3
-(惩 ㊀ 警 百)	cheng2yi4jing3bai3
 (想 不 清 楚)	xiang3bu5qing1chu3
 (想 不 清 楚)	xiang3bu5qing1chu3
 (想 像 得 到)	xiang3xiang4de5dao4
@@ -79325,11 +73522,8 @@ $textmode
 (想 得 出 神)	xiang3de5chu1shen2
 (意 猶 未 盡)	yi4you2wei4jin4
 (意 見 一 致)	yi4jian4yi2zhi4
-(意 見 ㊀ 致)	yi4jian4yi2zhi4
 (意 見 一 致)	yi4jian4yi2zhi4
-(意 見 ㊀ 致)	yi4jian4yi2zhi4
 (意 见 一 致)	yi4jian4yi2zhi4
-(意 见 ㊀ 致)	yi4jian4yi2zhi4
 (愛 人 如 己)	ai4ren2ru2ji3
 (愛 樂 樂 團)	ai4yue4yue4tuan2
 (愛 樂 樂 團)	ai4yue4yue4tuan2
@@ -79347,18 +73541,13 @@ $textmode
 (憨 不 楞 登)	han1bu5leng2deng1
 (應 付 帳 款)	ying1fu4zhang4kuan3
 (應 有 盡 有)	ying1you3jin4you3
-(應 ㊒ 盡 ㊒)	ying1you3jin4you3
 (應 縣 木 塔)	ying4xian4mu4ta3
-(應 縣 ㊍ 塔)	ying4xian4mu4ta3
 (應 許 之 地)	ying1xu3zhi1di4
 (應 試 教 育)	ying4shi4jiao4yu4
 (應 運 而 生)	ying4yun4er2sheng1
 (懲 一 警 百)	cheng2yi4jing3bai3
-(懲 ㊀ 警 百)	cheng2yi4jing3bai3
 (懲 一 警 百)	cheng2yi4jing3bai3
-(懲 ㊀ 警 百)	cheng2yi4jing3bai3
 (懲 一 警 百)	cheng2yi4jing3bai3
-(懲 ㊀ 警 百)	cheng2yi4jing3bai3
 (成 吉 思 汗)	cheng2ji2si1han2
 (我 得 不 到)	wo3de2bu5dao4
 (我 得 不 到)	wo3de2bu5dao4
@@ -79375,7 +73564,6 @@ $textmode
 (我 得 便 宜)	wo3de2pian2yi5
 (我 得 劲 儿)	wo3de2jin4r5
 (我 得 天 下)	wo3de2tian1xia4
-(我 得 天 ㊦)	wo3de2tian1xia4
 (我 得 数 儿)	wo3de2shu4r5
 (我 得 样 儿)	wo3de2yang4r5
 (我 得 樣 兒)	wo3de2yang4r5
@@ -79395,9 +73583,7 @@ $textmode
 (扁 形 动 物)	pian1xing2dong4wu4
 (扁 形 動 物)	pian1xing2dong4wu4
 (扁 袒 一 方)	pian1tan3yi4fang1
-(扁 袒 ㊀ 方)	pian1tan3yi4fang1
 (手 写 辩 识)	shou3xie3bian4shi2
-(手 ㊢ 辩 识)	shou3xie3bian4shi2
 (手 寫 辯 識)	shou3xie3bian4shi2
 (手 寫 辯 識)	shou3xie3bian4shi2
 (扎 尔 达 里)	za1er3da2li3
@@ -79412,16 +73598,11 @@ $textmode
 (扎 爾 達 里)	za1er3da2li3
 (扎 爾 達 里)	za1er3da2li3
 (扎 魯 特 旗)	za1lu3te4qi2
-(扎 魯 ㊕ 旗)	za1lu3te4qi2
 (扎 魯 特 旗)	za1lu3te4qi2
-(扎 魯 ㊕ 旗)	za1lu3te4qi2
 (扎 鲁 特 旗)	za1lu3te4qi2
-(扎 鲁 ㊕ 旗)	za1lu3te4qi2
 (扑 哧 一 笑)	pu1chi1yi2xiao4
-(扑 哧 ㊀ 笑)	pu1chi1yi2xiao4
 (打 家 劫 舍)	da3jia1jie2she4
 (扛 在 肩 上)	kang2zai4jian1shang4
-(扛 在 肩 ㊤)	kang2zai4jian1shang4
 (扭 扭 捏 捏)	niu3niu5nie1nie1
 (扳 不 倒 儿)	ban1bu5dao3r5
 (扳 不 倒 儿)	ban1bu5dao3r5
@@ -79453,17 +73634,11 @@ $textmode
 (抛 头 露 面)	pao1tou2lu4mian4
 (抛 头 露 面)	pao1tou2lu4mian4
 (报 以 一 笑)	bao4yi3yi2xiao4
-(报 以 ㊀ 笑)	bao4yi3yi2xiao4
 (披 头 散 发)	pi1tou2san4fa4
 (抬 头 一 看)	tai2tou2yi2kan4
-(抬 头 ㊀ 看)	tai2tou2yi2kan4
 (抬 頭 一 看)	tai2tou2yi2kan4
-(抬 頭 ㊀ 看)	tai2tou2yi2kan4
 (拆 东 补 西)	chai1dong1bu3xi1
-(拆 东 补 🀂)	chai1dong1bu3xi1
-(拆 🀀 补 西)	chai1dong1bu3xi1
 (拆 東 補 西)	chai1dong1bu3xi1
-(拆 東 補 🀂)	chai1dong1bu3xi1
 (拉 不 出 來)	la1bu5chu1lai5
 (拉 不 出 來)	la1bu5chu1lai5
 (拉 不 出 來)	la1bu5chu1lai5
@@ -79479,31 +73654,23 @@ $textmode
 (拉 夫 羅 夫)	la1fu1luo2fu1
 (拉 夫 羅 夫)	la1fu1luo2fu1
 (拉 美 西 斯)	la1mei3xi1si1
-(拉 美 🀂 斯)	la1mei3xi1si1
 (拉 美 西 斯)	la1mei3xi1si1
-(拉 美 🀂 斯)	la1mei3xi1si1
 (拋 頭 露 面)	pao1tou2lu4mian4
 (拋 頭 露 面)	pao1tou2lu4mian4
 (拐 弯 抹 角)	guai3wan1mo4jiao3
 (拐 彎 抹 角)	guai3wan1mo4jiao3
 (拔 十 得 五)	ba2shi2de2wu3
-(拔 ㊉ 得 五)	ba2shi2de2wu3
-(拔 十 得 ㊄)	ba2shi2de2wu3
 (拔 得 头 筹)	ba2de2tou2chou2
 (拔 得 頭 籌)	ba2de2tou2chou2
 (拔 火 罐 儿)	ba2huo3guan4r5
-(拔 ㊋ 罐 儿)	ba2huo3guan4r5
 (拖 兒 帶 女)	tuo1er2dai4nv3
-(拖 兒 帶 ㊛)	tuo1er2dai4nv3
 (拖 兒 帶 女)	tuo1er2dai4nv3
 (招 揽 生 意)	zhao1lan3sheng1yi4
 (招 攬 生 意)	zhao1lan3sheng1yi4
 (拟 古 之 作)	ni3gu3zhi4zuo4
 (拣 佛 烧 香)	jian3fo2shao1xiang1
 (择 一 假 设)	ze2yi4jia3she4
-(择 ㊀ 假 设)	ze2yi4jia3she4
 (择 一 成 本)	ze2yi4cheng2ben3
-(择 ㊀ 成 本)	ze2yi4cheng2ben3
 (拳 头 产 品)	quan2tou2chan3pin3
 (拳 頭 產 品)	quan2tou2chan3pin3
 (拴 不 住 心)	shuan1bu5zhu4xin1
@@ -79513,12 +73680,9 @@ $textmode
 (拾 人 牙 慧)	shi2ren2ya2hui4
 (拾 人 牙 慧)	shi2ren2ya2hui4
 (拾 金 不 昧)	shi2jin1bu2mei4
-(拾 ㊎ 不 昧)	shi2jin1bu2mei4
 (拾 金 不 昧)	shi2jin1bu2mei4
 (拾 金 不 昧)	shi2jin1bu2mei4
-(拾 ㊎ 不 昧)	shi2jin1bu2mei4
 (拾 金 不 昧)	shi2jin1bu2mei4
-(拾 ㊎ 不 昧)	shi2jin1bu2mei4
 (拿 不 好 調)	na2bu5hao3diao4
 (拿 不 好 調)	na2bu5hao3diao4
 (拿 不 好 調)	na2bu5hao3diao4
@@ -79531,15 +73695,10 @@ $textmode
 (拿 不 起 来)	na2bu5qi3lai5
 (拿 定 主 意)	na2ding4zhu3yi4
 (挂 一 漏 万)	gua4yi2lou4wan4
-(挂 ㊀ 漏 万)	gua4yi2lou4wan4
 (挂 一 漏 万)	gua4yi2lou4wan4
-(挂 ㊀ 漏 万)	gua4yi2lou4wan4
 (挂 在 嘴 上)	gua4zai5zui3shang5
-(挂 在 嘴 ㊤)	gua4zai5zui3shang5
 (指 令 名 字)	zhi3ling4ming2zi4
-(指 令 ㊔ 字)	zhi3ling4ming2zi4
 (指 令 名 字)	zhi3ling4ming2zi4
-(指 令 ㊔ 字)	zhi3ling4ming2zi4
 (指 手 划 脚)	zhi3shou3hua2jiao3
 (指 手 划 腳)	zhi3shou3hua2jiao3
 (指 鹿 为 马)	zhi3lu4wei2ma3
@@ -79549,26 +73708,18 @@ $textmode
 (按 捺 不 住)	an4na4bu5zhu4
 (按 捺 不 住)	an4na4bu5zhu4
 (挑 三 窝 四)	tiao3san1wo1si4
-(挑 ㊂ 窝 四)	tiao3san1wo1si4
-(挑 三 窝 ㊃)	tiao3san1wo1si4
 (挑 三 窩 四)	tiao3san1wo1si4
-(挑 ㊂ 窩 四)	tiao3san1wo1si4
-(挑 三 窩 ㊃)	tiao3san1wo1si4
 (振 作 精 神)	zhen4zuo4jing1shen5
 (振 作 精 神)	zhen4zuo4jing1shen5
 (振 作 精 神)	zhen4zuo4jing1shen5
 (振 臂 一 呼)	zhen4bi4yi4hu1
-(振 臂 ㊀ 呼)	zhen4bi4yi4hu1
 (捏 脊 治 疗)	nie1ji3zhi4liao2
 (捏 脊 治 療)	nie1ji3zhi4liao2
 (捏 脊 治 療)	nie1ji3zhi4liao2
 (捧 人 一 场)	peng3ren2yi4chang3
-(捧 人 ㊀ 场)	peng3ren2yi4chang3
 (捧 人 一 場)	peng3ren2yi4chang3
-(捧 人 ㊀ 場)	peng3ren2yi4chang3
 (捨 己 為 人)	she3ji3wei4ren2
 (据 为 己 有)	ju4wei2ji3you3
-(据 为 己 ㊒)	ju4wei2ji3you3
 (捷 足 先 得)	jie2zu2xian1de2
 (掀 不 开 锅)	xian1bu5kai1guo1
 (掀 不 开 锅)	xian1bu5kai1guo1
@@ -79582,18 +73733,13 @@ $textmode
 (排 難 解 紛)	pai2nan4jie3fen1
 (排 難 解 紛)	pai2nan4jie3fen1
 (掛 一 漏 萬)	gua4yi2lou4wan4
-(掛 ㊀ 漏 萬)	gua4yi2lou4wan4
 (掛 一 漏 萬)	gua4yi2lou4wan4
-(掛 ㊀ 漏 萬)	gua4yi2lou4wan4
 (掛 在 嘴 上)	gua4zai5zui3shang5
-(掛 在 嘴 ㊤)	gua4zai5zui3shang5
 (探 驪 得 珠)	tan4li2de2zhu1
 (探 驪 得 珠)	tan4li2de2zhu1
 (探 骊 得 珠)	tan4li2de2zhu1
 (推 一 知 万)	tui1yi4zhi1wan4
-(推 ㊀ 知 万)	tui1yi4zhi1wan4
 (推 一 知 萬)	tui1yi4zhi1wan4
-(推 ㊀ 知 萬)	tui1yi4zhi1wan4
 (推 不 知 情)	tui1bu5zhi1qing2
 (推 不 知 情)	tui1bu5zhi1qing2
 (揀 佛 燒 香)	jian3fo2shao1xiang1
@@ -79603,11 +73749,8 @@ $textmode
 (提 不 起 来)	ti2bu5qi3lai5
 (提 不 起 来)	ti2bu5qi3lai5
 (插 一 杠 子)	cha1yi2gang4zi5
-(插 ㊀ 杠 子)	cha1yi2gang4zi5
 (插 不 上 嘴)	cha1bu5shang4zui3
-(插 不 ㊤ 嘴)	cha1bu5shang4zui3
 (插 不 上 嘴)	cha1bu5shang4zui3
-(插 不 ㊤ 嘴)	cha1bu5shang4zui3
 (揣 在 怀 里)	chuai1zai4huai2li5
 (揣 在 怀 里)	chuai1zai4huai2li5
 (揣 在 懷 裡)	chuai1zai4huai2li5
@@ -79622,26 +73765,18 @@ $textmode
 (搋 在 懷 裡)	chuai1zai4huai2li5
 (搖 搖 晃 晃)	yao2yao2huang4huang4
 (搖 身 一 變)	yao2shen1yi2bian4
-(搖 身 ㊀ 變)	yao2shen1yi2bian4
 (搖 身 一 變)	yao2shen1yi2bian4
-(搖 身 ㊀ 變)	yao2shen1yi2bian4
 (搪 不 过 去)	tang2bu5guo4qu5
 (搪 不 过 去)	tang2bu5guo4qu5
 (搪 不 過 去)	tang2bu5guo4qu5
 (搪 不 過 去)	tang2bu5guo4qu5
 (摇 摇 晃 晃)	yao2yao2huang4huang4
 (摇 身 一 变)	yao2shen1yi2bian4
-(摇 身 ㊀ 变)	yao2shen1yi2bian4
 (摽 在 一 起)	biao4zai4yi4qi3
-(摽 在 ㊀ 起)	biao4zai4yi4qi3
 (撐 不 下 去)	cheng1bu5xia4qu5
-(撐 不 ㊦ 去)	cheng1bu5xia4qu5
 (撐 不 下 去)	cheng1bu5xia4qu5
-(撐 不 ㊦ 去)	cheng1bu5xia4qu5
 (撑 不 下 去)	cheng1bu5xia4qu5
-(撑 不 ㊦ 去)	cheng1bu5xia4qu5
 (撑 不 下 去)	cheng1bu5xia4qu5
-(撑 不 ㊦ 去)	cheng1bu5xia4qu5
 (撒 巴 第 业)	sa1ba1di4ye4
 (撒 巴 第 業)	sa1ba1di4ye4
 (撒 都 該 人)	sa1du1gai1ren2
@@ -79651,19 +73786,14 @@ $textmode
 (撒 马 尔 干)	sa1ma3er3gan4
 (撩 是 生 非)	liao2shi4sheng1fei1
 (撲 哧 一 笑)	pu1chi1yi2xiao4
-(撲 哧 ㊀ 笑)	pu1chi1yi2xiao4
 (擇 一 假 設)	ze2yi4jia3she4
-(擇 ㊀ 假 設)	ze2yi4jia3she4
 (擇 一 成 本)	ze2yi4cheng2ben3
-(擇 ㊀ 成 本)	ze2yi4cheng2ben3
 (據 為 己 有)	ju4wei2ji3you3
-(據 為 己 ㊒)	ju4wei2ji3you3
 (擬 古 之 作)	ni3gu3zhi4zuo4
 (擬 於 不 倫)	ni3yu2bu4lun2
 (擬 於 不 倫)	ni3yu2bu4lun2
 (擬 於 不 倫)	ni3yu2bu4lun2
 (攮 人 一 刀)	nang3ren2yi4dao1
-(攮 人 ㊀ 刀)	nang3ren2yi4dao1
 (支 付 得 起)	zhi1fu4de2qi3
 (支 吾 其 詞)	zhi1wu5qi2ci2
 (支 吾 其 词)	zhi1wu5qi2ci2
@@ -79681,9 +73811,7 @@ $textmode
 (改 變 主 意)	gai3bian4zhu3yi4
 (改 變 主 意)	gai3bian4zhu3yi4
 (放 下 架 子)	fang4xia4jia4zi5
-(放 ㊦ 架 子)	fang4xia4jia4zi5
 (放 手 一 搏)	fang4shou3yi4bo2
-(放 手 ㊀ 搏)	fang4shou3yi4bo2
 (故 地 重 游)	gu4di4chong2you2
 (故 地 重 遊)	gu4di4chong2you2
 (敗 不 成 軍)	bai4bu5cheng2jun1
@@ -79691,7 +73819,6 @@ $textmode
 (敗 子 回 頭)	bai4zi3hui2tou2
 (教 授 得 法)	jiao1shou4de2fa3
 (敝 帚 千 金)	bi4zhou3qian1jin1
-(敝 帚 千 ㊎)	bi4zhou3qian1jin1
 (敝 帚 千 金)	bi4zhou3qian1jin1
 (敝 帚 自 珍)	bi4zhou3zi4zhen1
 (数 不 胜 数)	shu3bu2sheng4shu3
@@ -79713,94 +73840,54 @@ $textmode
 (數 理 邏 輯)	shu4li3luo2ji2
 (數 理 邏 輯)	shu4li3luo2ji2
 (斗 南 一 人)	dou3nan2yi4ren2
-(斗 🀁 一 人)	dou3nan2yi4ren2
-(斗 南 ㊀ 人)	dou3nan2yi4ren2
-(斗 🀁 ㊀ 人)	dou3nan2yi4ren2
 (斗 筲 之 人)	dou3shao1zhi1ren2
 (斗 酒 只 鸡)	dou3jiu3zhi1ji1
 (斗 酒 隻 雞)	dou3jiu3zhi1ji1
 (斜 眼 一 瞟)	xie2yan3yi4piao3
-(斜 眼 ㊀ 瞟)	xie2yan3yi4piao3
 (斜 紋 軟 呢)	xie2wen2ruan3ni2
 (斜 纹 软 呢)	xie2wen2ruan3ni2
 (斯 科 普 裡)	si1ke1pu3li3
 (斯 科 普 裡)	si1ke1pu3li3
 (新 华 日 报)	xing1hua2ri4bao4
-(新 华 ㊐ 报)	xing1hua2ri4bao4
 (新 天 新 地)	xin1tian1xin1di4
 (新 斯 科 舍)	xin1si1ke1she4
 (新 華 日 報)	xing1hua2ri4bao4
-(新 華 ㊐ 報)	xing1hua2ri4bao4
 (新 華 日 報)	xing1hua2ri4bao4
-(新 華 ㊐ 報)	xing1hua2ri4bao4
 (方 兴 未 艾)	fang1xing1wei4ai4
 (方 興 未 艾)	fang1xing1wei4ai4
 (於 事 無 補)	yu2shi4wu2bu3
 (旋 得 旋 失)	xuan2de2xuan2shi1
 (无 一 不 备)	wu2yi2bu2bei4
-(无 ㊀ 不 备)	wu2yi2bu2bei4
 (无 一 不 备)	wu2yi2bu2bei4
-(无 ㊀ 不 备)	wu2yi2bu2bei4
 (无 一 不 精)	wu2yi2bu4jing1
-(无 ㊀ 不 精)	wu2yi2bu4jing1
 (无 一 不 精)	wu2yi2bu4jing1
-(无 ㊀ 不 精)	wu2yi2bu4jing1
 (无 一 不 精)	wu2yi2bu4jing1
-(无 ㊀ 不 精)	wu2yi2bu4jing1
 (无 一 不 能)	wu2yi2bu4neng2
-(无 ㊀ 不 能)	wu2yi2bu4neng2
 (无 一 不 能)	wu2yi2bu4neng2
-(无 ㊀ 不 能)	wu2yi2bu4neng2
 (无 一 不 通)	wu2yi2bu4tong1
-(无 ㊀ 不 通)	wu2yi2bu4tong1
 (无 一 不 通)	wu2yi2bu4tong1
-(无 ㊀ 不 通)	wu2yi2bu4tong1
 (无 地 自 容)	wu2di4zi4rong2
 (无 所 不 为)	wu2suo3bu4wei2
 (无 所 不 为)	wu2suo3bu4wei2
 (无 的 放 矢)	wu2di4fang4shi3
 (无 知 无 识)	wu2zhi1wu2shi2
 (日 复 一 日)	ri4fu4yi2ri4
-(日 复 ㊀ 日)	ri4fu4yi2ri4
-(㊐ 复 一 ㊐)	ri4fu4yi2ri4
 (日 復 一 日)	ri4fu4yi2ri4
-(日 復 ㊀ 日)	ri4fu4yi2ri4
-(㊐ 復 一 ㊐)	ri4fu4yi2ri4
 (日 復 一 日)	ri4fu4yi2ri4
-(日 復 ㊀ 日)	ri4fu4yi2ri4
-(㊐ 復 一 ㊐)	ri4fu4yi2ri4
 (日 月 重 光)	ri4yue4chong2guang1
-(日 ㊊ 重 光)	ri4yue4chong2guang1
-(㊐ 月 重 光)	ri4yue4chong2guang1
 (日 甚 一 日)	ri4shen4yi2ri4
-(日 甚 ㊀ 日)	ri4shen4yi2ri4
-(㊐ 甚 一 ㊐)	ri4shen4yi2ri4
 (日 积 月 累)	ri4ji1yue4lei3
-(日 积 ㊊ 累)	ri4ji1yue4lei3
-(㊐ 积 月 累)	ri4ji1yue4lei3
 (日 积 月 累)	ri4ji1yue4lei3
-(日 积 ㊊ 累)	ri4ji1yue4lei3
-(㊐ 积 月 累)	ri4ji1yue4lei3
 (日 積 月 累)	ri4ji1yue4lei3
-(日 積 ㊊ 累)	ri4ji1yue4lei3
-(㊐ 積 月 累)	ri4ji1yue4lei3
 (日 積 月 累)	ri4ji1yue4lei3
-(日 積 ㊊ 累)	ri4ji1yue4lei3
-(㊐ 積 月 累)	ri4ji1yue4lei3
 (日 行 一 善)	ri4xing2yi2shan4
-(日 行 ㊀ 善)	ri4xing2yi2shan4
-(㊐ 行 一 善)	ri4xing2yi2shan4
 (日 行 一 善)	ri4xing2yi2shan4
-(日 行 ㊀ 善)	ri4xing2yi2shan4
-(㊐ 行 一 善)	ri4xing2yi2shan4
 (旧 地 重 遊)	jiu4di4chong2you2
 (旱 得 邪 火)	han4de5xie2huo5
-(旱 得 邪 ㊋)	han4de5xie2huo5
 (时 不 常 儿)	shi2bu5chang2r5
 (时 不 常 儿)	shi2bu5chang2r5
 (时 好 时 坏)	shi2hao4shi2huai4
 (时 机 一 到)	shi2ji1yi2dao4
-(时 机 ㊀ 到)	shi2ji1yi2dao4
 (明 明 白 白)	ming2ming2bai2bai2
 (明 窗 淨 几)	ming2chuang1jing4ji1
 (明 窗 淨 幾)	ming2chuang1jing4ji1
@@ -79810,13 +73897,9 @@ $textmode
 (易 得 易 失)	yi4de2yi4shi1
 (易 得 易 失)	yi4de2yi4shi1
 (昙 花 一 现)	tan2hua1yi2xian4
-(昙 花 ㊀ 现)	tan2hua1yi2xian4
 (星 星 之 火)	xing1xing1zhi5huo3
-(星 星 之 ㊋)	xing1xing1zhi5huo3
 (春 秋 三 传)	chun1qiu1san1zhuan4
-(春 秋 ㊂ 传)	chun1qiu1san1zhuan4
 (春 秋 三 傳)	chun1qiu1san1zhuan4
-(春 秋 ㊂ 傳)	chun1qiu1san1zhuan4
 (是 非 得 失)	shi4fei1de2shi1
 (昴 宿 星 团)	mao3xiu4xing1tuan2
 (昴 宿 星 團)	mao3xiu4xing1tuan2
@@ -79824,7 +73907,6 @@ $textmode
 (時 不 常 兒)	shi2bu5chang2r5
 (時 好 時 壞)	shi2hao4shi2huai4
 (時 機 一 到)	shi2ji1yi2dao4
-(時 機 ㊀ 到)	shi2ji1yi2dao4
 (晒 得 漆 黑)	shai4de2qi1hei1
 (晕 头 转 向)	yun1tou2zhuan4xiang4
 (晨 鐘 暮 鼓)	chen2zhong1mu4gu3
@@ -79834,11 +73916,7 @@ $textmode
 (暈 頭 轉 向)	yun1tou2zhuan4xiang4
 (暈 頭 轉 向)	yun1tou2zhuan4xiang4
 (暗 中 摸 索)	an4zhong1mo1suo3
-(暗 🀄 摸 索)	an4zhong1mo1suo3
-(暗 ㊥ 摸 索)	an4zhong1mo1suo3
 (暗 中 摸 索)	an4zhong1mo1suo3
-(暗 🀄 摸 索)	an4zhong1mo1suo3
-(暗 ㊥ 摸 索)	an4zhong1mo1suo3
 (暮 鼓 晨 鐘)	mu4gu3chen2zhong1
 (暮 鼓 晨 钟)	mu4gu3chen2zhong1
 (暴 虎 冯 河)	bao4hu3ping2he2
@@ -79846,7 +73924,6 @@ $textmode
 (暴 虎 馮 河)	bao4hu3ping2he2
 (暴 虎 馮 河)	bao4hu3ping2he2
 (曇 花 一 現)	tan2hua1yi2xian4
-(曇 花 ㊀ 現)	tan2hua1yi2xian4
 (曬 得 漆 黑)	shai4de2qi1hei1
 (曲 終 奏 雅)	qu3zhong1zou4ya3
 (曲 终 奏 雅)	qu3zhong1zou4ya3
@@ -79862,31 +73939,19 @@ $textmode
 (更 高 性 能)	geng1gao1xing4neng2
 (更 高 性 能)	geng1gao1xing4neng2
 (曼 切 斯 特)	man4qie1si1te4
-(曼 切 斯 ㊕)	man4qie1si1te4
 (曼 切 斯 特)	man4qie1si1te4
-(曼 切 斯 ㊕)	man4qie1si1te4
 (曾 外 祖 母)	zeng1wai4zu3mu3
 (曾 外 祖 母)	zeng1wai4zu3mu3
 (最 低 限 度)	zui4di1xian4du5
 (最 低 限 度)	zui4di1xian4du5
 (最 后 一 滴)	zui4hou4yi4di1
-(最 后 ㊀ 滴)	zui4hou4yi4di1
 (最 後 一 滴)	zui4hou4yi4di1
-(最 後 ㊀ 滴)	zui4hou4yi4di1
 (會 心 一 笑)	hui4xin1yi2xiao4
-(會 心 ㊀ 笑)	hui4xin1yi2xiao4
 (有 夫 之 妇)	you3fu1zhi1fu4
-(㊒ 夫 之 妇)	you3fu1zhi1fu4
 (有 夫 之 婦)	you3fu1zhi1fu4
-(㊒ 夫 之 婦)	you3fu1zhi1fu4
 (有 朝 一 日)	you3zhao1yi2ri4
-(有 朝 ㊀ 日)	you3zhao1yi2ri4
-(㊒ 朝 一 日)	you3zhao1yi2ri4
-(有 朝 一 ㊐)	you3zhao1yi2ri4
 (有 机 分 子)	you3ji1fen1zi3
-(㊒ 机 分 子)	you3ji1fen1zi3
 (有 機 分 子)	you3ji1fen1zi3
-(㊒ 機 分 子)	you3ji1fen1zi3
 (望 子 成 龍)	wang4zi3cheng2long2
 (望 子 成 龍)	wang4zi3cheng2long2
 (望 子 成 龍)	wang4zi3cheng2long2
@@ -79898,25 +73963,19 @@ $textmode
 (望 而 興 嘆)	wang4er2xing1tan4
 (望 而 興 嘆)	wang4er2xing1tan4
 (朝 三 暮 四)	zhao1san1mu4si4
-(朝 ㊂ 暮 四)	zhao1san1mu4si4
-(朝 三 暮 ㊃)	zhao1san1mu4si4
 (朝 秦 暮 楚)	zhao1qin2mu4chu3
 (朝 阳 地 区)	zhao1yang2di4qu1
 (朝 陽 地 區)	zhao1yang2di4qu1
 (木 骨 都 束)	mu4gu3du1shu4
-(㊍ 骨 都 束)	mu4gu3du1shu4
 (木 骨 都 束)	mu4gu3du1shu4
-(㊍ 骨 都 束)	mu4gu3du1shu4
 (未 雨 綢 繆)	wei4yu3chou2mou2
 (未 雨 绸 缪)	wei4yu3chou2mou2
 (本 同 一 源)	ben3tong2yi4yuan2
-(本 同 ㊀ 源)	ben3tong2yi4yuan2
 (本 徵 向 量)	ben3zheng1xiang4liang4
 (本 徵 向 量)	ben3zheng1xiang4liang4
 (朱 云 折 槛)	zhu1yun2zhe1kan3
 (朱 雲 折 檻)	zhu1yun2zhe1kan3
 (杀 一 儆 百)	sha1yi4jing3bai3
-(杀 ㊀ 儆 百)	sha1yi4jing3bai3
 (杜 秋 娘 歌)	du4qiu1niang2ge1
 (杜 莎 夫 人)	du4suo1fu1ren5
 (来 回 来 去)	lai2hui2lai2qu4
@@ -79924,33 +73983,20 @@ $textmode
 (来 路 不 明)	lai2lu5bu4ming2
 (来 路 不 明)	lai2lu5bu4ming2
 (東 倒 西 歪)	dong1dao3xi1wai1
-(東 倒 🀂 歪)	dong1dao3xi1wai1
 (東 奔 西 走)	dong1ben1xi1zou3
-(東 奔 🀂 走)	dong1ben1xi1zou3
 (東 奔 西 走)	dong1ben1xi1zou3
-(東 奔 🀂 走)	dong1ben1xi1zou3
 (東 奔 西 跑)	dong1ben1xi1pao3
-(東 奔 🀂 跑)	dong1ben1xi1pao3
 (東 奔 西 跑)	dong1ben1xi1pao3
-(東 奔 🀂 跑)	dong1ben1xi1pao3
 (東 巴 文 化)	dong1ba1wen2hua4
 (東 張 西 望)	dong1zhang1xi1wang4
-(東 張 🀂 望)	dong1zhang1xi1wang4
 (東 張 西 望)	dong1zhang1xi1wang4
-(東 張 🀂 望)	dong1zhang1xi1wang4
 (東 征 西 怨)	dong1zheng1xi1yuan4
-(東 征 🀂 怨)	dong1zheng1xi1yuan4
 (東 征 西 討)	dong1zheng1xi1tao3
-(東 征 🀂 討)	dong1zheng1xi1tao3
 (東 拉 西 扯)	dong1la1xi1che3
-(東 拉 🀂 扯)	dong1la1xi1che3
 (東 拉 西 扯)	dong1la1xi1che3
-(東 拉 🀂 扯)	dong1la1xi1che3
 (松 赞 干 布)	song1zan4gan4bu4
 (板 上 釘 釘)	ban3shang4ding4ding1
-(板 ㊤ 釘 釘)	ban3shang4ding4ding1
 (板 上 钉 钉)	ban3shang4ding4ding1
-(板 ㊤ 钉 钉)	ban3shang4ding4ding1
 (板 块 构 造)	ban3kuai4gou4zao5
 (板 塊 構 造)	ban3kuai4gou4zao5
 (枉 費 心 機)	wang3fei4xin1ji1
@@ -79979,29 +74025,17 @@ $textmode
 (柯 尔 克 孜)	ke3er3ke4zi1
 (柯 爾 克 孜)	ke3er3ke4zi1
 (柳 眉 一 扬)	liu3mei2yi4yang2
-(柳 眉 ㊀ 扬)	liu3mei2yi4yang2
 (柳 眉 一 扬)	liu3mei2yi4yang2
-(柳 眉 ㊀ 扬)	liu3mei2yi4yang2
 (柳 眉 一 揚)	liu3mei2yi4yang2
-(柳 眉 ㊀ 揚)	liu3mei2yi4yang2
 (柳 眉 一 揚)	liu3mei2yi4yang2
-(柳 眉 ㊀ 揚)	liu3mei2yi4yang2
 (桑 給 巴 爾)	sang1ji3ba1er3
 (桑 给 巴 尔)	sang1ji3ba1er3
 (棋 高 一 着)	qi2gao1yi4zhao1
-(棋 高 ㊀ 着)	qi2gao1yi4zhao1
 (棋 高 一 着)	qi2gao1yi4zhao1
-(棋 高 ㊀ 着)	qi2gao1yi4zhao1
 (棋 高 一 著)	qi2gao1yi4zhao1
-(棋 高 ㊀ 著)	qi2gao1yi4zhao1
 (棋 高 一 著)	qi2gao1yi4zhao1
-(棋 高 ㊀ 著)	qi2gao1yi4zhao1
 (森 林 一 木)	sen1lin2yi2mu4
-(森 林 一 ㊍)	sen1lin2yi2mu4
-(森 林 ㊀ 木)	sen1lin2yi2mu4
 (森 林 一 木)	sen1lin2yi2mu4
-(森 林 一 ㊍)	sen1lin2yi2mu4
-(森 林 ㊀ 木)	sen1lin2yi2mu4
 (楚 弓 楚 得)	chu3gong1chu3de2
 (楚 汉 战 争)	chu3han4zhan4zheng1
 (楚 漢 戰 爭)	chu3han4zhan4zheng1
@@ -80025,9 +74059,7 @@ $textmode
 (欧 几 里 得)	ou1ji3li3de2
 (欺 人 太 甚)	qi1ren2tai4shen4
 (歇 一 会 儿)	xie1yi4hui3r5
-(歇 ㊀ 会 儿)	xie1yi4hui3r5
 (歉 然 一 笑)	qian4ran2yi2xiao4
-(歉 然 ㊀ 笑)	qian4ran2yi2xiao4
 (歐 幾 裡 德)	ou1ji3li3de2
 (歐 幾 裡 德)	ou1ji3li3de2
 (歐 幾 里 得)	ou1ji3li3de2
@@ -80037,18 +74069,10 @@ $textmode
 (歡 蹦 亂 跳)	huan1beng4luan4tiao4
 (歡 蹦 亂 跳)	huan1beng4luan4tiao4
 (正 儿 八 经)	zheng4r5ba1jing1
-(㊣ 儿 八 经)	zheng4r5ba1jing1
-(正 儿 ㊇ 经)	zheng4r5ba1jing1
 (正 当 防 卫)	zheng4dang4fang2wei4
-(㊣ 当 防 卫)	zheng4dang4fang2wei4
 (正 當 防 衛)	zheng4dang4fang2wei4
-(㊣ 當 防 衛)	zheng4dang4fang2wei4
 (正 經 八 百)	zheng4jing5ba1bai3
-(㊣ 經 八 百)	zheng4jing5ba1bai3
-(正 經 ㊇ 百)	zheng4jing5ba1bai3
 (正 经 八 百)	zheng4jing5ba1bai3
-(㊣ 经 八 百)	zheng4jing5ba1bai3
-(正 经 ㊇ 百)	zheng4jing5ba1bai3
 (步 步 为 营)	bu4bu4wei2ying2
 (步 步 為 營)	bu4bu4wei2ying2
 (武 装 力 量)	wu3zhuang1li4liang4
@@ -80070,13 +74094,9 @@ $textmode
 (死 裡 逃 生)	si3li3tao2sheng1
 (死 裡 逃 生)	si3li3tao2sheng1
 (殺 一 儆 百)	sha1yi4jing3bai3
-(殺 ㊀ 儆 百)	sha1yi4jing3bai3
 (殺 一 儆 百)	sha1yi4jing3bai3
-(殺 ㊀ 儆 百)	sha1yi4jing3bai3
 (殺 一 儆 百)	sha1yi4jing3bai3
-(殺 ㊀ 儆 百)	sha1yi4jing3bai3
 (毀 於 一 旦)	hui3yu2yi2dan4
-(毀 於 ㊀ 旦)	hui3yu2yi2dan4
 (比 什 凯 克)	bi3shi2kai3ke4
 (比 什 凯 克)	bi3shi2kai3ke4
 (比 什 凱 克)	bi3shi2kai3ke4
@@ -80090,7 +74110,6 @@ $textmode
 (毫 不 在 意)	hao2bu5zai4yi4
 (毫 不 在 意)	hao2bu5zai4yi4
 (民 窮 財 盡)	min2qiong2cai2jin4
-(民 窮 ㊖ 盡)	min2qiong2cai2jin4
 (气 不 忿 儿)	qi4bu5fen4r5
 (气 不 忿 儿)	qi4bu5fen4r5
 (气 冲 牛 斗)	qi4chong1niu2dou3
@@ -80098,36 +74117,21 @@ $textmode
 (氣 沖 牛 斗)	qi4chong1niu2dou3
 (氣 貫 長 虹)	qi4guan4chang2hong2
 (水 上 运 动)	shui3shang4yun4dong5
-(水 ㊤ 运 动)	shui3shang4yun4dong5
-(㊌ 上 运 动)	shui3shang4yun4dong5
 (水 上 運 動)	shui3shang4yun4dong5
-(水 ㊤ 運 動)	shui3shang4yun4dong5
-(㊌ 上 運 動)	shui3shang4yun4dong5
 (水 天 一 色)	shui3tian1yi2se4
-(㊌ 天 一 色)	shui3tian1yi2se4
-(水 天 ㊀ 色)	shui3tian1yi2se4
 (水 浒 全 传)	shui3hu3quan2zhuan4
-(㊌ 浒 全 传)	shui3hu3quan2zhuan4
 (水 浒 全 传)	shui3hu3quan2zhuan4
-(㊌ 浒 全 传)	shui3hu3quan2zhuan4
 (水 浒 后 传)	shui3hu3hou4zhuan4
-(㊌ 浒 后 传)	shui3hu3hou4zhuan4
 (水 滸 全 傳)	shui3hu3quan2zhuan4
-(㊌ 滸 全 傳)	shui3hu3quan2zhuan4
 (水 滸 全 傳)	shui3hu3quan2zhuan4
-(㊌ 滸 全 傳)	shui3hu3quan2zhuan4
 (水 滸 後 傳)	shui3hu3hou4zhuan4
-(㊌ 滸 後 傳)	shui3hu3hou4zhuan4
 (永 贞 内 禅)	yong3zhen1nei4shan4
 (求 仁 得 仁)	qiu2ren2de2ren2
 (求 浆 得 酒)	qiu2jiang1de2jiu3
 (求 漿 得 酒)	qiu2jiang1de2jiu3
 (決 一 勝 負)	jue2yi2sheng4fu4
-(決 ㊀ 勝 負)	jue2yi2sheng4fu4
 (決 一 死 戰)	jue2yi4si3zhan4
-(決 ㊀ 死 戰)	jue2yi4si3zhan4
 (決 一 雌 雄)	jue2yi4ci2xiong2
-(決 ㊀ 雌 雄)	jue2yi4ci2xiong2
 (沈 魚 落 雁)	chen2yu2luo4yan4
 (沈 魚 落 雁)	chen2yu2luo4yan4
 (沈 魚 落 雁)	chen2yu2luo4yan4
@@ -80165,16 +74169,13 @@ $textmode
 (波 羅 的 海)	bo1luo2di4hai3
 (洁 身 自 好)	jie2shen1zi4hao4
 (洗 发 水 儿)	xi3fa4shui3r5
-(洗 发 ㊌ 儿)	xi3fa4shui3r5
 (津 巴 布 韋)	jin1ba1bu4wei2
 (津 巴 布 韦)	jin1ba1bu4wei2
 (洪 都 拉 斯)	hong2du1la1si1
 (洪 都 拉 斯)	hong2du1la1si1
 (洪 都 拉 斯)	hong2du1la1si1
 (活 不 下 去)	huo2bu5xia4qu4
-(活 不 ㊦ 去)	huo2bu5xia4qu4
 (活 不 下 去)	huo2bu5xia4qu4
-(活 不 ㊦ 去)	huo2bu5xia4qu4
 (派 拉 蒙 影)	pai4la1meng3ying3
 (派 拉 蒙 影)	pai4la1meng3ying3
 (流 里 流 气)	liu2li5liu2qi4
@@ -80185,28 +74186,17 @@ $textmode
 (测 地 曲 率)	ce4di4qu1lv4
 (测 地 曲 率)	ce4di4qu1lv4
 (济 济 一 堂)	ji3ji3yi4tang2
-(济 济 ㊀ 堂)	ji3ji3yi4tang2
 (浑 身 上 下)	hun2shen1shang4xia4
-(浑 身 上 ㊦)	hun2shen1shang4xia4
-(浑 身 ㊤ 下)	hun2shen1shang4xia4
 (浩 浩 荡 荡)	hao4hao5dang4dang4
 (浩 浩 蕩 蕩)	hao4hao5dang4dang4
 (浪 得 虚 名)	lang4de2xu1ming2
-(浪 得 虚 ㊔)	lang4de2xu1ming2
 (浪 得 虚 名)	lang4de2xu1ming2
-(浪 得 虚 ㊔)	lang4de2xu1ming2
 (浪 得 虛 名)	lang4de2xu1ming2
-(浪 得 虛 ㊔)	lang4de2xu1ming2
 (浪 得 虛 名)	lang4de2xu1ming2
-(浪 得 虛 ㊔)	lang4de2xu1ming2
 (浮 一 大 白)	fu2yi2da4bai2
-(浮 ㊀ 大 白)	fu2yi2da4bai2
 (海 天 一 色)	hai3tian1yi2se4
-(海 天 ㊀ 色)	hai3tian1yi2se4
 (海 天 一 色)	hai3tian1yi2se4
-(海 天 ㊀ 色)	hai3tian1yi2se4
 (涼 在 一 邊)	liang4zai4yi4bian1
-(涼 在 ㊀ 邊)	liang4zai4yi4bian1
 (淋 灕 盡 致)	lin2li2jin4zhi4
 (淋 灕 盡 致)	lin2li2jin4zhi4
 (淡 不 唧 儿)	dan4bu5ji5r5
@@ -80215,30 +74205,21 @@ $textmode
 (淡 不 唧 兒)	dan4bu5ji5r5
 (淡 泊 寡 味)	dan4bo2gua3wei4
 (淡 淡 一 笑)	dan4dan4yi2xiao4
-(淡 淡 ㊀ 笑)	dan4dan4yi2xiao4
 (深 恶 痛 绝)	shen1wu4tong4jue2
 (深 惡 痛 絕)	shen1wu4tong4jue2
 (深 惡 痛 絕)	shen1wu4tong4jue2
 (混 不 下 去)	hun4bu5xia4qu5
-(混 不 ㊦ 去)	hun4bu5xia4qu5
 (混 不 下 去)	hun4bu5xia4qu5
-(混 不 ㊦ 去)	hun4bu5xia4qu5
 (混 不 过 去)	hun4bu5guo4qu5
 (混 不 过 去)	hun4bu5guo4qu5
 (混 不 過 去)	hun4bu5guo4qu5
 (混 不 過 去)	hun4bu5guo4qu5
 (混 为 一 体)	hun2wei2yi4ti3
-(混 为 ㊀ 体)	hun2wei2yi4ti3
 (混 为 一 谈)	hun4wei2yi4tan2
-(混 为 ㊀ 谈)	hun4wei2yi4tan2
 (混 水 摸 魚)	hun2shui3mo1yu2
-(混 ㊌ 摸 魚)	hun2shui3mo1yu2
 (混 水 摸 鱼)	hun2shui3mo1yu2
-(混 ㊌ 摸 鱼)	hun2shui3mo1yu2
 (混 為 一 談)	hun4wei2yi4tan2
-(混 為 ㊀ 談)	hun4wei2yi4tan2
 (混 為 一 體)	hun2wei2yi4ti3
-(混 為 ㊀ 體)	hun2wei2yi4ti3
 (清 清 楚 楚)	qing1qing5chu3chu3
 (渔 人 得 利)	yu2ren2de2li4
 (渔 人 得 利)	yu2ren2de2li4
@@ -80255,8 +74236,6 @@ $textmode
 (游 行 隊 伍)	you2xing2dui4wu3
 (游 行 隊 伍)	you2xing2dui4wu3
 (渾 身 上 下)	hun2shen1shang4xia4
-(渾 身 上 ㊦)	hun2shen1shang4xia4
-(渾 身 ㊤ 下)	hun2shen1shang4xia4
 (溫 得 和 克)	wen1de2he2ke4
 (溫 情 脈 脈)	wen1qing2mo4mo4
 (滑 不 叽 溜)	hua2bu5ji1liu1
@@ -80268,11 +74247,8 @@ $textmode
 (滑 不 嘰 溜)	hua2bu5ji1liu1
 (滑 不 嘰 溜)	hua2bu5ji1liu1
 (滑 了 一 跤)	hua2le5yi4jiao1
-(滑 了 ㊀ 跤)	hua2le5yi4jiao1
 (滑 了 一 跤)	hua2le5yi4jiao1
-(滑 了 ㊀ 跤)	hua2le5yi4jiao1
 (滑 了 一 跤)	hua2le5yi4jiao1
-(滑 了 ㊀ 跤)	hua2le5yi4jiao1
 (满 口 应 承)	man3kou3ying4cheng2
 (滲 人 得 慌)	shen4ren2de2huang1
 (滿 口 應 承)	man3kou3ying4cheng2
@@ -80280,25 +74256,16 @@ $textmode
 (漁 人 得 利)	yu2ren2de2li4
 (潔 身 自 好)	jie2shen1zi4hao4
 (潛 水 夫 病)	qian2shui3fu1bing4
-(潛 ㊌ 夫 病)	qian2shui3fu1bing4
 (潛 水 夫 癥)	qian2shui3fu1zheng4
-(潛 ㊌ 夫 癥)	qian2shui3fu1zheng4
 (潜 水 夫 病)	qian2shui3fu1bing4
-(潜 ㊌ 夫 病)	qian2shui3fu1bing4
 (潜 水 夫 症)	qian2shui3fu1zheng4
-(潜 ㊌ 夫 症)	qian2shui3fu1zheng4
 (澎 湖 群 岛)	peng2hu2qun2dao3
 (澎 湖 群 島)	peng2hu2qun2dao3
 (濟 濟 一 堂)	ji3ji3yi4tang2
-(濟 濟 ㊀ 堂)	ji3ji3yi4tang2
 (火 烧 火 燎)	huo3shao1huo3liao3
-(㊋ 烧 ㊋ 燎)	huo3shao1huo3liao3
 (火 烧 火 燎)	huo3shao1huo3liao3
-(㊋ 烧 ㊋ 燎)	huo3shao1huo3liao3
 (火 燒 火 燎)	huo3shao1huo3liao3
-(㊋ 燒 ㊋ 燎)	huo3shao1huo3liao3
 (火 燒 火 燎)	huo3shao1huo3liao3
-(㊋ 燒 ㊋ 燎)	huo3shao1huo3liao3
 (灰 不 啦 唧)	hui1bu5la1ji1
 (灰 不 啦 唧)	hui1bu5la1ji1
 (灰 不 溜 丟)	hui1bu5liu1diu1
@@ -80313,17 +74280,11 @@ $textmode
 (灰 心 丧 气)	hui1xin1sang4qi4
 (灰 心 喪 氣)	hui1xin1sang4qi4
 (炸 土 豆 条)	zha2tu3dou4tiao2
-(炸 ㊏ 豆 条)	zha2tu3dou4tiao2
 (炸 土 豆 條)	zha2tu3dou4tiao2
-(炸 ㊏ 豆 條)	zha2tu3dou4tiao2
 (炸 土 豆 片)	zha2tu3dou4pian1
-(炸 ㊏ 豆 片)	zha2tu3dou4pian1
 (点 头 一 笑)	dian3tou2yi2xiao4
-(点 头 ㊀ 笑)	dian3tou2yi2xiao4
 (為 之 一 振)	wei4zhi1yi2zhen4
-(為 之 ㊀ 振)	wei4zhi1yi2zhen4
 (為 之 一 新)	wei2zhi1yi4xin1
-(為 之 ㊀ 新)	wei2zhi1yi4xin1
 (為 仁 不 富)	wei2ren2bu2fu4
 (為 仁 不 富)	wei2ren2bu2fu4
 (為 富 不 仁)	wei2fu4bu4ren2
@@ -80338,31 +74299,19 @@ $textmode
 (烏 蘭 巴 托)	wu1lan2ba1tuo1
 (烏 蘭 巴 托)	wu1lan2ba1tuo1
 (烟 燻 火 燎)	yan1xun1huo3liao3
-(烟 燻 ㊋ 燎)	yan1xun1huo3liao3
 (烟 燻 火 燎)	yan1xun1huo3liao3
-(烟 燻 ㊋ 燎)	yan1xun1huo3liao3
 (烟 花 行 院)	yan1hua1hang2yuan4
 (烟 花 行 院)	yan1hua1hang2yuan4
 (無 一 不 備)	wu2yi2bu2bei4
-(無 ㊀ 不 備)	wu2yi2bu2bei4
 (無 一 不 備)	wu2yi2bu2bei4
-(無 ㊀ 不 備)	wu2yi2bu2bei4
 (無 一 不 精)	wu2yi2bu4jing1
-(無 ㊀ 不 精)	wu2yi2bu4jing1
 (無 一 不 精)	wu2yi2bu4jing1
-(無 ㊀ 不 精)	wu2yi2bu4jing1
 (無 一 不 精)	wu2yi2bu4jing1
-(無 ㊀ 不 精)	wu2yi2bu4jing1
 (無 一 不 能)	wu2yi2bu4neng2
-(無 ㊀ 不 能)	wu2yi2bu4neng2
 (無 一 不 能)	wu2yi2bu4neng2
-(無 ㊀ 不 能)	wu2yi2bu4neng2
 (無 一 不 通)	wu2yi2bu4tong1
-(無 ㊀ 不 通)	wu2yi2bu4tong1
 (無 一 不 通)	wu2yi2bu4tong1
-(無 ㊀ 不 通)	wu2yi2bu4tong1
 (無 兒 無 女)	wu2er2wu2nv3
-(無 兒 無 ㊛)	wu2er2wu2nv3
 (無 兒 無 女)	wu2er2wu2nv3
 (無 動 於 衷)	wu2dong4yu2zhong1
 (無 地 自 容)	wu2di4zi4rong2
@@ -80374,14 +74323,11 @@ $textmode
 (無 濟 於 事)	wu2ji4yu2shi4
 (無 的 放 矢)	wu2di4fang4shi3
 (無 盡 無 休)	wu2jin4wu2xiu1
-(無 盡 無 ㊡)	wu2jin4wu2xiu1
 (無 知 無 識)	wu2zhi1wu2shi2
 (無 知 無 識)	wu2zhi1wu2shi2
 (無 窮 無 盡)	wu2qiong2wu2jin4
 (煙 燻 火 燎)	yan1xun1huo3liao3
-(煙 燻 ㊋ 燎)	yan1xun1huo3liao3
 (煙 燻 火 燎)	yan1xun1huo3liao3
-(煙 燻 ㊋ 燎)	yan1xun1huo3liao3
 (煙 花 行 院)	yan1hua1hang2yuan4
 (煙 花 行 院)	yan1hua1hang2yuan4
 (燕 太 子 丹)	yan1tai4zi3dan1
@@ -80403,24 +74349,16 @@ $textmode
 (爱 民 如 子)	ai4min2ru2zi3
 (爽 爽 快 快)	shuang3shuang3kuai4kuai4
 (特 拉 維 夫)	te4la1wei2fu1
-(㊕ 拉 維 夫)	te4la1wei2fu1
 (特 拉 維 夫)	te4la1wei2fu1
-(㊕ 拉 維 夫)	te4la1wei2fu1
 (特 拉 维 夫)	te4la1wei2fu1
-(㊕ 拉 维 夫)	te4la1wei2fu1
 (特 拉 维 夫)	te4la1wei2fu1
-(㊕ 拉 维 夫)	te4la1wei2fu1
 (狂 飲 大 嚼)	kuang2yin3da4jiao4
 (狂 饮 大 嚼)	kuang2yin3da4jiao4
 (狐 朋 狗 友)	hu2peng2gou3you3
 (独 一 全 智)	du2yi4quan2zhi4
-(独 ㊀ 全 智)	du2yi4quan2zhi4
 (独 一 全 智)	du2yi4quan2zhi4
-(独 ㊀ 全 智)	du2yi4quan2zhi4
 (独 创 一 格)	du2chuang4yi4ge2
-(独 创 ㊀ 格)	du2chuang4yi4ge2
 (独 树 一 帜)	du2shu4yi2zhi4
-(独 树 ㊀ 帜)	du2shu4yi2zhi4
 (狼 号 鬼 哭)	lang2hao2gui3ku1
 (狼 号 鬼 哭)	lang2hao2gui3ku1
 (狼 子 野 心)	lang2zi3ye3xin1
@@ -80432,13 +74370,9 @@ $textmode
 (狼 號 鬼 哭)	lang2hao2gui3ku1
 (狼 號 鬼 哭)	lang2hao2gui3ku1
 (獨 一 全 智)	du2yi4quan2zhi4
-(獨 ㊀ 全 智)	du2yi4quan2zhi4
 (獨 一 全 智)	du2yi4quan2zhi4
-(獨 ㊀ 全 智)	du2yi4quan2zhi4
 (獨 創 一 格)	du2chuang4yi4ge2
-(獨 創 ㊀ 格)	du2chuang4yi4ge2
 (獨 樹 一 幟)	du2shu4yi2zhi4
-(獨 樹 ㊀ 幟)	du2shu4yi2zhi4
 (率 兽 食 人)	shuai4shou4shi2ren2
 (率 兽 食 人)	shuai4shou4shi2ren2
 (率 兽 食 人)	shuai4shou4shi2ren2
@@ -80474,27 +74408,19 @@ $textmode
 (琴 瑟 不 调)	qin2se4bu4tiao2
 (瑪 得 米 那)	ma3de2mi3na4
 (甚 嚣 尘 上)	shen4xiao1chen2shang4
-(甚 嚣 尘 ㊤)	shen4xiao1chen2shang4
 (甚 囂 塵 上)	shen4xiao1chen2shang4
-(甚 囂 塵 ㊤)	shen4xiao1chen2shang4
 (甚 感 詫 異)	shen4gan3cha4yi4
 (甚 感 詫 異)	shen4gan3cha4yi4
 (甚 感 诧 异)	shen4gan3cha4yi4
 (甜 不 唧 儿)	tian2bu5ji1r5
 (甜 不 唧 儿)	tian2bu5ji1r5
 (生 兒 育 女)	sheng1er2yu4nv3
-(生 兒 育 ㊛)	sheng1er2yu4nv3
 (生 兒 育 女)	sheng1er2yu4nv3
 (生 日 快 乐)	sheng1ri4kuai4le4
-(生 ㊐ 快 乐)	sheng1ri4kuai4le4
 (生 日 快 樂)	sheng1ri4kuai4le4
-(生 ㊐ 快 樂)	sheng1ri4kuai4le4
 (生 日 快 樂)	sheng1ri4kuai4le4
-(生 ㊐ 快 樂)	sheng1ri4kuai4le4
 (生 日 快 樂)	sheng1ri4kuai4le4
-(生 ㊐ 快 樂)	sheng1ri4kuai4le4
 (生 日 快 樂)	sheng1ri4kuai4le4
-(生 ㊐ 快 樂)	sheng1ri4kuai4le4
 (生 活 費 用)	sheng1huo2fei4yong4
 (生 活 费 用)	sheng1huo2fei4yong4
 (甲 壳 虫 类)	jia3ke2chong2lei4
@@ -80502,23 +74428,12 @@ $textmode
 (甲 殼 蟲 類)	jia3ke2chong2lei4
 (甲 殼 蟲 類)	jia3ke2chong2lei4
 (男 女 老 少)	nan2nv3lao3shao4
-(㊚ 女 老 少)	nan2nv3lao3shao4
-(男 ㊛ 老 少)	nan2nv3lao3shao4
 (男 女 老 少)	nan2nv3lao3shao4
-(㊚ 女 老 少)	nan2nv3lao3shao4
 (男 女 老 少)	nan2nv3lao3shao4
-(㊚ 女 老 少)	nan2nv3lao3shao4
-(男 ㊛ 老 少)	nan2nv3lao3shao4
 (男 扮 女 装)	nan2ban4nv3zhuang1
-(㊚ 扮 女 装)	nan2ban4nv3zhuang1
-(男 扮 ㊛ 装)	nan2ban4nv3zhuang1
 (男 扮 女 装)	nan2ban4nv3zhuang1
-(㊚ 扮 女 装)	nan2ban4nv3zhuang1
 (男 扮 女 裝)	nan2ban4nv3zhuang1
-(㊚ 扮 女 裝)	nan2ban4nv3zhuang1
-(男 扮 ㊛ 裝)	nan2ban4nv3zhuang1
 (男 扮 女 裝)	nan2ban4nv3zhuang1
-(㊚ 扮 女 裝)	nan2ban4nv3zhuang1
 (画 荻 教 子)	hua4di2jiao1zi3
 (画 荻 教 子)	hua4di2jiao1zi3
 (留 连 论 诗)	liu2lian2lun4shi2
@@ -80530,13 +74445,9 @@ $textmode
 (畢 尼 奧 夫)	bi4ni2ao4fu1
 (畢 爾 巴 鄂)	bi4er3ba1e4
 (略 一 过 目)	lve4yi2guo4mu4
-(略 ㊀ 过 目)	lve4yi2guo4mu4
 (略 一 过 目)	lve4yi2guo4mu4
-(略 ㊀ 过 目)	lve4yi2guo4mu4
 (略 一 過 目)	lve4yi2guo4mu4
-(略 ㊀ 過 目)	lve4yi2guo4mu4
 (略 一 過 目)	lve4yi2guo4mu4
-(略 ㊀ 過 目)	lve4yi2guo4mu4
 (略 識 之 無)	lve4shi2zhi1wu2
 (略 識 之 無)	lve4shi2zhi1wu2
 (略 識 之 無)	lve4shi2zhi1wu2
@@ -80547,25 +74458,19 @@ $textmode
 (異 乎 尋 常)	yi4hu1xun2chang2
 (當 務 之 急)	dang1wu4zhi1ji2
 (當 頭 一 棒)	dang1tou2yi2bang4
-(當 頭 ㊀ 棒)	dang1tou2yi2bang4
 (疏 忽 大 意)	shu1hu1da4yi4
 (疏 忽 职 守)	shu1hu1zhi2shou3
 (疏 忽 職 守)	shu1hu1zhi2shou3
 (疏 於 防 範)	shu1yu2fang2fan4
 (疯 疯 癫 癫)	feng1feng5dian1dian1
 (痛 哭 一 场)	tong4ku1yi4chang3
-(痛 哭 ㊀ 场)	tong4ku1yi4chang3
 (痛 哭 一 場)	tong4ku1yi4chang3
-(痛 哭 ㊀ 場)	tong4ku1yi4chang3
 (痛 得 蝎 虎)	tong4de5xie1hu5
 (痛 快 一 时)	tong4kuai4yi4shi2
-(痛 快 ㊀ 时)	tong4kuai4yi4shi2
 (痛 快 一 時)	tong4kuai4yi4shi2
-(痛 快 ㊀ 時)	tong4kuai4yi4shi2
 (痛 痛 快 快)	tong4tong5kuai4kuai4
 (瘋 瘋 癲 癲)	feng1feng5dian1dian1
 (登 高 一 呼)	deng1gao1yi4hu1
-(登 高 ㊀ 呼)	deng1gao1yi4hu1
 (發 明 創 造)	fa1ming2chuang1zao4
 (白 不 呲 咧)	bai2bu5ci1lie1
 (白 不 呲 咧)	bai2bu5ci1lie1
@@ -80575,65 +74480,38 @@ $textmode
 (白 馬 王 子)	bai2ma3wang2zi5
 (白 马 王 子)	bai2ma3wang2zi5
 (百 儿 八 十)	bai3r5ba1shi2
-(百 儿 八 ㊉)	bai3r5ba1shi2
-(百 儿 ㊇ 十)	bai3r5ba1shi2
 (百 发 百 中)	bai3fa1bai3zhong4
-(百 发 百 🀄)	bai3fa1bai3zhong4
-(百 发 百 ㊥)	bai3fa1bai3zhong4
 (百 密 一 疏)	bai3mi4yi4shu1
-(百 密 ㊀ 疏)	bai3mi4yi4shu1
 (百 废 俱 兴)	bai3fei4ju4xing1
 (百 度 百 科)	bai3du4bai3ke4
 (百 度 百 科)	bai3du4bai3ke4
 (百 廢 俱 興)	bai3fei4ju4xing1
 (百 无 一 失)	bai3wu2yi4shi1
-(百 无 ㊀ 失)	bai3wu2yi4shi1
 (百 无 一 精)	bai3wu2yi4jing1
-(百 无 ㊀ 精)	bai3wu2yi4jing1
 (百 无 一 精)	bai3wu2yi4jing1
-(百 无 ㊀ 精)	bai3wu2yi4jing1
 (百 无 一 能)	bai3wu2yi4neng2
-(百 无 ㊀ 能)	bai3wu2yi4neng2
 (百 无 一 长)	bai3wu2yi4chang2
-(百 无 ㊀ 长)	bai3wu2yi4chang2
 (百 無 一 失)	bai3wu2yi4shi1
-(百 無 ㊀ 失)	bai3wu2yi4shi1
 (百 無 一 精)	bai3wu2yi4jing1
-(百 無 ㊀ 精)	bai3wu2yi4jing1
 (百 無 一 精)	bai3wu2yi4jing1
-(百 無 ㊀ 精)	bai3wu2yi4jing1
 (百 無 一 能)	bai3wu2yi4neng2
-(百 無 ㊀ 能)	bai3wu2yi4neng2
 (百 無 一 長)	bai3wu2yi4chang2
-(百 無 ㊀ 長)	bai3wu2yi4chang2
 (百 發 百 中)	bai3fa1bai3zhong4
-(百 發 百 🀄)	bai3fa1bai3zhong4
-(百 發 百 ㊥)	bai3fa1bai3zhong4
 (百 裡 挑 一)	bai3li3tiao1yi1
-(百 裡 挑 ㊀)	bai3li3tiao1yi1
 (百 裡 挑 一)	bai3li3tiao1yi1
-(百 裡 挑 ㊀)	bai3li3tiao1yi1
 (的 黎 波 裡)	de5li2bo1li3
 (的 黎 波 裡)	de5li2bo1li3
 (的 黎 波 裡)	de5li2bo1li3
 (皇 亲 国 戚)	huang2qin1guo2qi1
 (皇 親 國 戚)	huang2qin1guo2qi1
 (皮 西 迪 亚)	pi2xi1di2ya4
-(皮 🀂 迪 亚)	pi2xi1di2ya4
 (皮 西 迪 亞)	pi2xi1di2ya4
-(皮 🀂 迪 亞)	pi2xi1di2ya4
 (皮 諾 切 特)	pi2nuo4qie1te4
-(皮 諾 切 ㊕)	pi2nuo4qie1te4
 (皮 諾 切 特)	pi2nuo4qie1te4
-(皮 諾 切 ㊕)	pi2nuo4qie1te4
 (皮 諾 切 特)	pi2nuo4qie1te4
-(皮 諾 切 ㊕)	pi2nuo4qie1te4
 (皮 諾 切 特)	pi2nuo4qie1te4
-(皮 諾 切 ㊕)	pi2nuo4qie1te4
 (皮 诺 切 特)	pi2nuo4qie1te4
-(皮 诺 切 ㊕)	pi2nuo4qie1te4
 (皮 诺 切 特)	pi2nuo4qie1te4
-(皮 诺 切 ㊕)	pi2nuo4qie1te4
 (盈 千 累 万)	ying2qian1lei3wan4
 (盈 千 累 万)	ying2qian1lei3wan4
 (盈 千 累 萬)	ying2qian1lei3wan4
@@ -80666,14 +74544,11 @@ $textmode
 (相 依 為 命)	xiang1yi1wei2ming4
 (相 关 系 数)	xiang1guan1xi4shu4
 (相 同 名 字)	xiang1tong2ming2zi4
-(相 同 ㊔ 字)	xiang1tong2ming2zi4
 (相 夫 教 子)	xiang4fu1jiao4zi3
 (相 關 係 數)	xiang1guan1xi4shu4
 (相 關 係 數)	xiang1guan1xi4shu4
 (相 顧 一 笑)	xiang1gu4yi2xiao4
-(相 顧 ㊀ 笑)	xiang1gu4yi2xiao4
 (相 顾 一 笑)	xiang1gu4yi2xiao4
-(相 顾 ㊀ 笑)	xiang1gu4yi2xiao4
 (相 體 裁 衣)	xiang4ti3cai2yi1
 (眉 目 传 情)	mei2mu4chuan2qing2
 (眉 目 傳 情)	mei2mu4chuan2qing2
@@ -80698,11 +74573,8 @@ $textmode
 (看 得 出 來)	kan4de5chu1lai5
 (看 得 出 来)	kan4de5chu1lai5
 (眼 珠 一 轉)	yan3zhu1yi2zhuan4
-(眼 珠 ㊀ 轉)	yan3zhu1yi2zhuan4
 (眼 珠 一 转)	yan3zhu1yi2zhuan4
-(眼 珠 ㊀ 转)	yan3zhu1yi2zhuan4
 (眾 口 一 詞)	zhong4kou3yi4ci2
-(眾 口 ㊀ 詞)	zhong4kou3yi4ci2
 (眾 矢 之 的)	zhong4shi3zhi1di4
 (睁 开 眼 睛)	zheng1kai1yan3jing1
 (睜 開 眼 睛)	zheng1kai1yan3jing1
@@ -80713,13 +74585,9 @@ $textmode
 (睡 不 著 覺)	shui4bu5zhao2jiao4
 (睡 不 著 覺)	shui4bu5zhao2jiao4
 (瞎 搞 一 通)	xia1gao3yi2tong4
-(瞎 搞 ㊀ 通)	xia1gao3yi2tong4
 (瞧 不 上 眼)	qiao2bu5shang4yan3
-(瞧 不 ㊤ 眼)	qiao2bu5shang4yan3
 (瞧 不 上 眼)	qiao2bu5shang4yan3
-(瞧 不 ㊤ 眼)	qiao2bu5shang4yan3
 (瞧 不 上 眼)	qiao2bu5shang4yan3
-(瞧 不 ㊤ 眼)	qiao2bu5shang4yan3
 (矇 在 鼓 裡)	meng2zai4gu3li3
 (矇 在 鼓 裡)	meng2zai4gu3li3
 (矇 地 卡 罗)	meng2di4ka3luo2
@@ -80729,23 +74597,18 @@ $textmode
 (矇 頭 轉 向)	meng1tou2zhuan3xiang4
 (矫 揉 造 作)	jiao3rou2zao4zuo4
 (矫 枉 过 正)	jiao3wang3guo4zheng4
-(矫 枉 过 ㊣)	jiao3wang3guo4zheng4
 (矫 枉 过 直)	jiao3wang3guo4zhi2
 (矫 枉 过 直)	jiao3wang3guo4zhi2
 (矮 人 一 截)	ai3ren2yi4jie2
-(矮 人 ㊀ 截)	ai3ren2yi4jie2
 (矮 杆 品 种)	ai3gan3pin3zhong3
 (矯 揉 造 作)	jiao3rou2zao4zuo4
 (矯 枉 過 正)	jiao3wang3guo4zheng4
-(矯 枉 過 ㊣)	jiao3wang3guo4zheng4
 (矯 枉 過 直)	jiao3wang3guo4zhi2
 (矯 枉 過 直)	jiao3wang3guo4zhi2
 (破 涕 为 笑)	po4ti4wei2xiao4
 (破 涕 為 笑)	po4ti4wei2xiao4
 (破 顏 一 笑)	po4yan2yi2xiao4
-(破 顏 ㊀ 笑)	po4yan2yi2xiao4
 (破 颜 一 笑)	po4yan2yi2xiao4
-(破 颜 ㊀ 笑)	po4yan2yi2xiao4
 (磁 单 极 子)	ci2dan1ji2zi3
 (磁 單 極 子)	ci2dan1ji2zi3
 (神 不 守 舍)	shen2bu4shou3she4
@@ -80760,13 +74623,9 @@ $textmode
 (神 差 鬼 使)	shen2chai1gui3shi3
 (神 差 鬼 使)	shen2chai1gui3shi3
 (神 气 十 足)	shen2qi5shi2zu2
-(神 气 ㊉ 足)	shen2qi5shi2zu2
 (神 气 十 足)	shen2qi5shi2zu2
-(神 气 ㊉ 足)	shen2qi5shi2zu2
 (神 氣 十 足)	shen2qi5shi2zu2
-(神 氣 ㊉ 足)	shen2qi5shi2zu2
 (神 氣 十 足)	shen2qi5shi2zu2
-(神 氣 ㊉ 足)	shen2qi5shi2zu2
 (神 話 故 事)	shen2hua4gu4shi4
 (神 話 故 事)	shen2hua4gu4shi4
 (神 话 故 事)	shen2hua4gu4shi4
@@ -80791,17 +74650,13 @@ $textmode
 (种 豆 得 麦)	zhong4dou4de2mai4
 (种 麦 得 麦)	zhong4mai4de2mai4
 (科 学 种 田)	ke1xue2zhong4tian2
-(科 ㊫ 种 田)	ke1xue2zhong4tian2
 (科 學 種 田)	ke1xue2zhong4tian2
 (科 納 克 裡)	ke1na4ke4li3
 (科 納 克 裡)	ke1na4ke4li3
 (秾 纤 得 中)	nong2xian1de2zhong1
-(秾 纤 得 🀄)	nong2xian1de2zhong1
-(秾 纤 得 ㊥)	nong2xian1de2zhong1
 (稀 稀 拉 拉)	xi1xi5la1la1
 (稀 稀 拉 拉)	xi1xi5la1la1
 (稍 稍 一 怔)	shao1shao1yi2zheng4
-(稍 稍 ㊀ 怔)	shao1shao1yi2zheng4
 (種 子 選 手)	zhong3zi3xuan3shou3
 (種 瓜 得 瓜)	zhong4gua1de2gua1
 (種 豆 得 豆)	zhong4dou4de2dou4
@@ -80811,8 +74666,6 @@ $textmode
 (稳 不 住 架)	wen3bu5zhu4jia4
 (積 於 忽 微)	ji1yu2hu1wei1
 (穠 纖 得 中)	nong2xian1de2zhong1
-(穠 纖 得 🀄)	nong2xian1de2zhong1
-(穠 纖 得 ㊥)	nong2xian1de2zhong1
 (穩 不 住 架)	wen3bu5zhu4jia4
 (穩 不 住 架)	wen3bu5zhu4jia4
 (窗 明 几 淨)	chuang1ming2ji1jing4
@@ -80832,42 +74685,25 @@ $textmode
 (笑 裡 藏 奸)	xiao4li3cang2jian1
 (笑 裡 藏 奸)	xiao4li3cang2jian1
 (第 一 世 界)	di4yi1shi4jie4
-(第 ㊀ 世 界)	di4yi1shi4jie4
 (第 一 人 称)	di4yi1ren2cheng1
-(第 ㊀ 人 称)	di4yi1ren2cheng1
 (第 一 人 稱)	di4yi1ren2cheng1
-(第 ㊀ 人 稱)	di4yi1ren2cheng1
 (第 一 夫 人)	di4yi1fu1ren2
-(第 ㊀ 夫 人)	di4yi1fu1ren2
 (第 一 性 徵)	di4yi1xing4zheng1
-(第 ㊀ 性 徵)	di4yi1xing4zheng1
 (第 一 語 言)	di4yi1yu3yan2
-(第 ㊀ 語 言)	di4yi1yu3yan2
 (第 一 语 言)	di4yi1yu3yan2
-(第 ㊀ 语 言)	di4yi1yu3yan2
 (第 比 利 斯)	di4bi4li4si1
 (第 比 利 斯)	di4bi4li4si1
 (笼 鸟 槛 猿)	long2niao3jian4yuan2
 (答 不 上 來)	da2bu5shang4lai5
-(答 不 ㊤ 來)	da2bu5shang4lai5
 (答 不 上 來)	da2bu5shang4lai5
-(答 不 ㊤ 來)	da2bu5shang4lai5
 (答 不 上 來)	da2bu5shang4lai5
-(答 不 ㊤ 來)	da2bu5shang4lai5
 (答 不 上 来)	da2bu5shang4lai5
-(答 不 ㊤ 来)	da2bu5shang4lai5
 (答 不 上 来)	da2bu5shang4lai5
-(答 不 ㊤ 来)	da2bu5shang4lai5
 (答 不 下 來)	da2bu5xia4lai5
-(答 不 ㊦ 來)	da2bu5xia4lai5
 (答 不 下 來)	da2bu5xia4lai5
-(答 不 ㊦ 來)	da2bu5xia4lai5
 (答 不 下 來)	da2bu5xia4lai5
-(答 不 ㊦ 來)	da2bu5xia4lai5
 (答 不 下 来)	da2bu5xia4lai5
-(答 不 ㊦ 来)	da2bu5xia4lai5
 (答 不 下 来)	da2bu5xia4lai5
-(答 不 ㊦ 来)	da2bu5xia4lai5
 (算 得 什 么)	suan4de5shen2me5
 (算 得 什 么)	suan4de5shen2me5
 (算 得 什 麼)	suan4de5shen2me5
@@ -80881,12 +74717,9 @@ $textmode
 (粉 不 喇 唧)	fen3bu5la1ji1
 (粉 不 喇 唧)	fen3bu5la1ji1
 (粗 略 一 看)	cu1lve4yi2kan4
-(粗 略 ㊀ 看)	cu1lve4yi2kan4
 (粗 略 一 看)	cu1lve4yi2kan4
-(粗 略 ㊀ 看)	cu1lve4yi2kan4
 (粮 食 供 应)	liang2shi5gong4ying4
 (粲 然 一 笑)	can4ran2yi2xiao4
-(粲 然 ㊀ 笑)	can4ran2yi2xiao4
 (精 明 强 干)	jing1ming2qiang2gan4
 (精 明 强 干)	jing1ming2qiang2gan4
 (精 灵 宝 钻)	jing1ling2bao3zuan4
@@ -80909,44 +74742,27 @@ $textmode
 (糧 食 供 應)	liang2shi5gong4ying4
 (糧 食 供 應)	liang2shi5gong4ying4
 (系 于 一 发)	xi4yu2yi2fa4
-(系 于 ㊀ 发)	xi4yu2yi2fa4
 (約 翰 一 書)	yue1han4yi4shu1
-(約 翰 ㊀ 書)	yue1han4yi4shu1
 (約 設 巴 設)	yue1she4ba1she4
 (紅 不 棱 登)	hong2bu5leng1deng1
 (紅 不 棱 登)	hong2bu5leng1deng1
 (細 嚼 慢 咽)	xi4jiao2man4yan4
 (細 嚼 慢 咽)	xi4jiao2man4yan4
 (終 有 一 日)	zhong1you3yi2ri4
-(終 有 ㊀ 日)	zhong1you3yi2ri4
-(終 ㊒ 一 日)	zhong1you3yi2ri4
-(終 有 一 ㊐)	zhong1you3yi2ri4
 (結 結 巴 巴)	jie1jie1ba1ba1
 (絕 大 部 份)	jue2da4bu4fen4
 (絞 盡 腦 汁)	jiao3jin4nao3zhi1
 (絮 絮 叨 叨)	xu4xu5dao1dao1
 (統 一 大 業)	tong3yi2da4ye4
-(統 ㊀ 大 業)	tong3yi2da4ye4
 (統 一 戰 線)	tong3yi2zhan4xian4
-(統 ㊀ 戰 線)	tong3yi2zhan4xian4
 (統 一 招 生)	tong3yi4zhao1sheng1
-(統 ㊀ 招 生)	tong3yi4zhao1sheng1
 (統 一 核 算)	tong3yi4he2suan4
-(統 ㊀ 核 算)	tong3yi4he2suan4
 (統 一 祖 國)	tong3yi4zu3guo2
-(統 ㊀ 祖 國)	tong3yi4zu3guo2
 (統 一 祖 國)	tong3yi4zu3guo2
-(統 ㊀ 祖 國)	tong3yi4zu3guo2
 (統 一 規 劃)	tong3yi4gui1hua4
-(統 ㊀ 規 劃)	tong3yi4gui1hua4
 (綠 女 紅 男)	lv4nv3hong2nan2
-(綠 女 紅 ㊚)	lv4nv3hong2nan2
-(綠 ㊛ 紅 男)	lv4nv3hong2nan2
 (綠 女 紅 男)	lv4nv3hong2nan2
-(綠 女 紅 ㊚)	lv4nv3hong2nan2
-(綠 ㊛ 紅 男)	lv4nv3hong2nan2
 (綠 女 紅 男)	lv4nv3hong2nan2
-(綠 女 紅 ㊚)	lv4nv3hong2nan2
 (綠 林 好 漢)	lu4lin2hao3han4
 (綠 林 好 漢)	lu4lin2hao3han4
 (綠 林 好 漢)	lu4lin2hao3han4
@@ -80964,55 +74780,36 @@ $textmode
 (繃 不 住 臉)	beng3bu5zhu4lian3
 (繃 不 住 臉)	beng3bu5zhu4lian3
 (繫 於 一 髮)	xi4yu2yi2fa4
-(繫 於 ㊀ 髮)	xi4yu2yi2fa4
 (红 不 棱 登)	hong2bu5leng1deng1
 (红 不 棱 登)	hong2bu5leng1deng1
 (约 翰 一 书)	yue1han4yi4shu1
-(约 翰 ㊀ 书)	yue1han4yi4shu1
 (约 设 巴 设)	yue1she4ba1she4
 (细 嚼 慢 咽)	xi4jiao2man4yan4
 (细 嚼 慢 咽)	xi4jiao2man4yan4
 (终 有 一 日)	zhong1you3yi2ri4
-(终 有 ㊀ 日)	zhong1you3yi2ri4
-(终 ㊒ 一 日)	zhong1you3yi2ri4
-(终 有 一 ㊐)	zhong1you3yi2ri4
 (结 结 巴 巴)	jie1jie1ba1ba1
 (绝 大 部 份)	jue2da4bu4fen4
 (统 一 大 业)	tong3yi2da4ye4
-(统 ㊀ 大 业)	tong3yi2da4ye4
 (统 一 战 线)	tong3yi2zhan4xian4
-(统 ㊀ 战 线)	tong3yi2zhan4xian4
 (统 一 招 生)	tong3yi4zhao1sheng1
-(统 ㊀ 招 生)	tong3yi4zhao1sheng1
 (统 一 核 算)	tong3yi4he2suan4
-(统 ㊀ 核 算)	tong3yi4he2suan4
 (统 一 祖 国)	tong3yi4zu3guo2
-(统 ㊀ 祖 国)	tong3yi4zu3guo2
 (统 一 祖 国)	tong3yi4zu3guo2
-(统 ㊀ 祖 国)	tong3yi4zu3guo2
 (统 一 规 划)	tong3yi4gui1hua4
-(统 ㊀ 规 划)	tong3yi4gui1hua4
 (绷 不 住 劲)	beng3bu5zhu4jin4
 (绷 不 住 劲)	beng3bu5zhu4jin4
 (绷 不 住 脸)	beng3bu5zhu4lian3
 (绷 不 住 脸)	beng3bu5zhu4lian3
 (绿 女 红 男)	lv4nv3hong2nan2
-(绿 女 红 ㊚)	lv4nv3hong2nan2
-(绿 ㊛ 红 男)	lv4nv3hong2nan2
 (绿 女 红 男)	lv4nv3hong2nan2
-(绿 女 红 ㊚)	lv4nv3hong2nan2
 (绿 林 好 汉)	lu4lin2hao3han4
 (绿 林 好 汉)	lu4lin2hao3han4
 (缝 缝 连 连)	feng2feng5lian2lian2
 (缝 衣 工 人)	feng2yi1gong1ren2
 (缺 一 不 可)	que1yi2bu4ke3
-(缺 ㊀ 不 可)	que1yi2bu4ke3
 (缺 一 不 可)	que1yi2bu4ke3
-(缺 ㊀ 不 可)	que1yi2bu4ke3
 (罗 切 斯 特)	luo2qie1si1te4
-(罗 切 斯 ㊕)	luo2qie1si1te4
 (罗 切 斯 特)	luo2qie1si1te4
-(罗 切 斯 ㊕)	luo2qie1si1te4
 (罗 摩 衍 那)	luo2mo2yan3na3
 (罗 斯 托 夫)	luo2si1tuo1fu1
 (罗 斯 涅 夫)	luo2si1nie4fu1
@@ -81020,13 +74817,9 @@ $textmode
 (罪 行 累 累)	zui4xing2lei3lei3
 (罪 行 累 累)	zui4xing2lei3lei3
 (置 之 一 笑)	zhi4zhi1yi2xiao4
-(置 之 ㊀ 笑)	zhi4zhi1yi2xiao4
 (羅 切 斯 特)	luo2qie1si1te4
-(羅 切 斯 ㊕)	luo2qie1si1te4
 (羅 切 斯 特)	luo2qie1si1te4
-(羅 切 斯 ㊕)	luo2qie1si1te4
 (羅 切 斯 特)	luo2qie1si1te4
-(羅 切 斯 ㊕)	luo2qie1si1te4
 (羅 摩 衍 那)	luo2mo2yan3na3
 (羅 摩 衍 那)	luo2mo2yan3na3
 (羅 斯 托 夫)	luo2si1tuo1fu1
@@ -81039,7 +74832,6 @@ $textmode
 (群 猴 猴 族)	qun2hou2hou5zu2
 (群 眾 組 織)	qun2zhong4zu3zhi5
 (羲 皇 上 人)	xi1huang2shang4ren2
-(羲 皇 ㊤ 人)	xi1huang2shang4ren2
 (翻 天 覆 地)	fan1tian1fu4di4
 (翻 天 覆 地)	fan1tian1fu4di4
 (翻 江 倒 海)	fan1jiang1dao3hai3
@@ -81078,28 +74870,18 @@ $textmode
 (考 波 什 堡)	kao3bo1shi2bao3
 (耿 耿 於 懷)	geng3geng3yu2huai2
 (聊 備 一 格)	liao2bei4yi4ge2
-(聊 備 ㊀ 格)	liao2bei4yi4ge2
 (聊 博 一 笑)	liao2bo2yi2xiao4
-(聊 博 ㊀ 笑)	liao2bo2yi2xiao4
 (聊 备 一 格)	liao2bei4yi4ge2
-(聊 备 ㊀ 格)	liao2bei4yi4ge2
 (联 成 一 组)	lian2cheng2yi4zu3
-(联 成 ㊀ 组)	lian2cheng2yi4zu3
 (聖 經 外 傳)	sheng4jing1wai4zhuan4
 (聖 經 賢 傳)	sheng4jing1xian2zhuan4
 (聖 赫 勒 拿)	sheng4he4lei1na2
 (聖 赫 勒 拿)	sheng4he4lei1na2
 (聞 一 知 十)	wen2yi4zhi1shi2
-(聞 一 知 ㊉)	wen2yi4zhi1shi2
-(聞 ㊀ 知 十)	wen2yi4zhi1shi2
 (聯 成 一 組)	lian2cheng2yi4zu3
-(聯 成 ㊀ 組)	lian2cheng2yi4zu3
 (聯 成 一 組)	lian2cheng2yi4zu3
-(聯 成 ㊀ 組)	lian2cheng2yi4zu3
 (聽 不 下 去)	ting1bu5xia4qu4
-(聽 不 ㊦ 去)	ting1bu5xia4qu4
 (聽 不 下 去)	ting1bu5xia4qu4
-(聽 不 ㊦ 去)	ting1bu5xia4qu4
 (聽 不 明 白)	ting1bu5ming2bai5
 (聽 不 明 白)	ting1bu5ming2bai5
 (聽 不 清 楚)	ting1bu5qing1chu3
@@ -81107,23 +74889,14 @@ $textmode
 (聽 不 進 去)	ting1bu5jin4qu5
 (聽 不 進 去)	ting1bu5jin4qu5
 (肥 瘦 得 中)	fei2shou4de2zhong1
-(肥 瘦 得 🀄)	fei2shou4de2zhong1
-(肥 瘦 得 ㊥)	fei2shou4de2zhong1
 (背 城 一 战)	bei4cheng2yi2zhan4
-(背 城 ㊀ 战)	bei4cheng2yi2zhan4
 (背 城 一 戰)	bei4cheng2yi2zhan4
-(背 城 ㊀ 戰)	bei4cheng2yi2zhan4
 (背 水 一 战)	bei4shui3yi2zhan4
-(背 ㊌ 一 战)	bei4shui3yi2zhan4
-(背 水 ㊀ 战)	bei4shui3yi2zhan4
 (背 水 一 戰)	bei4shui3yi2zhan4
-(背 ㊌ 一 戰)	bei4shui3yi2zhan4
-(背 水 ㊀ 戰)	bei4shui3yi2zhan4
 (胚 胎 发 生)	pei1tai1fa4sheng1
 (胡 作 非 为)	hu2zuo4fei1wei2
 (胡 作 非 為)	hu2zuo4fei1wei2
 (胡 搞 一 通)	hu2gao3yi4tong1
-(胡 搞 ㊀ 通)	hu2gao3yi4tong1
 (脚 踏 实 地)	jiao3ta4shi2di4
 (脫 不 得 身)	tuo1bu5de5shen1
 (脫 不 得 身)	tuo1bu5de5shen1
@@ -81132,21 +74905,13 @@ $textmode
 (脱 不 得 身)	tuo1bu5de5shen1
 (脱 骨 成 佛)	tuo1gu3cheng2fo2
 (脸 色 一 沉)	lian3se4yi4chen2
-(脸 色 ㊀ 沉)	lian3se4yi4chen2
 (腳 踏 實 地)	jiao3ta4shi2di4
 (臉 色 一 沉)	lian3se4yi4chen2
-(臉 色 ㊀ 沉)	lian3se4yi4chen2
 (臣 一 主 二)	chen2yi4zhu3er4
-(臣 ㊀ 主 二)	chen2yi4zhu3er4
-(臣 一 主 ㊁)	chen2yi4zhu3er4
 (臨 門 一 腳)	lin2men2yi4jiao3
-(臨 門 ㊀ 腳)	lin2men2yi4jiao3
 (臨 門 一 腳)	lin2men2yi4jiao3
-(臨 門 ㊀ 腳)	lin2men2yi4jiao3
 (自 一 推 万)	zi4yi4tui1wan4
-(自 ㊀ 推 万)	zi4yi4tui1wan4
 (自 一 推 萬)	zi4yi4tui1wan4
-(自 ㊀ 推 萬)	zi4yi4tui1wan4
 (自 作 聪 明)	zi4zuo4cong1ming2
 (自 作 聰 明)	zi4zuo4cong1ming2
 (自 吹 自 擂)	zi4chui1zi4lei2
@@ -81157,11 +74922,8 @@ $textmode
 (自 視 甚 高)	zi4shi4shen4gao1
 (自 视 甚 高)	zi4shi4shen4gao1
 (臭 名 昭 著)	chou4ming2zhao1zhu4
-(臭 ㊔ 昭 著)	chou4ming2zhao1zhu4
 (臭 名 昭 著)	chou4ming2zhao1zhu4
-(臭 ㊔ 昭 著)	chou4ming2zhao1zhu4
 (臭 名 昭 著)	chou4ming2zhao1zhu4
-(臭 ㊔ 昭 著)	chou4ming2zhao1zhu4
 (臻 於 完 善)	zhen1yu2wan2shan4
 (與 時 俱 進)	yu3shi2ju1jin4
 (興 得 起 來)	xing1de5qi3lai5
@@ -81174,9 +74936,7 @@ $textmode
 (興 高 彩 烈)	xing1gao1cai3lie4
 (興 高 彩 烈)	xing1gao1cai3lie4
 (舉 一 廢 百)	ju3yi2fei4bai3
-(舉 ㊀ 廢 百)	ju3yi2fei4bai3
 (舉 一 賅 百)	ju3yi4gai1bai3
-(舉 ㊀ 賅 百)	ju3yi4gai1bai3
 (舊 地 重 遊)	jiu4di4chong2you2
 (舍 己 为 人)	she3ji3wei4ren2
 (舍 己 爲 人)	she3ji3wei4ren2
@@ -81185,26 +74945,20 @@ $textmode
 (艾 哈 迈 德)	ai4ha3mai4de2
 (艾 哈 邁 德)	ai4ha3mai4de2
 (艾 扑 西 龙)	ai4pu1xi1long2
-(艾 扑 🀂 龙)	ai4pu1xi1long2
 (艾 撲 西 龍)	ai4pu1xi1long2
-(艾 撲 🀂 龍)	ai4pu1xi1long2
 (艾 撲 西 龍)	ai4pu1xi1long2
-(艾 撲 🀂 龍)	ai4pu1xi1long2
 (芥 兰 牛 肉)	jie4lan2niu2rou4
 (芥 蘭 牛 肉)	jie4lan2niu2rou4
 (芥 蘭 牛 肉)	jie4lan2niu2rou4
 (花 不 棱 登)	hua1bu5leng1deng1
 (花 不 棱 登)	hua1bu5leng1deng1
 (花 朝 月 夕)	hua1zhao1yue4xi1
-(花 朝 ㊊ 夕)	hua1zhao1yue4xi1
 (花 花 搭 搭)	hua1hua5da1da1
 (花 花 肠 子)	hua1hua5chang2zi5
 (花 花 腸 子)	hua1hua5chang2zi5
 (苍 生 涂 炭)	cang1sheng1tu2tan4
 (苏 拉 威 西)	su1la1wei1xi1
-(苏 拉 威 🀂)	su1la1wei1xi1
 (苏 拉 威 西)	su1la1wei1xi1
-(苏 拉 威 🀂)	su1la1wei1xi1
 (苦 不 唧 儿)	ku3bu5ji1r5
 (苦 不 唧 儿)	ku3bu5ji1r5
 (苦 不 唧 兒)	ku3bu5ji1r5
@@ -81222,27 +74976,20 @@ $textmode
 (草 食 動 物)	cao3shi2dong4wu5
 (荣 誉 教 授)	rong2yu2jiao4shou4
 (莞 尔 一 笑)	wan3er3yi2xiao4
-(莞 尔 ㊀ 笑)	wan3er3yi2xiao4
 (莞 爾 一 笑)	wan3er3yi2xiao4
-(莞 爾 ㊀ 笑)	wan3er3yi2xiao4
 (莫 可 指 数)	mo4ke3zhi3shu3
 (莫 可 指 數)	mo4ke3zhi3shu3
 (莫 可 指 數)	mo4ke3zhi3shu3
 (莫 名 一 文)	mo4ming2yi4wen2
-(莫 名 ㊀ 文)	mo4ming2yi4wen2
-(莫 ㊔ 一 文)	mo4ming2yi4wen2
 (華 納 兄 弟)	hua4na4xiong1di4
 (華 納 兄 弟)	hua4na4xiong1di4
 (萃 於 一 堂)	cui4yu2yi4tang2
-(萃 於 ㊀ 堂)	cui4yu2yi4tang2
 (萃 於 一 身)	cui4yu2yi4shen1
-(萃 於 ㊀ 身)	cui4yu2yi4shen1
 (萨 哈 洛 夫)	sa4ha1luo4fu1
 (萨 哈 洛 夫)	sa4ha1luo4fu1
 (萨 哈 罗 夫)	sa4ha3luo2fu1
 (萨 哈 诺 夫)	sa4ha3nuo4fu1
 (萬 無 一 失)	wan4wu2yi4shi1
-(萬 無 ㊀ 失)	wan4wu2yi4shi1
 (著 称 于 世)	zhu4cheng1yu2shi4
 (著 称 于 世)	zhu4cheng1yu2shi4
 (著 稱 於 世)	zhu4cheng1yu2shi4
@@ -81276,46 +75023,29 @@ $textmode
 (藏 茴 香 果)	zang4hui2xiang1guo3
 (藏 身 之 地)	cang2shen1zhi1di4
 (蘇 拉 威 西)	su1la1wei1xi1
-(蘇 拉 威 🀂)	su1la1wei1xi1
 (蘇 拉 威 西)	su1la1wei1xi1
-(蘇 拉 威 🀂)	su1la1wei1xi1
 (處 之 泰 然)	chu3zhi1tai4ran2
 (虚 与 委 蛇)	xu1yu3wei1yi2
 (虚 惊 一 场)	xu1jing1yi4chang3
-(虚 惊 ㊀ 场)	xu1jing1yi4chang3
 (虚 无 缥 缈)	xu1wu2piao1miao3
 (虚 晃 一 下)	xu1huang3yi2xia4
-(虚 晃 一 ㊦)	xu1huang3yi2xia4
-(虚 晃 ㊀ 下)	xu1huang3yi2xia4
 (虚 晃 一 枪)	xu1huang3yi4qiang1
-(虚 晃 ㊀ 枪)	xu1huang3yi4qiang1
 (虛 晃 一 下)	xu1huang3yi2xia4
-(虛 晃 一 ㊦)	xu1huang3yi2xia4
-(虛 晃 ㊀ 下)	xu1huang3yi2xia4
 (虛 晃 一 槍)	xu1huang3yi4qiang1
-(虛 晃 ㊀ 槍)	xu1huang3yi4qiang1
 (虛 無 縹 緲)	xu1wu2piao1miao3
 (虛 與 委 蛇)	xu1yu3wei1yi2
 (虛 驚 一 場)	xu1jing1yi4chang3
-(虛 驚 ㊀ 場)	xu1jing1yi4chang3
 (虾 兵 蟹 将)	xia1bing1xie4jiang4
 (蛛 丝 马 迹)	zhu1si1ma3ji4
 (蛛 絲 馬 跡)	zhu1si1ma3ji4
 (蛟 龍 得 水)	jiao1long2de2shui3
-(蛟 龍 得 ㊌)	jiao1long2de2shui3
 (蛟 龍 得 水)	jiao1long2de2shui3
-(蛟 龍 得 ㊌)	jiao1long2de2shui3
 (蛟 龙 得 水)	jiao1long2de2shui3
-(蛟 龙 得 ㊌)	jiao1long2de2shui3
 (蝦 兵 蟹 將)	xia1bing1xie4jiang4
 (融 为 一 体)	rong2wei2yi4ti3
-(融 为 ㊀ 体)	rong2wei2yi4ti3
 (融 合 为 一)	rong2he2wei4yi1
-(融 合 为 ㊀)	rong2he2wei4yi1
 (融 合 為 一)	rong2he2wei4yi1
-(融 合 為 ㊀)	rong2he2wei4yi1
 (融 為 一 體)	rong2wei2yi4ti3
-(融 為 ㊀ 體)	rong2wei2yi4ti3
 (血 债 累 累)	xue4zhai4lei3lei3
 (血 债 累 累)	xue4zhai4lei3lei3
 (血 債 累 累)	xue4zhai4lei3lei3
@@ -81324,7 +75054,6 @@ $textmode
 (血 流 漂 杵)	xue4liu2piao1chu3
 (血 流 漂 杵)	xue4liu2piao1chu3
 (血 濃 於 水)	xue4nong2yu2shui3
-(血 濃 於 ㊌)	xue4nong2yu2shui3
 (血 跡 斑 斑)	xue4ji1ban1ban1
 (血 迹 斑 斑)	xue4ji1ban1ban1
 (衡 量 得 失)	heng2liang2de2shi1
@@ -81338,7 +75067,6 @@ $textmode
 (衣 锦 荣 归)	yi4jin3rong2gui1
 (衣 锦 还 乡)	yi4jin3huan2xiang1
 (袒 臂 一 呼)	tan3bi4yi4hu1
-(袒 臂 ㊀ 呼)	tan3bi4yi4hu1
 (被 子 植 物)	bei4zi3zhi2wu4
 (裡 出 外 進)	li3chu1wai4jin4
 (裡 出 外 進)	li3chu1wai4jin4
@@ -81349,69 +75077,37 @@ $textmode
 (裸 子 植 物)	luo3zi3zhi2wu4
 (裸 子 植 物)	luo3zi3zhi2wu4
 (西 利 西 亚)	xi1li4xi1ya4
-(🀂 利 🀂 亚)	xi1li4xi1ya4
 (西 利 西 亚)	xi1li4xi1ya4
-(🀂 利 🀂 亚)	xi1li4xi1ya4
 (西 利 西 亞)	xi1li4xi1ya4
-(🀂 利 🀂 亞)	xi1li4xi1ya4
 (西 利 西 亞)	xi1li4xi1ya4
-(🀂 利 🀂 亞)	xi1li4xi1ya4
 (西 双 版 纳)	xi1shuang1ban3na4
-(🀂 双 版 纳)	xi1shuang1ban3na4
 (西 古 提 人)	xi1gu3ti2ren2
-(🀂 古 提 人)	xi1gu3ti2ren2
 (西 太 平 洋)	xi1tai4ping2yang2
-(🀂 太 平 洋)	xi1tai4ping2yang2
 (西 拿 基 立)	xi1na2ji1li4
-(🀂 拿 基 立)	xi1na2ji1li4
 (西 拿 基 立)	xi1na2ji1li4
-(🀂 拿 基 立)	xi1na2ji1li4
 (西 撒 哈 拉)	xi1sa1ha1la1
-(🀂 撒 哈 拉)	xi1sa1ha1la1
 (西 撒 哈 拉)	xi1sa1ha1la1
-(🀂 撒 哈 拉)	xi1sa1ha1la1
 (西 斯 塔 尼)	xi1si1ta3ni2
-(🀂 斯 塔 尼)	xi1si1ta3ni2
 (西 格 蒙 德)	xi1ge2meng1de2
-(🀂 格 蒙 德)	xi1ge2meng1de2
 (西 沙 群 岛)	xi1sha1qun2dao3
-(🀂 沙 群 岛)	xi1sha1qun2dao3
 (西 沙 群 島)	xi1sha1qun2dao3
-(🀂 沙 群 島)	xi1sha1qun2dao3
 (西 洛 賽 賓)	xi1luo4sai4bin1
-(🀂 洛 賽 賓)	xi1luo4sai4bin1
 (西 洛 賽 賓)	xi1luo4sai4bin1
-(🀂 洛 賽 賓)	xi1luo4sai4bin1
 (西 洛 賽 賓)	xi1luo4sai4bin1
-(🀂 洛 賽 賓)	xi1luo4sai4bin1
 (西 洛 赛 宾)	xi1luo4sai4bin1
-(🀂 洛 赛 宾)	xi1luo4sai4bin1
 (西 洛 赛 宾)	xi1luo4sai4bin1
-(🀂 洛 赛 宾)	xi1luo4sai4bin1
 (西 罗 非 哈)	xi1luo2fei1ha1
-(🀂 罗 非 哈)	xi1luo2fei1ha1
 (西 羅 非 哈)	xi1luo2fei1ha1
-(🀂 羅 非 哈)	xi1luo2fei1ha1
 (西 羅 非 哈)	xi1luo2fei1ha1
-(🀂 羅 非 哈)	xi1luo2fei1ha1
 (西 萨 摩 亚)	xi1sa4mo2ya4
-(🀂 萨 摩 亚)	xi1sa4mo2ya4
 (西 薩 摩 亞)	xi1sa4mo2ya4
-(🀂 薩 摩 亞)	xi1sa4mo2ya4
 (西 西 裡 島)	xi1xi1li3dao3
-(🀂 🀂 裡 島)	xi1xi1li3dao3
 (西 西 裡 島)	xi1xi1li3dao3
-(🀂 🀂 裡 島)	xi1xi1li3dao3
 (西 里 西 亚)	xi1li3xi1ya4
-(🀂 里 🀂 亚)	xi1li3xi1ya4
 (西 里 西 亚)	xi1li3xi1ya4
-(🀂 里 🀂 亚)	xi1li3xi1ya4
 (西 里 西 亞)	xi1li3xi1ya4
-(🀂 里 🀂 亞)	xi1li3xi1ya4
 (西 里 西 亞)	xi1li3xi1ya4
-(🀂 里 🀂 亞)	xi1li3xi1ya4
 (西 雙 版 納)	xi1shuang1ban3na4
-(🀂 雙 版 納)	xi1shuang1ban3na4
 (見 微 知 著)	jian4wei1zhi1zhu4
 (見 微 知 著)	jian4wei1zhi1zhu4
 (見 微 知 著)	jian4wei1zhi1zhu4
@@ -81440,28 +75136,20 @@ $textmode
 (解 決 不 了)	jie3jue2bu5liao3
 (解 決 不 了)	jie3jue2bu5liao3
 (解 球 不 下)	jie3qiu2bu5xia4
-(解 球 不 ㊦)	jie3qiu2bu5xia4
 (解 球 不 下)	jie3qiu2bu5xia4
-(解 球 不 ㊦)	jie3qiu2bu5xia4
 (言 不 得 当)	yan2bu4de2dang4
 (言 不 得 当)	yan2bu4de2dang4
 (言 不 得 當)	yan2bu4de2dang4
 (言 不 得 當)	yan2bu4de2dang4
 (言 归 正 传)	yan2gui1zheng4zhuan4
-(言 归 ㊣ 传)	yan2gui1zheng4zhuan4
 (言 歸 正 傳)	yan2gui1zheng4zhuan4
-(言 歸 ㊣ 傳)	yan2gui1zheng4zhuan4
 (訊 框 傳 送)	xun4kuang4chuan2song4
 (記 錄 下 來)	ji4lu4xia4lai2
-(記 錄 ㊦ 來)	ji4lu4xia4lai2
 (記 錄 下 來)	ji4lu4xia4lai2
-(記 錄 ㊦ 來)	ji4lu4xia4lai2
 (記 錄 下 來)	ji4lu4xia4lai2
-(記 錄 ㊦ 來)	ji4lu4xia4lai2
 (訪 親 問 友)	fang3qin1wen4you3
 (設 身 處 地)	she4shen1chu3di4
 (話 題 一 轉)	hua4ti2yi4zhuan3
-(話 題 ㊀ 轉)	hua4ti2yi4zhuan3
 (誅 盡 殺 絕)	zhu1jin4sha1jue2
 (誅 盡 殺 絕)	zhu1jin4sha1jue2
 (誅 盡 殺 絕)	zhu1jin4sha1jue2
@@ -81469,17 +75157,9 @@ $textmode
 (誓 死 不 降)	shi4si3bu4xiang2
 (誓 死 不 降)	shi4si3bu4xiang2
 (說 一 不 二)	shuo1yi2bu2er4
-(說 ㊀ 不 二)	shuo1yi2bu2er4
-(說 一 不 ㊁)	shuo1yi2bu2er4
 (說 一 不 二)	shuo1yi2bu2er4
-(說 ㊀ 不 二)	shuo1yi2bu2er4
-(說 一 不 ㊁)	shuo1yi2bu2er4
 (說 一 不 二)	shuo1yi2bu2er4
-(說 ㊀ 不 二)	shuo1yi2bu2er4
-(說 一 不 ㊁)	shuo1yi2bu2er4
 (說 一 不 二)	shuo1yi2bu2er4
-(說 ㊀ 不 二)	shuo1yi2bu2er4
-(說 一 不 ㊁)	shuo1yi2bu2er4
 (說 不 出 來)	shuo1bu5chu1lai5
 (說 不 出 來)	shuo1bu5chu1lai5
 (說 不 出 來)	shuo1bu5chu1lai5
@@ -81507,11 +75187,8 @@ $textmode
 (說 不 過 去)	shuo1bu5guo4qu5
 (說 不 過 去)	shuo1bu5guo4qu5
 (說 得 下 去)	shuo1de5xia4qu4
-(說 得 ㊦ 去)	shuo1de5xia4qu4
 (說 得 下 去)	shuo1de5xia4qu4
-(說 得 ㊦ 去)	shuo1de5xia4qu4
 (說 得 下 去)	shuo1de5xia4qu4
-(說 得 ㊦ 去)	shuo1de5xia4qu4
 (說 得 恰 當)	shuo1de5qia4dang1
 (說 得 恰 當)	shuo1de5qia4dang1
 (說 得 恰 當)	shuo1de5qia4dang1
@@ -81530,7 +75207,6 @@ $textmode
 (談 天 說 地)	tan2tian1shuo1di4
 (談 天 說 地)	tan2tian1shuo1di4
 (諷 一 勸 百)	feng3yi2quan4bai3
-(諷 ㊀ 勸 百)	feng3yi2quan4bai3
 (謀 臣 猛 將)	mou2chen2meng3jiang4
 (講 不 出 口)	jiang3bu5chu1kou3
 (講 不 出 口)	jiang3bu5chu1kou3
@@ -81555,11 +75231,9 @@ $textmode
 (认 死 理 儿)	ren4si3li3r5
 (讯 框 传 送)	xun4kuang4chuan2song4
 (记 录 下 来)	ji4lu4xia4lai2
-(记 录 ㊦ 来)	ji4lu4xia4lai2
 (讲 不 出 口)	jiang3bu5chu1kou3
 (讲 不 出 口)	jiang3bu5chu1kou3
 (讽 一 劝 百)	feng3yi2quan4bai3
-(讽 ㊀ 劝 百)	feng3yi2quan4bai3
 (设 身 处 地)	she4shen1chu3di4
 (访 亲 问 友)	fang3qin1wen4you3
 (识 多 才 广)	shi2duo1cai2guang3
@@ -81571,13 +75245,8 @@ $textmode
 (识 途 老 马)	shi2tu2lao3ma3
 (词 干 启 动)	ci2gan4qi3dong4
 (话 题 一 转)	hua4ti2yi4zhuan3
-(话 题 ㊀ 转)	hua4ti2yi4zhuan3
 (说 一 不 二)	shuo1yi2bu2er4
-(说 ㊀ 不 二)	shuo1yi2bu2er4
-(说 一 不 ㊁)	shuo1yi2bu2er4
 (说 一 不 二)	shuo1yi2bu2er4
-(说 ㊀ 不 二)	shuo1yi2bu2er4
-(说 一 不 ㊁)	shuo1yi2bu2er4
 (说 不 出 口)	shuo1bu5chu1kou3
 (说 不 出 口)	shuo1bu5chu1kou3
 (说 不 出 来)	shuo1bu5chu1lai5
@@ -81592,13 +75261,11 @@ $textmode
 (说 不 过 去)	shuo1bu5guo4qu5
 (说 不 过 去)	shuo1bu5guo4qu5
 (说 得 下 去)	shuo1de5xia4qu4
-(说 得 ㊦ 去)	shuo1de5xia4qu4
 (说 得 恰 当)	shuo1de5qia4dang1
 (说 文 解 字)	shuo1wen2jie3zi4
 (谁 人 乐 队)	shei2ren2yue4dui4
 (调 和 分 析)	tiao2he2fen1xi1
 (调 嘴 学 舌)	tiao2zui3xue2she2
-(调 嘴 ㊫ 舌)	tiao2zui3xue2she2
 (谈 天 说 地)	tan2tian1shuo1di4
 (谋 臣 猛 将)	mou2chen2meng3jiang4
 (谢 天 谢 地)	xie4tian1xie4di4
@@ -81611,22 +75278,16 @@ $textmode
 (貪 多 務 得)	tan1duo1wu4de2
 (貪 得 無 厭)	tan1de2wu2yan4
 (買 一 送 一)	mai3yi2song4yi1
-(買 ㊀ 送 ㊀)	mai3yi2song4yi1
 (費 爾 巴 哈)	fei4er3ba1ha1
 (費 爾 干 納)	fei4er3gan4na4
 (費 盡 心 思)	fei4jin4xin1si5
 (賈 南 德 拉)	jia3nan2de2la1
-(賈 🀁 德 拉)	jia3nan2de2la1
 (賈 南 德 拉)	jia3nan2de2la1
-(賈 🀁 德 拉)	jia3nan2de2la1
 (賈 南 德 拉)	jia3nan2de2la1
-(賈 🀁 德 拉)	jia3nan2de2la1
 (賈 夾 威 德)	jia3jia1wei1de2
 (賈 夾 威 德)	jia3jia1wei1de2
 (賊 眼 一 溜)	zei2yan3yi4liu1
-(賊 眼 ㊀ 溜)	zei2yan3yi4liu1
 (賊 眼 一 溜)	zei2yan3yi4liu1
-(賊 眼 ㊀ 溜)	zei2yan3yi4liu1
 (賣 不 出 去)	mai4bu5chu1qu5
 (賣 不 出 去)	mai4bu5chu1qu5
 (负 债 累 累)	fu4zhai4lei3lei3
@@ -81643,13 +75304,9 @@ $textmode
 (费 尔 巴 哈)	fei4er3ba1ha1
 (费 尔 干 纳)	fei4er3gan4na4
 (贼 眼 一 溜)	zei2yan3yi4liu1
-(贼 眼 ㊀ 溜)	zei2yan3yi4liu1
 (贼 眼 一 溜)	zei2yan3yi4liu1
-(贼 眼 ㊀ 溜)	zei2yan3yi4liu1
 (贾 南 德 拉)	jia3nan2de2la1
-(贾 🀁 德 拉)	jia3nan2de2la1
 (贾 南 德 拉)	jia3nan2de2la1
-(贾 🀁 德 拉)	jia3nan2de2la1
 (贾 夹 威 德)	jia3jia1wei1de2
 (赫 魯 雪 夫)	he4lu3xue3fu1
 (赫 魯 雪 夫)	he4lu3xue3fu1
@@ -81669,11 +75326,8 @@ $textmode
 (跑 跑 顛 顛)	pao3pao5dian1dian1
 (跑 跑 颠 颠)	pao3pao5dian1dian1
 (跨 鶴 西 遊)	kua4he4xi1you2
-(跨 鶴 🀂 遊)	kua4he4xi1you2
 (跨 鶴 西 遊)	kua4he4xi1you2
-(跨 鶴 🀂 遊)	kua4he4xi1you2
 (跨 鹤 西 遊)	kua4he4xi1you2
-(跨 鹤 🀂 遊)	kua4he4xi1you2
 (踏 踏 实 实)	ta1ta1shi2shi2
 (踏 踏 實 實)	ta1ta1shi2shi2
 (蹦 蹦 跳 跳)	beng4beng5tiao4tiao4
@@ -81693,7 +75347,6 @@ $textmode
 (轉 磨 不 開)	zhuan4mo5bu5kai1
 (轉 磨 不 開)	zhuan4mo5bu5kai1
 (轉 而 一 想)	zhuan3er2yi4xiang3
-(轉 而 ㊀ 想)	zhuan3er2yi4xiang3
 (轉 變 抹 角)	zhuan3bian4mo4jiao3
 (轉 變 抹 角)	zhuan3bian4mo4jiao3
 (车 行 通 道)	che1hang2tong1dao4
@@ -81706,7 +75359,6 @@ $textmode
 (转 磨 不 开)	zhuan4mo5bu5kai1
 (转 磨 不 开)	zhuan4mo5bu5kai1
 (转 而 一 想)	zhuan3er2yi4xiang3
-(转 而 ㊀ 想)	zhuan3er2yi4xiang3
 (转 败 为 胜)	zhuan3bai4wei2sheng4
 (轴 突 运 输)	zhou2tu2yun4shu1
 (轴 突 运 输)	zhou2tu2yun4shu1
@@ -81715,13 +75367,11 @@ $textmode
 (辣 不 唧 兒)	la4bu5ji1r5
 (辣 不 唧 兒)	la4bu5ji1r5
 (过 一 会 儿)	guo4yi4hui3r5
-(过 ㊀ 会 儿)	guo4yi4hui3r5
 (过 去 分 词)	guo4qu4fen1ci2
 (近 乎 同 步)	jin1hu5tong2bu4
 (还 以 颜 色)	huan2yi3yan2se4
 (这 早 晚 儿)	zhe4zao3wan3r5
 (迦 西 斐 雅)	jia1xi1fei3ya3
-(迦 🀂 斐 雅)	jia1xi1fei3ya3
 (迪 斯 科 吧)	di2si1ke1ba1
 (迷 迷 糊 糊)	mi2mi2hu1hu1
 (退 耕 还 林)	tui4geng1huan2lin2
@@ -81729,7 +75379,6 @@ $textmode
 (退 耕 還 林)	tui4geng1huan2lin2
 (退 耕 還 林)	tui4geng1huan2lin2
 (退 避 三 舍)	tui4bi4san1she4
-(退 避 ㊂ 舍)	tui4bi4san1she4
 (适 度 微 调)	shi4du4wei1tiao2
 (适 度 微 调)	shi4du4wei1tiao2
 (适 得 其 反)	shi4de2qi2fan3
@@ -81742,24 +75391,17 @@ $textmode
 (透 不 過 氣)	tou4bu5guo4qi4
 (透 不 過 氣)	tou4bu5guo4qi4
 (逐 一 解 决)	zhu2yi4jie3jue2
-(逐 ㊀ 解 决)	zhu2yi4jie3jue2
 (逐 一 解 決)	zhu2yi4jie3jue2
-(逐 ㊀ 解 決)	zhu2yi4jie3jue2
 (逐 兔 先 得)	zhu2tu4xian1de2
 (遊 手 好 閑)	you2shou3hao4xian2
 (遊 手 好 闲)	you2shou3hao4xian2
 (過 一 會 兒)	guo4yi4hui3r5
-(過 ㊀ 會 兒)	guo4yi4hui3r5
 (過 去 分 詞)	guo4qu4fen1ci2
 (遗 妻 弃 子)	yi2qi1qi4zi3
 (適 度 微 調)	shi4du4wei1tiao2
-(㊜ 度 微 調)	shi4du4wei1tiao2
 (適 度 微 調)	shi4du4wei1tiao2
-(㊜ 度 微 調)	shi4du4wei1tiao2
 (適 度 微 調)	shi4du4wei1tiao2
-(㊜ 度 微 調)	shi4du4wei1tiao2
 (適 得 其 反)	shi4de2qi2fan3
-(㊜ 得 其 反)	shi4de2qi2fan3
 (遺 妻 棄 子)	yi2qi1qi4zi3
 (避 不 作 答)	bi4bu5zuo4da2
 (避 不 作 答)	bi4bu5zuo4da2
@@ -81808,17 +75450,12 @@ $textmode
 (重 歷 舊 遊)	chong2li4jiu4you2
 (重 眼 皮 儿)	chong2yan3pi2r5
 (重 睹 天 日)	chong2du3tian1ri4
-(重 睹 天 ㊐)	chong2du3tian1ri4
 (重 碳 酸 鈣)	chong2tan4suan1gai4
 (重 碳 酸 钙)	chong2tan4suan1gai4
 (重 聚 一 堂)	chong2ju4yi4tang2
-(重 聚 ㊀ 堂)	chong2ju4yi4tang2
 (重 見 天 日)	chong2jian4tian1ri4
-(重 見 天 ㊐)	chong2jian4tian1ri4
 (重 見 天 日)	chong2jian4tian1ri4
-(重 見 天 ㊐)	chong2jian4tian1ri4
 (重 见 天 日)	chong2jian4tian1ri4
-(重 见 天 ㊐)	chong2jian4tian1ri4
 (重 足 而 立)	chong2zu2er2li4
 (重 足 而 立)	chong2zu2er2li4
 (重 蹈 覆 轍)	chong2dao3fu4zhe2
@@ -81836,40 +75473,30 @@ $textmode
 (量 力 而 為)	liang4li4er2wei2
 (量 力 而 為)	liang4li4er2wei2
 (金 属 薄 片)	jin1shu3bo2pian4
-(㊎ 属 薄 片)	jin1shu3bo2pian4
 (金 属 薄 片)	jin1shu3bo2pian4
 (金 屬 薄 片)	jin1shu3bo2pian4
-(㊎ 屬 薄 片)	jin1shu3bo2pian4
 (金 屬 薄 片)	jin1shu3bo2pian4
 (金 蝉 脱 壳)	jin1chan2tuo1qiao4
-(㊎ 蝉 脱 壳)	jin1chan2tuo1qiao4
 (金 蝉 脱 壳)	jin1chan2tuo1qiao4
 (金 蟬 脫 殼)	jin1chan2tuo1qiao4
-(㊎ 蟬 脫 殼)	jin1chan2tuo1qiao4
 (金 蟬 脫 殼)	jin1chan2tuo1qiao4
 (鉛 刀 一 割)	qian1dao1yi4ge1
-(鉛 刀 ㊀ 割)	qian1dao1yi4ge1
 (鋪 天 蓋 地)	pu1tian1gai4di4
 (鋪 蓋 卷 兒)	pu1gai5juan3r5
 (鐘 鳴 漏 盡)	zhong1ming2lou4jin4
 (鐘 鳴 漏 盡)	zhong1ming2lou4jin4
 (鑽 火 得 冰)	zuan1huo3de2bing1
-(鑽 ㊋ 得 冰)	zuan1huo3de2bing1
 (鑽 頭 卡 盤)	zuan4tou2qia3pan2
 (鑽 頭 夾 盤)	zuan1tou2jia2pan2
 (钻 头 卡 盘)	zuan4tou2qia3pan2
 (钻 头 夹 盘)	zuan1tou2jia2pan2
 (钻 火 得 冰)	zuan1huo3de2bing1
-(钻 ㊋ 得 冰)	zuan1huo3de2bing1
 (铅 刀 一 割)	qian1dao1yi4ge1
-(铅 刀 ㊀ 割)	qian1dao1yi4ge1
 (铺 天 盖 地)	pu1tian1gai4di4
 (铺 盖 卷 儿)	pu1gai5juan3r5
 (長 此 下 去)	chang2ci3xia4qu4
-(長 此 ㊦ 去)	chang2ci3xia4qu4
 (長 點 心 眼)	chang2dian3xin1yan3
 (长 此 下 去)	chang2ci3xia4qu4
-(长 此 ㊦ 去)	chang2ci3xia4qu4
 (长 点 心 眼)	chang2dian3xin1yan3
 (門 捷 列 夫)	men2jie2lie4fu1
 (門 捷 列 夫)	men2jie2lie4fu1
@@ -81884,8 +75511,6 @@ $textmode
 (闹 不 清 楚)	nao4bu5qing1chu3
 (闹 不 清 楚)	nao4bu5qing1chu3
 (闻 一 知 十)	wen2yi4zhi1shi2
-(闻 一 知 ㊉)	wen2yi4zhi1shi2
-(闻 ㊀ 知 十)	wen2yi4zhi1shi2
 (阳 欧 予 倩)	ou1yang2yu2qian4
 (阴 曹 地 府)	yin1cao2di4fu3
 (阻 挡 不 住)	zu3dang3bu5zhu4
@@ -81917,9 +75542,7 @@ $textmode
 (阿 瓦 裡 德)	a1wa3li3de2
 (阿 瓦 裡 德)	a1wa3li3de2
 (阿 甘 正 传)	a1gan1zheng4zhuan4
-(阿 甘 ㊣ 传)	a1gan1zheng4zhuan4
 (阿 甘 正 傳)	a1gan1zheng4zhuan4
-(阿 甘 ㊣ 傳)	a1gan1zheng4zhuan4
 (阿 里 地 区)	a1li3di4qu4
 (阿 里 地 区)	a1li3di4qu4
 (阿 里 地 區)	a1li3di4qu4
@@ -81927,11 +75550,7 @@ $textmode
 (阿 鼻 地 狱)	a1bi2di4yu4
 (阿 鼻 地 獄)	a1bi2di4yu4
 (附 上 一 笔)	fu4shang5yi4bi3
-(附 ㊤ 一 笔)	fu4shang5yi4bi3
-(附 上 ㊀ 笔)	fu4shang5yi4bi3
 (附 上 一 筆)	fu4shang5yi4bi3
-(附 ㊤ 一 筆)	fu4shang5yi4bi3
-(附 上 ㊀ 筆)	fu4shang5yi4bi3
 (降 妖 伏 磨)	xiang2yao1fu2mo2
 (降 妖 伏 磨)	xiang2yao1fu2mo2
 (除 恶 务 尽)	chu2e4wu4jin4
@@ -81949,13 +75568,9 @@ $textmode
 (难 以 应 付)	nan2yi3ying4fu4
 (难 得 要 命)	nan2de5yao4ming4
 (雄 据 一 方)	xiong2ju1yi4fang1
-(雄 据 ㊀ 方)	xiong2ju1yi4fang1
 (雄 據 一 方)	xiong2ju1yi4fang1
-(雄 據 ㊀ 方)	xiong2ju1yi4fang1
 (集 於 一 身)	ji2yu2yi4shen1
-(集 於 ㊀ 身)	ji2yu2yi4shen1
 (雙 膝 跪 下)	shuang1xi1gui4xia4
-(雙 膝 跪 ㊦)	shuang1xi1gui4xia4
 (難 以 應 付)	nan2yi3ying4fu4
 (難 以 應 付)	nan2yi3ying4fu4
 (難 以 應 付)	nan2yi3ying4fu4
@@ -81972,9 +75587,7 @@ $textmode
 (霧 裡 看 花)	wu4li3kan4hua1
 (霧 裡 看 花)	wu4li3kan4hua1
 (露 一 鼻 子)	lou4yi4bi2zi5
-(露 ㊀ 鼻 子)	lou4yi4bi2zi5
 (露 一 鼻 子)	lou4yi4bi2zi5
-(露 ㊀ 鼻 子)	lou4yi4bi2zi5
 (露 齒 而 笑)	lu4chi3er2xiao4
 (露 齒 而 笑)	lu4chi3er2xiao4
 (露 齿 而 笑)	lu4chi3er2xiao4
@@ -82005,8 +75618,6 @@ $textmode
 (預 備 知 識)	yu4bei4zhi1shi2
 (頭 面 人 物)	tou2mian4ren2wu4
 (顛 三 倒 四)	dian1san1dao3si4
-(顛 ㊂ 倒 四)	dian1san1dao3si4
-(顛 三 倒 ㊃)	dian1san1dao3si4
 (顛 來 倒 去)	dian1lai2dao3qu4
 (顛 來 倒 去)	dian1lai2dao3qu4
 (顛 鸞 倒 鳳)	dian1luan2dao3feng4
@@ -82021,8 +75632,6 @@ $textmode
 (顾 不 过 来)	gu4bu5guo4lai5
 (预 备 知 识)	yu4bei4zhi1shi2
 (颠 三 倒 四)	dian1san1dao3si4
-(颠 ㊂ 倒 四)	dian1san1dao3si4
-(颠 三 倒 ㊃)	dian1san1dao3si4
 (颠 来 倒 去)	dian1lai2dao3qu4
 (颠 鸾 倒 凤)	dian1luan2dao3feng4
 (風 調 雨 順)	feng1tiao2yu3shun4
@@ -82031,9 +75640,7 @@ $textmode
 (養 兒 防 老)	yang3er2fang2lao3
 (養 兒 防 老)	yang3er2fang2lao3
 (養 尊 處 優)	yang3zun1chu3you1
-(養 尊 處 ㊝)	yang3zun1chu3you1
 (首 屈 一 指)	shou3qu1yi4zhi3
-(首 屈 ㊀ 指)	shou3qu1yi4zhi3
 (香 榭 丽 舍)	xiang1xie4li4she4
 (香 榭 麗 舍)	xiang1xie4li4she4
 (香 榭 麗 舍)	xiang1xie4li4she4
@@ -82048,9 +75655,7 @@ $textmode
 (馬 薩 諸 塞)	ma3sa4zhu1sai4
 (馬 馬 虎 虎)	ma3ma5hu1hu1
 (駕 鶴 西 遊)	jia4he4xi1you2
-(駕 鶴 🀂 遊)	jia4he4xi1you2
 (駕 鶴 西 遊)	jia4he4xi1you2
-(駕 鶴 🀂 遊)	jia4he4xi1you2
 (驚 天 動 地)	jing1tian1dong4di4
 (驚 奇 不 已)	jing1ji1bu4yi3
 (驚 奇 不 已)	jing1ji1bu4yi3
@@ -82063,12 +75668,9 @@ $textmode
 (马 萨 诸 塞)	ma3sa4zhu1sai4
 (马 马 虎 虎)	ma3ma5hu1hu1
 (驾 鹤 西 遊)	jia4he4xi1you2
-(驾 鹤 🀂 遊)	jia4he4xi1you2
 (骨 头 节 儿)	gu3tou5jie2r5
 (高 村 正 彥)	gao1cun1zheng1yan4
-(高 村 ㊣ 彥)	gao1cun1zheng1yan4
 (高 村 正 彦)	gao1cun1zheng1yan4
-(高 村 ㊣ 彦)	gao1cun1zheng1yan4
 (鬆 贊 干 布)	song1zan4gan4bu4
 (鬧 不 清 楚)	nao4bu5qing1chu3
 (鬧 不 清 楚)	nao4bu5qing1chu3
@@ -82090,252 +75692,119 @@ $textmode
 (鹹 不 唧 兒)	xian2bu5ji5r5
 (鹹 不 唧 兒)	xian2bu5ji5r5
 (麗 水 地 區)	li4shui3di4qu1
-(麗 ㊌ 地 區)	li4shui3di4qu1
 (麗 水 地 區)	li4shui3di4qu1
-(麗 ㊌ 地 區)	li4shui3di4qu1
 (黃 粱 一 夢)	huang2liang2yi2meng4
-(黃 粱 ㊀ 夢)	huang2liang2yi2meng4
 (黃 花 閨 女)	huang2hua1gui1nv3
-(黃 花 閨 ㊛)	huang2hua1gui1nv3
 (黃 花 閨 女)	huang2hua1gui1nv3
 (黄 粱 一 梦)	huang2liang2yi2meng4
-(黄 粱 ㊀ 梦)	huang2liang2yi2meng4
 (黄 花 闺 女)	huang2hua1gui1nv3
-(黄 花 闺 ㊛)	huang2hua1gui1nv3
 (黄 花 闺 女)	huang2hua1gui1nv3
 (點 頭 一 笑)	dian3tou2yi2xiao4
-(點 頭 ㊀ 笑)	dian3tou2yi2xiao4
 (鼎 鐺 玉 石)	ding3cheng1yu4shi2
 (鼎 铛 玉 石)	ding3cheng1yu4shi2
 (鼓 盆 之 戚)	gu3pen2zhi1qi1
 (鼻 子 一 酸)	bi2zi5yi4suan1
-(鼻 子 ㊀ 酸)	bi2zi5yi4suan1
 (龍 生 九 子)	long2sheng1jiu3zi3
-(龍 生 ㊈ 子)	long2sheng1jiu3zi3
 (龍 生 九 子)	long2sheng1jiu3zi3
-(龍 生 ㊈ 子)	long2sheng1jiu3zi3
 (龙 生 九 子)	long2sheng1jiu3zi3
-(龙 生 ㊈ 子)	long2sheng1jiu3zi3
 (一 丝 一 毫 儿)	yi4si1yi4hao2r5
-(㊀ 丝 ㊀ 毫 儿)	yi4si1yi4hao2r5
 (一 个 半 个 儿)	yi2ge4ban4ge4r5
-(㊀ 个 半 个 儿)	yi2ge4ban4ge4r5
 (一 九 四 九 年)	yi4jiu3si4jiu3nian2
-(一 ㊈ 四 ㊈ 年)	yi4jiu3si4jiu3nian2
-(一 九 ㊃ 九 年)	yi4jiu3si4jiu3nian2
-(㊀ 九 四 九 年)	yi4jiu3si4jiu3nian2
 (一 九 四 九 年)	yi4jiu3si4jiu3nian2
-(一 ㊈ 四 ㊈ 年)	yi4jiu3si4jiu3nian2
-(一 九 ㊃ 九 年)	yi4jiu3si4jiu3nian2
-(㊀ 九 四 九 年)	yi4jiu3si4jiu3nian2
 (一 会 儿 工 夫)	yi2hui4r5gong1fu1
-(㊀ 会 儿 工 夫)	yi2hui4r5gong1fu1
 (一 個 半 個 兒)	yi2ge4ban4ge4r5
-(㊀ 個 半 個 兒)	yi2ge4ban4ge4r5
 (一 分 鐘 小 說)	yi4fen1zhong1xiao3shuo1
-(㊀ 分 鐘 小 說)	yi4fen1zhong1xiao3shuo1
 (一 分 鐘 小 說)	yi4fen1zhong1xiao3shuo1
-(㊀ 分 鐘 小 說)	yi4fen1zhong1xiao3shuo1
 (一 分 鐘 小 說)	yi4fen1zhong1xiao3shuo1
-(㊀ 分 鐘 小 說)	yi4fen1zhong1xiao3shuo1
 (一 分 鐘 照 相)	yi4fen1zhong1zhao4xiang4
-(㊀ 分 鐘 照 相)	yi4fen1zhong1zhao4xiang4
 (一 分 钟 小 说)	yi4fen1zhong1xiao3shuo1
-(㊀ 分 钟 小 说)	yi4fen1zhong1xiao3shuo1
 (一 分 钟 照 相)	yi4fen1zhong1zhao4xiang4
-(㊀ 分 钟 照 相)	yi4fen1zhong1zhao4xiang4
 (一 千 零 一 夜)	yi4qian1ling2yi2ye4
-(一 千 零 一 ㊰)	yi4qian1ling2yi2ye4
-(㊀ 千 零 ㊀ 夜)	yi4qian1ling2yi2ye4
 (一 千 零 一 夜)	yi4qian1ling2yi2ye4
-(一 千 零 一 ㊰)	yi4qian1ling2yi2ye4
-(㊀ 千 零 ㊀ 夜)	yi4qian1ling2yi2ye4
 (一 厘 钱 精 神)	yi4li2qian2jing1shen2
-(㊀ 厘 钱 精 神)	yi4li2qian2jing1shen2
 (一 厘 钱 精 神)	yi4li2qian2jing1shen2
-(㊀ 厘 钱 精 神)	yi4li2qian2jing1shen2
 (一 厘 钱 精 神)	yi4li2qian2jing1shen2
-(㊀ 厘 钱 精 神)	yi4li2qian2jing1shen2
 (一 去 不 复 返)	yi2qu4bu2fu4fan3
-(㊀ 去 不 复 返)	yi2qu4bu2fu4fan3
 (一 去 不 复 返)	yi2qu4bu2fu4fan3
-(㊀ 去 不 复 返)	yi2qu4bu2fu4fan3
 (一 去 不 復 返)	yi2qu4bu2fu4fan3
-(㊀ 去 不 復 返)	yi2qu4bu2fu4fan3
 (一 去 不 復 返)	yi2qu4bu2fu4fan3
-(㊀ 去 不 復 返)	yi2qu4bu2fu4fan3
 (一 去 不 復 返)	yi2qu4bu2fu4fan3
-(㊀ 去 不 復 返)	yi2qu4bu2fu4fan3
 (一 去 无 影 踪)	yi2qu4wu2ying3zong1
-(㊀ 去 无 影 踪)	yi2qu4wu2ying3zong1
 (一 去 無 影 蹤)	yi2qu4wu2ying3zong1
-(㊀ 去 無 影 蹤)	yi2qu4wu2ying3zong1
 (一 口 京 片 子)	yi4kou3jing1pian4zi5
-(㊀ 口 京 片 子)	yi4kou3jing1pian4zi5
 (一 問 三 不 知)	yi2wen4san1bu4zhi1
-(一 問 ㊂ 不 知)	yi2wen4san1bu4zhi1
-(㊀ 問 三 不 知)	yi2wen4san1bu4zhi1
 (一 問 三 不 知)	yi2wen4san1bu4zhi1
-(一 問 ㊂ 不 知)	yi2wen4san1bu4zhi1
-(㊀ 問 三 不 知)	yi2wen4san1bu4zhi1
 (一 善 掩 百 恶)	yi2shan4yan3bai3e4
-(㊀ 善 掩 百 恶)	yi2shan4yan3bai3e4
 (一 善 掩 百 惡)	yi2shan4yan3bai3e4
-(㊀ 善 掩 百 惡)	yi2shan4yan3bai3e4
 (一 善 掩 百 惡)	yi2shan4yan3bai3e4
-(㊀ 善 掩 百 惡)	yi2shan4yan3bai3e4
 (一 報 還 一 報)	yi2bao4huan2yi2bao4
-(㊀ 報 還 ㊀ 報)	yi2bao4huan2yi2bao4
 (一 好 遮 百 丑)	yi4hao3zhe1bai3chou3
-(㊀ 好 遮 百 丑)	yi4hao3zhe1bai3chou3
 (一 好 遮 百 醜)	yi4hao3zhe1bai3chou3
-(㊀ 好 遮 百 醜)	yi4hao3zhe1bai3chou3
 (一 对 一 对 应)	yi2dui4yi2dui4ying4
-(㊀ 对 ㊀ 对 应)	yi2dui4yi2dui4ying4
 (一 对 一 翻 译)	yi2dui4yi4fan1yi4
-(㊀ 对 ㊀ 翻 译)	yi2dui4yi4fan1yi4
 (一 對 一 對 應)	yi2dui4yi2dui4ying4
-(㊀ 對 ㊀ 對 應)	yi2dui4yi2dui4ying4
 (一 對 一 翻 譯)	yi2dui4yi4fan1yi4
-(㊀ 對 ㊀ 翻 譯)	yi2dui4yi4fan1yi4
 (一 扑 纳 心 儿)	yi4pu1na5xin1r5
-(㊀ 扑 纳 心 儿)	yi4pu1na5xin1r5
 (一 报 还 一 报)	yi2bao4huan2yi2bao4
-(㊀ 报 还 ㊀ 报)	yi2bao4huan2yi2bao4
 (一 挡 子 事 儿)	yi2dang4zi5shi4r5
-(㊀ 挡 子 事 儿)	yi2dang4zi5shi4r5
 (一 推 六 二 五)	yi4tui1liu4er4wu3
-(㊀ 推 六 二 五)	yi4tui1liu4er4wu3
-(一 推 六 ㊁ 五)	yi4tui1liu4er4wu3
-(一 推 六 二 ㊄)	yi4tui1liu4er4wu3
-(一 推 ㊅ 二 五)	yi4tui1liu4er4wu3
 (一 推 六 二 五)	yi4tui1liu4er4wu3
-(㊀ 推 六 二 五)	yi4tui1liu4er4wu3
-(一 推 六 ㊁ 五)	yi4tui1liu4er4wu3
-(一 推 六 二 ㊄)	yi4tui1liu4er4wu3
 (一 撲 納 心 兒)	yi4pu1na5xin1r5
-(㊀ 撲 納 心 兒)	yi4pu1na5xin1r5
 (一 擋 子 事 兒)	yi2dang4zi5shi4r5
-(㊀ 擋 子 事 兒)	yi2dang4zi5shi4r5
 (一 整 套 技 术)	yi4zheng3tao4ji4shu4
-(㊀ 整 套 技 术)	yi4zheng3tao4ji4shu4
 (一 整 套 技 術)	yi4zheng3tao4ji4shu4
-(㊀ 整 套 技 術)	yi4zheng3tao4ji4shu4
 (一 时 半 会 儿)	yi4shi2ban4hui3r5
-(㊀ 时 半 会 儿)	yi4shi2ban4hui3r5
 (一 时 性 黑 晕)	yi4shi2xing4hei1yun4
-(㊀ 时 性 黑 晕)	yi4shi2xing4hei1yun4
 (一 星 半 点 儿)	yi4xing1ban4dian3r5
-(㊀ 星 半 点 儿)	yi4xing1ban4dian3r5
 (一 時 半 會 兒)	yi4shi2ban4hui3r5
-(㊀ 時 半 會 兒)	yi4shi2ban4hui3r5
 (一 時 性 黑 暈)	yi4shi2xing4hei1yun4
-(㊀ 時 性 黑 暈)	yi4shi2xing4hei1yun4
 (一 時 性 黑 暈)	yi4shi2xing4hei1yun4
-(㊀ 時 性 黑 暈)	yi4shi2xing4hei1yun4
 (一 會 兒 工 夫)	yi2hui4r5gong1fu1
-(㊀ 會 兒 工 夫)	yi2hui4r5gong1fu1
 (一 棍 子 打 死)	yi2gun4zi5da3si3
-(㊀ 棍 子 打 死)	yi2gun4zi5da3si3
 (一 模 活 脫 兒)	yi4mo2huo2tuo1r5
-(㊀ 模 活 脫 兒)	yi4mo2huo2tuo1r5
 (一 模 活 脱 儿)	yi4mo2huo2tuo1r5
-(㊀ 模 活 脱 儿)	yi4mo2huo2tuo1r5
 (一 次 性 削 价)	yi2ci4xing4xiao1jia4
-(㊀ 次 性 削 价)	yi2ci4xing4xiao1jia4
 (一 次 性 削 價)	yi2ci4xing4xiao1jia4
-(㊀ 次 性 削 價)	yi2ci4xing4xiao1jia4
 (一 氧 化 二 氮)	yi4yang3hua4er4dan4
-(㊀ 氧 化 二 氮)	yi4yang3hua4er4dan4
-(一 氧 化 ㊁ 氮)	yi4yang3hua4er4dan4
 (一 浪 接 一 浪)	yi2lang4jie1yi2lang4
-(㊀ 浪 接 ㊀ 浪)	yi2lang4jie1yi2lang4
 (一 浪 接 一 浪)	yi2lang4jie1yi2lang4
-(㊀ 浪 接 ㊀ 浪)	yi2lang4jie1yi2lang4
 (一 燕 不 成 夏)	yi2yan4bu4cheng2xia4
-(㊀ 燕 不 成 夏)	yi2yan4bu4cheng2xia4
 (一 燕 不 成 夏)	yi2yan4bu4cheng2xia4
-(㊀ 燕 不 成 夏)	yi2yan4bu4cheng2xia4
 (一 物 降 一 物)	yi2wu4xiang2yi2wu4
-(㊀ 物 降 ㊀ 物)	yi2wu4xiang2yi2wu4
 (一 物 降 一 物)	yi2wu4xiang2yi2wu4
-(㊀ 物 降 ㊀ 物)	yi2wu4xiang2yi2wu4
 (一 环 扣 一 环)	yi4huan2kou4yi4huan2
-(㊀ 环 扣 ㊀ 环)	yi4huan2kou4yi4huan2
 (一 環 扣 一 環)	yi4huan2kou4yi4huan2
-(㊀ 環 扣 ㊀ 環)	yi4huan2kou4yi4huan2
 (一 生 日 儿 多)	yi4sheng1ri4r5duo1
-(㊀ 生 日 儿 多)	yi4sheng1ri4r5duo1
-(一 生 ㊐ 儿 多)	yi4sheng1ri4r5duo1
 (一 眨 巴 眼 儿)	yi4zha3ba5yan3r5
-(㊀ 眨 巴 眼 儿)	yi4zha3ba5yan3r5
 (一 眨 巴 眼 兒)	yi4zha3ba5yan3r5
-(㊀ 眨 巴 眼 兒)	yi4zha3ba5yan3r5
 (一 眨 眯 眼 儿)	yi4zha3mi1yan3r5
-(㊀ 眨 眯 眼 儿)	yi4zha3mi1yan3r5
 (一 眨 眯 眼 兒)	yi4zha3mi1yan3r5
-(㊀ 眨 眯 眼 兒)	yi4zha3mi1yan3r5
 (一 股 热 劲 儿)	yi4gu3re4jin4r5
-(㊀ 股 热 劲 儿)	yi4gu3re4jin4r5
 (一 茶 匙 容 量)	yi4cha2chi2rong2liang4
-(㊀ 茶 匙 容 量)	yi4cha2chi2rong2liang4
 (一 茶 匙 容 量)	yi4cha2chi2rong2liang4
-(㊀ 茶 匙 容 量)	yi4cha2chi2rong2liang4
 (一 茶 匙 容 量)	yi4cha2chi2rong2liang4
-(㊀ 茶 匙 容 量)	yi4cha2chi2rong2liang4
 (一 釐 錢 精 神)	yi4li2qian2jing1shen2
-(㊀ 釐 錢 精 神)	yi4li2qian2jing1shen2
 (一 釐 錢 精 神)	yi4li2qian2jing1shen2
-(㊀ 釐 錢 精 神)	yi4li2qian2jing1shen2
 (一 釐 錢 精 神)	yi4li2qian2jing1shen2
-(㊀ 釐 錢 精 神)	yi4li2qian2jing1shen2
 (一 銃 子 性 兒)	yi2chong4zi5xing4r5
-(㊀ 銃 子 性 兒)	yi2chong4zi5xing4r5
 (一 錘 子 買 賣)	yi4chui2zi5mai3mai5
-(㊀ 錘 子 買 賣)	yi4chui2zi5mai3mai5
 (一 铳 子 性 儿)	yi2chong4zi5xing4r5
-(㊀ 铳 子 性 儿)	yi2chong4zi5xing4r5
 (一 锤 子 买 卖)	yi4chui2zi5mai3mai5
-(㊀ 锤 子 买 卖)	yi4chui2zi5mai3mai5
 (一 问 三 不 知)	yi2wen4san1bu4zhi1
-(一 问 ㊂ 不 知)	yi2wen4san1bu4zhi1
-(㊀ 问 三 不 知)	yi2wen4san1bu4zhi1
 (一 问 三 不 知)	yi2wen4san1bu4zhi1
-(一 问 ㊂ 不 知)	yi2wen4san1bu4zhi1
-(㊀ 问 三 不 知)	yi2wen4san1bu4zhi1
 (一 鼻 孔 出 气)	yi4bi2kong3chu1qi4
-(㊀ 鼻 孔 出 气)	yi4bi2kong3chu1qi4
 (一 鼻 孔 出 氣)	yi4bi2kong3chu1qi4
-(㊀ 鼻 孔 出 氣)	yi4bi2kong3chu1qi4
 (七 二 一 大 学)	qi1er4yi2da4xue2
-(七 二 一 大 ㊫)	qi1er4yi2da4xue2
-(七 二 ㊀ 大 学)	qi1er4yi2da4xue2
-(七 ㊁ 一 大 学)	qi1er4yi2da4xue2
-(㊆ 二 一 大 学)	qi1er4yi2da4xue2
 (七 二 一 大 學)	qi1er4yi2da4xue2
-(七 二 ㊀ 大 學)	qi1er4yi2da4xue2
-(七 ㊁ 一 大 學)	qi1er4yi2da4xue2
-(㊆ 二 一 大 學)	qi1er4yi2da4xue2
 (三 分 之 一 弱)	san1fen1zhi1yi2ruo4
-(㊂ 分 之 一 弱)	san1fen1zhi1yi2ruo4
-(三 分 之 ㊀ 弱)	san1fen1zhi1yi2ruo4
 (三 合 一 疫 苗)	san1he2yi2yi4miao2
-(㊂ 合 一 疫 苗)	san1he2yi2yi4miao2
-(三 合 ㊀ 疫 苗)	san1he2yi2yi4miao2
 (不 万 无 一 失)	bu2wan4wu2yi4shi1
-(不 万 无 ㊀ 失)	bu2wan4wu2yi4shi1
 (不 万 无 一 失)	bu2wan4wu2yi4shi1
-(不 万 无 ㊀ 失)	bu2wan4wu2yi4shi1
 (不 下 面 請 看)	bu2xia4mian4qing3kan4
-(不 ㊦ 面 請 看)	bu2xia4mian4qing3kan4
 (不 下 面 請 看)	bu2xia4mian4qing3kan4
-(不 ㊦ 面 請 看)	bu2xia4mian4qing3kan4
 (不 下 面 請 看)	bu2xia4mian4qing3kan4
-(不 ㊦ 面 請 看)	bu2xia4mian4qing3kan4
 (不 下 面 请 看)	bu2xia4mian4qing3kan4
-(不 ㊦ 面 请 看)	bu2xia4mian4qing3kan4
 (不 下 面 请 看)	bu2xia4mian4qing3kan4
-(不 ㊦ 面 请 看)	bu2xia4mian4qing3kan4
 (不 串 亲 访 友)	bu2chuan4qin1fang3you3
 (不 串 亲 访 友)	bu2chuan4qin1fang3you3
 (不 串 亲 访 友)	bu2chuan4qin1fang3you3
@@ -82351,42 +75820,27 @@ $textmode
 (不 互 為 因 果)	bu2hu4wei2yin1guo3
 (不 互 為 因 果)	bu2hu4wei2yin1guo3
 (不 付 之 一 叹)	bu2fu4zhi1yi2tan4
-(不 付 之 ㊀ 叹)	bu2fu4zhi1yi2tan4
 (不 付 之 一 叹)	bu2fu4zhi1yi2tan4
-(不 付 之 ㊀ 叹)	bu2fu4zhi1yi2tan4
 (不 付 之 一 嘆)	bu2fu4zhi1yi2tan4
-(不 付 之 ㊀ 嘆)	bu2fu4zhi1yi2tan4
 (不 付 之 一 嘆)	bu2fu4zhi1yi2tan4
-(不 付 之 ㊀ 嘆)	bu2fu4zhi1yi2tan4
 (不 付 之 一 嘆)	bu2fu4zhi1yi2tan4
-(不 付 之 ㊀ 嘆)	bu2fu4zhi1yi2tan4
 (不 付 之 一 歎)	bu2fu4zhi1yi2tan4
-(不 付 之 ㊀ 歎)	bu2fu4zhi1yi2tan4
 (不 付 之 一 歎)	bu2fu4zhi1yi2tan4
-(不 付 之 ㊀ 歎)	bu2fu4zhi1yi2tan4
 (不 付 之 一 炬)	bu2fu4zhi1yi2ju4
-(不 付 之 ㊀ 炬)	bu2fu4zhi1yi2ju4
 (不 付 之 一 炬)	bu2fu4zhi1yi2ju4
-(不 付 之 ㊀ 炬)	bu2fu4zhi1yi2ju4
 (不 付 之 一 笑)	bu2fu4zhi1yi2xiao4
-(不 付 之 ㊀ 笑)	bu2fu4zhi1yi2xiao4
 (不 付 之 一 笑)	bu2fu4zhi1yi2xiao4
-(不 付 之 ㊀ 笑)	bu2fu4zhi1yi2xiao4
 (不 令 人 发 指)	bu2ling4ren2fa4zhi3
 (不 令 人 发 指)	bu2ling4ren2fa4zhi3
 (不 令 人 发 指)	bu2ling4ren2fa4zhi3
 (不 众 口 一 词)	bu2zhong4kou3yi4ci2
-(不 众 口 ㊀ 词)	bu2zhong4kou3yi4ci2
 (不 众 口 一 词)	bu2zhong4kou3yi4ci2
-(不 众 口 ㊀ 词)	bu2zhong4kou3yi4ci2
 (不 众 矢 之 的)	bu2zhong4shi3zhi1di4
 (不 众 矢 之 的)	bu2zhong4shi3zhi1di4
 (不 佣 人 领 班)	bu2yong4ren5ling3ban1
 (不 佣 人 领 班)	bu2yong4ren5ling3ban1
 (不 倒 打 一 耙)	bu2dao4da3yi4pa2
-(不 倒 打 ㊀ 耙)	bu2dao4da3yi4pa2
 (不 倒 打 一 耙)	bu2dao4da3yi4pa2
-(不 倒 打 ㊀ 耙)	bu2dao4da3yi4pa2
 (不 倒 果 为 因)	bu2dao4guo3wei2yin1
 (不 倒 果 为 因)	bu2dao4guo3wei2yin1
 (不 倒 果 為 因)	bu2dao4guo3wei2yin1
@@ -82401,13 +75855,9 @@ $textmode
 (不 傭 人 領 班)	bu2yong4ren5ling3ban1
 (不 傭 人 領 班)	bu2yong4ren5ling3ban1
 (不 入 土 为 安)	bu2ru4tu3wei2an1
-(不 入 ㊏ 为 安)	bu2ru4tu3wei2an1
 (不 入 土 为 安)	bu2ru4tu3wei2an1
-(不 入 ㊏ 为 安)	bu2ru4tu3wei2an1
 (不 入 土 為 安)	bu2ru4tu3wei2an1
-(不 入 ㊏ 為 安)	bu2ru4tu3wei2an1
 (不 入 土 為 安)	bu2ru4tu3wei2an1
-(不 入 ㊏ 為 安)	bu2ru4tu3wei2an1
 (不 內 懮 外 患)	bu2nei4you1wai4huan4
 (不 內 懮 外 患)	bu2nei4you1wai4huan4
 (不 兴 高 采 烈)	bu2xing4gao1cai3lie4
@@ -82418,22 +75868,14 @@ $textmode
 (不 冒 冒 失 失)	bu2mao4mao5shi1shi1
 (不 冒 冒 失 失)	bu2mao4mao5shi1shi1
 (不 划 一 不 二)	bu2hua4yi2bu2er4
-(不 划 ㊀ 不 二)	bu2hua4yi2bu2er4
-(不 划 一 不 ㊁)	bu2hua4yi2bu2er4
 (不 划 一 不 二)	bu2hua4yi2bu2er4
-(不 划 ㊀ 不 二)	bu2hua4yi2bu2er4
-(不 划 一 不 ㊁)	bu2hua4yi2bu2er4
 (不 剃 发 留 辫)	bu2ti4fa4liu2bian4
 (不 剃 发 留 辫)	bu2ti4fa4liu2bian4
 (不 剃 发 留 辫)	bu2ti4fa4liu2bian4
 (不 剑 拔 弩 张)	bu2jian4ba2nu3zhang1
 (不 剑 拔 弩 张)	bu2jian4ba2nu3zhang1
 (不 劃 一 不 二)	bu2hua4yi2bu2er4
-(不 劃 ㊀ 不 二)	bu2hua4yi2bu2er4
-(不 劃 一 不 ㊁)	bu2hua4yi2bu2er4
 (不 劃 一 不 二)	bu2hua4yi2bu2er4
-(不 劃 ㊀ 不 二)	bu2hua4yi2bu2er4
-(不 劃 一 不 ㊁)	bu2hua4yi2bu2er4
 (不 劃 圓 防 守)	bu2hua4yuan2fang2shou3
 (不 劃 圓 防 守)	bu2hua4yuan2fang2shou3
 (不 劍 拔 弩 張)	bu2jian4ba2nu3zhang1
@@ -82460,14 +75902,8 @@ $textmode
 (不 半 半 拉 拉)	bu2ban4ban5la1la1
 (不 半 半 拉 拉)	bu2ban4ban5la1la1
 (不 半 夜 三 更)	bu2ban4ye4san1geng1
-(不 半 ㊰ 三 更)	bu2ban4ye4san1geng1
-(不 半 夜 ㊂ 更)	bu2ban4ye4san1geng1
 (不 半 夜 三 更)	bu2ban4ye4san1geng1
-(不 半 ㊰ 三 更)	bu2ban4ye4san1geng1
-(不 半 夜 ㊂ 更)	bu2ban4ye4san1geng1
 (不 半 夜 三 更)	bu2ban4ye4san1geng1
-(不 半 ㊰ 三 更)	bu2ban4ye4san1geng1
-(不 半 夜 ㊂ 更)	bu2ban4ye4san1geng1
 (不 半 开 门 儿)	bu2ban4kai1men2r5
 (不 半 开 门 儿)	bu2ban4kai1men2r5
 (不 厚 养 薄 葬)	bu2hou4yang3bo2zang4
@@ -82482,28 +75918,20 @@ $textmode
 (不 变 征 之 声)	bu2bian4zhi3zhi1sheng1
 (不 变 征 之 声)	bu2bian4zhi3zhi1sheng1
 (不 右 派 分 子)	bu2you4pai4fen4zi3
-(不 ㊨ 派 分 子)	bu2you4pai4fen4zi3
 (不 右 派 分 子)	bu2you4pai4fen4zi3
-(不 ㊨ 派 分 子)	bu2you4pai4fen4zi3
 (不 叹 为 观 止)	bu2tan4wei2guan1zhi3
 (不 叹 为 观 止)	bu2tan4wei2guan1zhi3
 (不 各 執 一 詞)	bu2ge4zhi2yi4ci2
-(不 各 執 ㊀ 詞)	bu2ge4zhi2yi4ci2
 (不 各 執 一 詞)	bu2ge4zhi2yi4ci2
-(不 各 執 ㊀ 詞)	bu2ge4zhi2yi4ci2
 (不 各 奔 前 程)	bu2ge4ben4qian2cheng2
 (不 各 奔 前 程)	bu2ge4ben4qian2cheng2
 (不 各 奔 前 程)	bu2ge4ben4qian2cheng2
 (不 各 得 其 所)	bu2ge4de2qi2suo3
 (不 各 得 其 所)	bu2ge4de2qi2suo3
 (不 各 执 一 词)	bu2ge4zhi2yi4ci2
-(不 各 执 ㊀ 词)	bu2ge4zhi2yi4ci2
 (不 各 执 一 词)	bu2ge4zhi2yi4ci2
-(不 各 执 ㊀ 词)	bu2ge4zhi2yi4ci2
 (不 各 有 所 好)	bu2ge4you3suo3hao4
-(不 各 ㊒ 所 好)	bu2ge4you3suo3hao4
 (不 各 有 所 好)	bu2ge4you3suo3hao4
-(不 各 ㊒ 所 好)	bu2ge4you3suo3hao4
 (不 各 盡 所 能)	bu2ge4jin4suo3neng2
 (不 各 盡 所 能)	bu2ge4jin4suo3neng2
 (不 各 行 各 业)	bu2ge4hang2ge4ye4
@@ -82525,21 +75953,13 @@ $textmode
 (不 嘆 為 觀 止)	bu2tan4wei2guan1zhi3
 (不 嘆 為 觀 止)	bu2tan4wei2guan1zhi3
 (不 四 个 小 时)	bu2si4ge4xiao3shi2
-(不 ㊃ 个 小 时)	bu2si4ge4xiao3shi2
 (不 四 个 小 时)	bu2si4ge4xiao3shi2
-(不 ㊃ 个 小 时)	bu2si4ge4xiao3shi2
 (不 四 個 小 時)	bu2si4ge4xiao3shi2
-(不 ㊃ 個 小 時)	bu2si4ge4xiao3shi2
 (不 四 個 小 時)	bu2si4ge4xiao3shi2
-(不 ㊃ 個 小 時)	bu2si4ge4xiao3shi2
 (不 四 季 豆 腐)	bu2si4ji4dou4fu3
-(不 ㊃ 季 豆 腐)	bu2si4ji4dou4fu3
 (不 四 季 豆 腐)	bu2si4ji4dou4fu3
-(不 ㊃ 季 豆 腐)	bu2si4ji4dou4fu3
 (不 四 面 楚 歌)	bu2si4mian4chu3ge1
-(不 ㊃ 面 楚 歌)	bu2si4mian4chu3ge1
 (不 四 面 楚 歌)	bu2si4mian4chu3ge1
-(不 ㊃ 面 楚 歌)	bu2si4mian4chu3ge1
 (不 圣 经 贤 传)	bu2sheng4jing1xian2zhuan4
 (不 圣 经 贤 传)	bu2sheng4jing1xian2zhuan4
 (不 地 久 天 長)	bu2di4jiu3tian1chang2
@@ -82570,69 +75990,39 @@ $textmode
 (不 地 方 選 舉)	bu2di4fang1xuan2ju3
 (不 地 方 選 舉)	bu2di4fang1xuan2ju3
 (不 块 儿 八 毛)	bu2kuai4r5ba1mao2
-(不 块 儿 ㊇ 毛)	bu2kuai4r5ba1mao2
 (不 块 儿 八 毛)	bu2kuai4r5ba1mao2
-(不 块 儿 ㊇ 毛)	bu2kuai4r5ba1mao2
 (不 壽 數 已 盡)	bu2shou4shu5yi3jin4
 (不 壽 數 已 盡)	bu2shou4shu5yi3jin4
 (不 壽 數 已 盡)	bu2shou4shu5yi3jin4
 (不 壽 終 正 寢)	bu2shou4zhong1zheng4qin3
-(不 壽 終 ㊣ 寢)	bu2shou4zhong1zheng4qin3
 (不 壽 終 正 寢)	bu2shou4zhong1zheng4qin3
-(不 壽 終 ㊣ 寢)	bu2shou4zhong1zheng4qin3
 (不 外 甥 女 婿)	bu2wai4sheng1nv3xu4
-(不 外 甥 ㊛ 婿)	bu2wai4sheng1nv3xu4
 (不 外 甥 女 婿)	bu2wai4sheng1nv3xu4
 (不 外 甥 女 婿)	bu2wai4sheng1nv3xu4
-(不 外 甥 ㊛ 婿)	bu2wai4sheng1nv3xu4
 (不 外 甥 媳 妇)	bu2wai4sheng1xi2fu5
 (不 外 甥 媳 妇)	bu2wai4sheng1xi2fu5
 (不 外 甥 媳 婦)	bu2wai4sheng1xi2fu5
 (不 外 甥 媳 婦)	bu2wai4sheng1xi2fu5
 (不 夙 兴 夜 寐)	bu2su4xing1ye4mei4
-(不 夙 兴 ㊰ 寐)	bu2su4xing1ye4mei4
 (不 夙 兴 夜 寐)	bu2su4xing1ye4mei4
-(不 夙 兴 ㊰ 寐)	bu2su4xing1ye4mei4
 (不 夙 興 夜 寐)	bu2su4xing1ye4mei4
-(不 夙 興 ㊰ 寐)	bu2su4xing1ye4mei4
 (不 夙 興 夜 寐)	bu2su4xing1ye4mei4
-(不 夙 興 ㊰ 寐)	bu2su4xing1ye4mei4
 (不 大 一 会 儿)	bu2da4yi4hui3r5
-(不 大 ㊀ 会 儿)	bu2da4yi4hui3r5
 (不 大 一 会 儿)	bu2da4yi4hui3r5
-(不 大 ㊀ 会 儿)	bu2da4yi4hui3r5
 (不 大 一 會 兒)	bu2da4yi4hui3r5
-(不 大 ㊀ 會 兒)	bu2da4yi4hui3r5
 (不 大 一 會 兒)	bu2da4yi4hui3r5
-(不 大 ㊀ 會 兒)	bu2da4yi4hui3r5
 (不 大 中 学 生)	bu2da4zhong1xue2sheng5
-(不 大 🀄 学 生)	bu2da4zhong1xue2sheng5
-(不 大 中 ㊫ 生)	bu2da4zhong1xue2sheng5
-(不 大 🀄 ㊫ 生)	bu2da4zhong1xue2sheng5
-(不 大 ㊥ 学 生)	bu2da4zhong1xue2sheng5
 (不 大 中 学 生)	bu2da4zhong1xue2sheng5
-(不 大 🀄 学 生)	bu2da4zhong1xue2sheng5
-(不 大 中 ㊫ 生)	bu2da4zhong1xue2sheng5
-(不 大 🀄 ㊫ 生)	bu2da4zhong1xue2sheng5
-(不 大 ㊥ 学 生)	bu2da4zhong1xue2sheng5
 (不 大 中 學 生)	bu2da4zhong1xue2sheng5
-(不 大 🀄 學 生)	bu2da4zhong1xue2sheng5
-(不 大 ㊥ 學 生)	bu2da4zhong1xue2sheng5
 (不 大 中 學 生)	bu2da4zhong1xue2sheng5
-(不 大 🀄 學 生)	bu2da4zhong1xue2sheng5
-(不 大 ㊥ 學 生)	bu2da4zhong1xue2sheng5
 (不 大 可 不 必)	bu2da4ke3bu2bi4
 (不 大 可 不 必)	bu2da4ke3bu2bi4
 (不 大 吹 大 擂)	bu2da4chui1da4lei2
 (不 大 吹 大 擂)	bu2da4chui1da4lei2
 (不 大 有 可 为)	bu2da4you3ke3wei2
-(不 大 ㊒ 可 为)	bu2da4you3ke3wei2
 (不 大 有 可 为)	bu2da4you3ke3wei2
-(不 大 ㊒ 可 为)	bu2da4you3ke3wei2
 (不 大 有 可 為)	bu2da4you3ke3wei2
-(不 大 ㊒ 可 為)	bu2da4you3ke3wei2
 (不 大 有 可 為)	bu2da4you3ke3wei2
-(不 大 ㊒ 可 為)	bu2da4you3ke3wei2
 (不 太 阳 黑 子)	bu2tai4yang2hei1zi3
 (不 太 阳 黑 子)	bu2tai4yang2hei1zi3
 (不 太 陽 黑 子)	bu2tai4yang2hei1zi3
@@ -82679,9 +76069,7 @@ $textmode
 (不 寧 缺 毋 濫)	bu2ning4que1wu2lan4
 (不 寧 缺 毋 濫)	bu2ning4que1wu2lan4
 (不 寿 终 正 寝)	bu2shou4zhong1zheng4qin3
-(不 寿 终 ㊣ 寝)	bu2shou4zhong1zheng4qin3
 (不 寿 终 正 寝)	bu2shou4zhong1zheng4qin3
-(不 寿 终 ㊣ 寝)	bu2shou4zhong1zheng4qin3
 (不 尽 力 而 为)	bu2jin4li4er2wei2
 (不 尽 力 而 为)	bu2jin4li4er2wei2
 (不 尽 力 而 为)	bu2jin4li4er2wei2
@@ -82690,9 +76078,7 @@ $textmode
 (不 差 不 离 儿)	bu2cha4bu5li2r5
 (不 差 不 离 儿)	bu2cha4bu5li2r5
 (不 应 县 木 塔)	bu2ying4xian4mu4ta3
-(不 应 县 ㊍ 塔)	bu2ying4xian4mu4ta3
 (不 应 县 木 塔)	bu2ying4xian4mu4ta3
-(不 应 县 ㊍ 塔)	bu2ying4xian4mu4ta3
 (不 应 运 而 生)	bu2ying4yun4er2sheng1
 (不 应 运 而 生)	bu2ying4yun4er2sheng1
 (不 彈 盡 援 絕)	bu2dan4jin4yuan2jue2
@@ -82739,23 +76125,13 @@ $textmode
 (不 恶 恶 实 实)	bu2e4e5shi1shi1
 (不 恶 恶 实 实)	bu2e4e5shi1shi1
 (不 恶 意 中 伤)	bu2e4yi4zhong1shang1
-(不 恶 意 🀄 伤)	bu2e4yi4zhong1shang1
-(不 恶 意 ㊥ 伤)	bu2e4yi4zhong1shang1
 (不 恶 意 中 伤)	bu2e4yi4zhong1shang1
-(不 恶 意 🀄 伤)	bu2e4yi4zhong1shang1
-(不 恶 意 ㊥ 伤)	bu2e4yi4zhong1shang1
 (不 惡 惡 實 實)	bu2e4e5shi1shi1
 (不 惡 惡 實 實)	bu2e4e5shi1shi1
 (不 惡 惡 實 實)	bu2e4e5shi1shi1
 (不 惡 意 中 傷)	bu2e4yi4zhong1shang1
-(不 惡 意 🀄 傷)	bu2e4yi4zhong1shang1
-(不 惡 意 ㊥ 傷)	bu2e4yi4zhong1shang1
 (不 惡 意 中 傷)	bu2e4yi4zhong1shang1
-(不 惡 意 🀄 傷)	bu2e4yi4zhong1shang1
-(不 惡 意 ㊥ 傷)	bu2e4yi4zhong1shang1
 (不 惡 意 中 傷)	bu2e4yi4zhong1shang1
-(不 惡 意 🀄 傷)	bu2e4yi4zhong1shang1
-(不 惡 意 ㊥ 傷)	bu2e4yi4zhong1shang1
 (不 意 猶 未 盡)	bu2yi4you2wei4jin4
 (不 意 猶 未 盡)	bu2yi4you2wei4jin4
 (不 愛 人 如 己)	bu2ai4ren2ru2ji3
@@ -82776,22 +76152,16 @@ $textmode
 (不 慢 慢 吞 吞)	bu2man4man5tun1tun1
 (不 慢 慢 吞 吞)	bu2man4man5tun1tun1
 (不 應 縣 木 塔)	bu2ying4xian4mu4ta3
-(不 應 縣 ㊍ 塔)	bu2ying4xian4mu4ta3
 (不 應 縣 木 塔)	bu2ying4xian4mu4ta3
-(不 應 縣 ㊍ 塔)	bu2ying4xian4mu4ta3
 (不 應 運 而 生)	bu2ying4yun4er2sheng1
 (不 應 運 而 生)	bu2ying4yun4er2sheng1
 (不 扼 襟 控 咽)	bu2e4jin1kong4yan1
 (不 扼 襟 控 咽)	bu2e4jin1kong4yan1
 (不 扼 襟 控 咽)	bu2e4jin1kong4yan1
 (不 据 为 己 有)	bu2ju4wei2ji3you3
-(不 据 为 己 ㊒)	bu2ju4wei2ji3you3
 (不 据 为 己 有)	bu2ju4wei2ji3you3
-(不 据 为 己 ㊒)	bu2ju4wei2ji3you3
 (不 據 為 己 有)	bu2ju4wei2ji3you3
-(不 據 為 己 ㊒)	bu2ju4wei2ji3you3
 (不 據 為 己 有)	bu2ju4wei2ji3you3
-(不 據 為 己 ㊒)	bu2ju4wei2ji3you3
 (不 放 在 眼 裡)	bu2fang4zai5yan3li3
 (不 放 在 眼 裡)	bu2fang4zai5yan3li3
 (不 放 在 眼 裡)	bu2fang4zai5yan3li3
@@ -82805,10 +76175,8 @@ $textmode
 (不 敗 子 回 頭)	bu2bai4zi3hui2tou2
 (不 敗 子 回 頭)	bu2bai4zi3hui2tou2
 (不 敝 帚 千 金)	bu2bi4zhou3qian1jin1
-(不 敝 帚 千 ㊎)	bu2bi4zhou3qian1jin1
 (不 敝 帚 千 金)	bu2bi4zhou3qian1jin1
 (不 敝 帚 千 金)	bu2bi4zhou3qian1jin1
-(不 敝 帚 千 ㊎)	bu2bi4zhou3qian1jin1
 (不 敝 帚 自 珍)	bu2bi4zhou3zi4zhen1
 (不 敝 帚 自 珍)	bu2bi4zhou3zi4zhen1
 (不 数 理 逻 辑)	bu2shu4li3luo2ji2
@@ -82820,29 +76188,13 @@ $textmode
 (不 數 理 邏 輯)	bu2shu4li3luo2ji2
 (不 數 理 邏 輯)	bu2shu4li3luo2ji2
 (不 日 月 重 光)	bu2ri4yue4chong2guang1
-(不 日 ㊊ 重 光)	bu2ri4yue4chong2guang1
-(不 ㊐ 月 重 光)	bu2ri4yue4chong2guang1
 (不 日 月 重 光)	bu2ri4yue4chong2guang1
-(不 日 ㊊ 重 光)	bu2ri4yue4chong2guang1
-(不 ㊐ 月 重 光)	bu2ri4yue4chong2guang1
 (不 日 积 月 累)	bu2ri4ji1yue4lei3
-(不 日 积 ㊊ 累)	bu2ri4ji1yue4lei3
-(不 ㊐ 积 月 累)	bu2ri4ji1yue4lei3
 (不 日 积 月 累)	bu2ri4ji1yue4lei3
-(不 日 积 ㊊ 累)	bu2ri4ji1yue4lei3
-(不 ㊐ 积 月 累)	bu2ri4ji1yue4lei3
 (不 日 积 月 累)	bu2ri4ji1yue4lei3
-(不 日 积 ㊊ 累)	bu2ri4ji1yue4lei3
-(不 ㊐ 积 月 累)	bu2ri4ji1yue4lei3
 (不 日 積 月 累)	bu2ri4ji1yue4lei3
-(不 日 積 ㊊ 累)	bu2ri4ji1yue4lei3
-(不 ㊐ 積 月 累)	bu2ri4ji1yue4lei3
 (不 日 積 月 累)	bu2ri4ji1yue4lei3
-(不 日 積 ㊊ 累)	bu2ri4ji1yue4lei3
-(不 ㊐ 積 月 累)	bu2ri4ji1yue4lei3
 (不 日 積 月 累)	bu2ri4ji1yue4lei3
-(不 日 積 ㊊ 累)	bu2ri4ji1yue4lei3
-(不 ㊐ 積 月 累)	bu2ri4ji1yue4lei3
 (不 旧 地 重 遊)	bu2jiu4di4chong2you2
 (不 旧 地 重 遊)	bu2jiu4di4chong2you2
 (不 暮 鼓 晨 鐘)	bu2mu4gu3chen2zhong1
@@ -82884,31 +76236,15 @@ $textmode
 (不 樂 於 助 人)	bu2le4yu2zhu4ren2
 (不 樂 於 助 人)	bu2le4yu2zhu4ren2
 (不 正 儿 八 经)	bu2zheng4r5ba1jing1
-(不 ㊣ 儿 八 经)	bu2zheng4r5ba1jing1
-(不 正 儿 ㊇ 经)	bu2zheng4r5ba1jing1
 (不 正 儿 八 经)	bu2zheng4r5ba1jing1
-(不 ㊣ 儿 八 经)	bu2zheng4r5ba1jing1
-(不 正 儿 ㊇ 经)	bu2zheng4r5ba1jing1
 (不 正 当 防 卫)	bu2zheng4dang4fang2wei4
-(不 ㊣ 当 防 卫)	bu2zheng4dang4fang2wei4
 (不 正 当 防 卫)	bu2zheng4dang4fang2wei4
-(不 ㊣ 当 防 卫)	bu2zheng4dang4fang2wei4
 (不 正 當 防 衛)	bu2zheng4dang4fang2wei4
-(不 ㊣ 當 防 衛)	bu2zheng4dang4fang2wei4
 (不 正 當 防 衛)	bu2zheng4dang4fang2wei4
-(不 ㊣ 當 防 衛)	bu2zheng4dang4fang2wei4
 (不 正 經 八 百)	bu2zheng4jing5ba1bai3
-(不 ㊣ 經 八 百)	bu2zheng4jing5ba1bai3
-(不 正 經 ㊇ 百)	bu2zheng4jing5ba1bai3
 (不 正 經 八 百)	bu2zheng4jing5ba1bai3
-(不 ㊣ 經 八 百)	bu2zheng4jing5ba1bai3
-(不 正 經 ㊇ 百)	bu2zheng4jing5ba1bai3
 (不 正 经 八 百)	bu2zheng4jing5ba1bai3
-(不 ㊣ 经 八 百)	bu2zheng4jing5ba1bai3
-(不 正 经 ㊇ 百)	bu2zheng4jing5ba1bai3
 (不 正 经 八 百)	bu2zheng4jing5ba1bai3
-(不 ㊣ 经 八 百)	bu2zheng4jing5ba1bai3
-(不 正 经 ㊇ 百)	bu2zheng4jing5ba1bai3
 (不 步 步 为 营)	bu2bu4bu4wei2ying2
 (不 步 步 为 营)	bu2bu4bu4wei2ying2
 (不 步 步 為 營)	bu2bu4bu4wei2ying2
@@ -83001,13 +76337,9 @@ $textmode
 (不 率 由 舊 章)	bu2shuai4you2jiu4zhang1
 (不 率 由 舊 章)	bu2shuai4you2jiu4zhang1
 (不 甚 嚣 尘 上)	bu2shen4xiao1chen2shang4
-(不 甚 嚣 尘 ㊤)	bu2shen4xiao1chen2shang4
 (不 甚 嚣 尘 上)	bu2shen4xiao1chen2shang4
-(不 甚 嚣 尘 ㊤)	bu2shen4xiao1chen2shang4
 (不 甚 囂 塵 上)	bu2shen4xiao1chen2shang4
-(不 甚 囂 塵 ㊤)	bu2shen4xiao1chen2shang4
 (不 甚 囂 塵 上)	bu2shen4xiao1chen2shang4
-(不 甚 囂 塵 ㊤)	bu2shen4xiao1chen2shang4
 (不 甚 感 詫 異)	bu2shen4gan3cha4yi4
 (不 甚 感 詫 異)	bu2shen4gan3cha4yi4
 (不 甚 感 詫 異)	bu2shen4gan3cha4yi4
@@ -83056,9 +76388,7 @@ $textmode
 (不 看 不 顺 眼)	bu2kan4bu5shun4yan3
 (不 看 不 顺 眼)	bu2kan4bu5shun4yan3
 (不 眾 口 一 詞)	bu2zhong4kou3yi4ci2
-(不 眾 口 ㊀ 詞)	bu2zhong4kou3yi4ci2
 (不 眾 口 一 詞)	bu2zhong4kou3yi4ci2
-(不 眾 口 ㊀ 詞)	bu2zhong4kou3yi4ci2
 (不 眾 矢 之 的)	bu2zhong4shi3zhi1di4
 (不 眾 矢 之 的)	bu2zhong4shi3zhi1di4
 (不 破 涕 为 笑)	bu2po4ti4wei2xiao4
@@ -83088,16 +76418,9 @@ $textmode
 (不 絮 絮 叨 叨)	bu2xu4xu5dao1dao1
 (不 絮 絮 叨 叨)	bu2xu4xu5dao1dao1
 (不 綠 女 紅 男)	bu2lv4nv3hong2nan2
-(不 綠 女 紅 ㊚)	bu2lv4nv3hong2nan2
-(不 綠 ㊛ 紅 男)	bu2lv4nv3hong2nan2
 (不 綠 女 紅 男)	bu2lv4nv3hong2nan2
-(不 綠 女 紅 ㊚)	bu2lv4nv3hong2nan2
-(不 綠 ㊛ 紅 男)	bu2lv4nv3hong2nan2
 (不 綠 女 紅 男)	bu2lv4nv3hong2nan2
-(不 綠 女 紅 ㊚)	bu2lv4nv3hong2nan2
 (不 綠 女 紅 男)	bu2lv4nv3hong2nan2
-(不 綠 女 紅 ㊚)	bu2lv4nv3hong2nan2
-(不 綠 ㊛ 紅 男)	bu2lv4nv3hong2nan2
 (不 綠 林 好 漢)	bu2lu4lin2hao3han4
 (不 綠 林 好 漢)	bu2lu4lin2hao3han4
 (不 綠 林 好 漢)	bu2lu4lin2hao3han4
@@ -83105,38 +76428,21 @@ $textmode
 (不 綠 林 好 漢)	bu2lu4lin2hao3han4
 (不 綠 林 好 漢)	bu2lu4lin2hao3han4
 (不 绿 女 红 男)	bu2lv4nv3hong2nan2
-(不 绿 女 红 ㊚)	bu2lv4nv3hong2nan2
-(不 绿 ㊛ 红 男)	bu2lv4nv3hong2nan2
 (不 绿 女 红 男)	bu2lv4nv3hong2nan2
-(不 绿 女 红 ㊚)	bu2lv4nv3hong2nan2
 (不 绿 女 红 男)	bu2lv4nv3hong2nan2
-(不 绿 女 红 ㊚)	bu2lv4nv3hong2nan2
-(不 绿 ㊛ 红 男)	bu2lv4nv3hong2nan2
 (不 绿 林 好 汉)	bu2lu4lin2hao3han4
 (不 绿 林 好 汉)	bu2lu4lin2hao3han4
 (不 绿 林 好 汉)	bu2lu4lin2hao3han4
 (不 聖 經 賢 傳)	bu2sheng4jing1xian2zhuan4
 (不 聖 經 賢 傳)	bu2sheng4jing1xian2zhuan4
 (不 背 水 一 战)	bu2bei4shui3yi2zhan4
-(不 背 ㊌ 一 战)	bu2bei4shui3yi2zhan4
-(不 背 水 ㊀ 战)	bu2bei4shui3yi2zhan4
 (不 背 水 一 战)	bu2bei4shui3yi2zhan4
-(不 背 ㊌ 一 战)	bu2bei4shui3yi2zhan4
-(不 背 水 ㊀ 战)	bu2bei4shui3yi2zhan4
 (不 背 水 一 戰)	bu2bei4shui3yi2zhan4
-(不 背 ㊌ 一 戰)	bu2bei4shui3yi2zhan4
-(不 背 水 ㊀ 戰)	bu2bei4shui3yi2zhan4
 (不 背 水 一 戰)	bu2bei4shui3yi2zhan4
-(不 背 ㊌ 一 戰)	bu2bei4shui3yi2zhan4
-(不 背 水 ㊀ 戰)	bu2bei4shui3yi2zhan4
 (不 能 贊 一 辭)	bu4neng2zan4yi4ci2
-(不 能 贊 ㊀ 辭)	bu4neng2zan4yi4ci2
 (不 能 贊 一 辭)	bu4neng2zan4yi4ci2
-(不 能 贊 ㊀ 辭)	bu4neng2zan4yi4ci2
 (不 能 赞 一 辞)	bu4neng2zan4yi4ci2
-(不 能 赞 ㊀ 辞)	bu4neng2zan4yi4ci2
 (不 能 赞 一 辞)	bu4neng2zan4yi4ci2
-(不 能 赞 ㊀ 辞)	bu4neng2zan4yi4ci2
 (不 自 作 聪 明)	bu2zi4zuo4cong1ming2
 (不 自 作 聪 明)	bu2zi4zuo4cong1ming2
 (不 自 作 聰 明)	bu2zi4zuo4cong1ming2
@@ -83154,40 +76460,25 @@ $textmode
 (不 自 视 甚 高)	bu2zi4shi4shen4gao1
 (不 自 视 甚 高)	bu2zi4shi4shen4gao1
 (不 臭 名 昭 著)	bu2chou4ming2zhao1zhu4
-(不 臭 ㊔ 昭 著)	bu2chou4ming2zhao1zhu4
 (不 臭 名 昭 著)	bu2chou4ming2zhao1zhu4
-(不 臭 ㊔ 昭 著)	bu2chou4ming2zhao1zhu4
 (不 臭 名 昭 著)	bu2chou4ming2zhao1zhu4
-(不 臭 ㊔ 昭 著)	bu2chou4ming2zhao1zhu4
 (不 臭 名 昭 著)	bu2chou4ming2zhao1zhu4
-(不 臭 ㊔ 昭 著)	bu2chou4ming2zhao1zhu4
 (不 興 高 采 烈)	bu2xing4gao1cai3lie4
 (不 興 高 采 烈)	bu2xing4gao1cai3lie4
 (不 興 高 采 烈)	bu2xing4gao1cai3lie4
 (不 舊 地 重 遊)	bu2jiu4di4chong2you2
 (不 舊 地 重 遊)	bu2jiu4di4chong2you2
 (不 舜 日 堯 年)	bu2shun4ri4yao2nian2
-(不 舜 ㊐ 堯 年)	bu2shun4ri4yao2nian2
 (不 舜 日 堯 年)	bu2shun4ri4yao2nian2
-(不 舜 ㊐ 堯 年)	bu2shun4ri4yao2nian2
 (不 舜 日 堯 年)	bu2shun4ri4yao2nian2
-(不 舜 ㊐ 堯 年)	bu2shun4ri4yao2nian2
 (不 舜 日 尧 年)	bu2shun4ri4yao2nian2
-(不 舜 ㊐ 尧 年)	bu2shun4ri4yao2nian2
 (不 舜 日 尧 年)	bu2shun4ri4yao2nian2
-(不 舜 ㊐ 尧 年)	bu2shun4ri4yao2nian2
 (不 舜 日 尧 年)	bu2shun4ri4yao2nian2
-(不 舜 ㊐ 尧 年)	bu2shun4ri4yao2nian2
 (不 艾 扑 西 龙)	bu2ai4pu1xi1long2
-(不 艾 扑 🀂 龙)	bu2ai4pu1xi1long2
 (不 艾 扑 西 龙)	bu2ai4pu1xi1long2
-(不 艾 扑 🀂 龙)	bu2ai4pu1xi1long2
 (不 艾 撲 西 龍)	bu2ai4pu1xi1long2
-(不 艾 撲 🀂 龍)	bu2ai4pu1xi1long2
 (不 艾 撲 西 龍)	bu2ai4pu1xi1long2
-(不 艾 撲 🀂 龍)	bu2ai4pu1xi1long2
 (不 艾 撲 西 龍)	bu2ai4pu1xi1long2
-(不 艾 撲 🀂 龍)	bu2ai4pu1xi1long2
 (不 艾 滋 病 毒)	bu2ai4zi1bing4du2
 (不 艾 滋 病 毒)	bu2ai4zi1bing4du2
 (不 艾 滋 病 毒)	bu2ai4zi1bing4du2
@@ -83199,9 +76490,7 @@ $textmode
 (不 萨 克 斯 风)	bu2sa4ke4si1feng1
 (不 萨 克 斯 风)	bu2sa4ke4si1feng1
 (不 萬 無 一 失)	bu2wan4wu2yi4shi1
-(不 萬 無 ㊀ 失)	bu2wan4wu2yi4shi1
 (不 萬 無 一 失)	bu2wan4wu2yi4shi1
-(不 萬 無 ㊀ 失)	bu2wan4wu2yi4shi1
 (不 著 书 立 说)	bu2zhu4shu1li4shuo1
 (不 著 书 立 说)	bu2zhu4shu1li4shuo1
 (不 著 书 立 说)	bu2zhu4shu1li4shuo1
@@ -83223,9 +76512,7 @@ $textmode
 (不 血 流 漂 杵)	bu2xue4liu2piao1chu3
 (不 血 流 漂 杵)	bu2xue4liu2piao1chu3
 (不 血 濃 於 水)	bu2xue4nong2yu2shui3
-(不 血 濃 於 ㊌)	bu2xue4nong2yu2shui3
 (不 血 濃 於 水)	bu2xue4nong2yu2shui3
-(不 血 濃 於 ㊌)	bu2xue4nong2yu2shui3
 (不 血 跡 斑 斑)	bu2xue4ji1ban1ban1
 (不 血 跡 斑 斑)	bu2xue4ji1ban1ban1
 (不 血 迹 斑 斑)	bu2xue4ji1ban1ban1
@@ -83288,15 +76575,10 @@ $textmode
 (不 败 子 回 头)	bu2bai4zi3hui2tou2
 (不 败 子 回 头)	bu2bai4zi3hui2tou2
 (不 跨 鶴 西 遊)	bu2kua4he4xi1you2
-(不 跨 鶴 🀂 遊)	bu2kua4he4xi1you2
 (不 跨 鶴 西 遊)	bu2kua4he4xi1you2
-(不 跨 鶴 🀂 遊)	bu2kua4he4xi1you2
 (不 跨 鶴 西 遊)	bu2kua4he4xi1you2
-(不 跨 鶴 🀂 遊)	bu2kua4he4xi1you2
 (不 跨 鹤 西 遊)	bu2kua4he4xi1you2
-(不 跨 鹤 🀂 遊)	bu2kua4he4xi1you2
 (不 跨 鹤 西 遊)	bu2kua4he4xi1you2
-(不 跨 鹤 🀂 遊)	bu2kua4he4xi1you2
 (不 蹦 蹦 跳 跳)	bu2beng4beng5tiao4tiao4
 (不 蹦 蹦 跳 跳)	bu2beng4beng5tiao4tiao4
 (不 轉 渾 天 儀)	bu2zhuan4hun2tian1yi2
@@ -83304,9 +76586,7 @@ $textmode
 (不 转 浑 天 仪)	bu2zhuan4hun2tian1yi2
 (不 转 浑 天 仪)	bu2zhuan4hun2tian1yi2
 (不 过 一 会 儿)	bu2guo4yi4hui3r5
-(不 过 ㊀ 会 儿)	bu2guo4yi4hui3r5
 (不 过 一 会 儿)	bu2guo4yi4hui3r5
-(不 过 ㊀ 会 儿)	bu2guo4yi4hui3r5
 (不 过 去 分 词)	bu2guo4qu4fen1ci2
 (不 过 去 分 词)	bu2guo4qu4fen1ci2
 (不 这 早 晚 儿)	bu2zhe4zao3wan3r5
@@ -83318,16 +76598,12 @@ $textmode
 (不 退 耕 還 林)	bu2tui4geng1huan2lin2
 (不 退 耕 還 林)	bu2tui4geng1huan2lin2
 (不 退 避 三 舍)	bu2tui4bi4san1she4
-(不 退 避 ㊂ 舍)	bu2tui4bi4san1she4
 (不 退 避 三 舍)	bu2tui4bi4san1she4
-(不 退 避 ㊂ 舍)	bu2tui4bi4san1she4
 (不 逆 行 倒 施)	bu2ni4xing2dao3shi1
 (不 逆 行 倒 施)	bu2ni4xing2dao3shi1
 (不 逆 行 倒 施)	bu2ni4xing2dao3shi1
 (不 過 一 會 兒)	bu2guo4yi4hui3r5
-(不 過 ㊀ 會 兒)	bu2guo4yi4hui3r5
 (不 過 一 會 兒)	bu2guo4yi4hui3r5
-(不 過 ㊀ 會 兒)	bu2guo4yi4hui3r5
 (不 過 去 分 詞)	bu2guo4qu4fen1ci2
 (不 過 去 分 詞)	bu2guo4qu4fen1ci2
 (不 重 於 泰 山)	bu2zhong4yu2tai4shan1
@@ -83379,81 +76655,29 @@ $textmode
 (不 预 备 知 识)	bu2yu4bei4zhi1shi2
 (不 预 备 知 识)	bu2yu4bei4zhi1shi2
 (不 駕 鶴 西 遊)	bu2jia4he4xi1you2
-(不 駕 鶴 🀂 遊)	bu2jia4he4xi1you2
 (不 駕 鶴 西 遊)	bu2jia4he4xi1you2
-(不 駕 鶴 🀂 遊)	bu2jia4he4xi1you2
 (不 駕 鶴 西 遊)	bu2jia4he4xi1you2
-(不 駕 鶴 🀂 遊)	bu2jia4he4xi1you2
 (不 驾 鹤 西 遊)	bu2jia4he4xi1you2
-(不 驾 鹤 🀂 遊)	bu2jia4he4xi1you2
 (不 驾 鹤 西 遊)	bu2jia4he4xi1you2
-(不 驾 鹤 🀂 遊)	bu2jia4he4xi1you2
 (中 大 西 洋 脊)	zhong1da4xi1yang2ji3
-(中 大 🀂 洋 脊)	zhong1da4xi1yang2ji3
-(🀄 大 西 洋 脊)	zhong1da4xi1yang2ji3
-(㊥ 大 西 洋 脊)	zhong1da4xi1yang2ji3
-(㊥ 大 🀂 洋 脊)	zhong1da4xi1yang2ji3
 (乌 兰 察 布 市)	wu1lan4cha2bu4shi4
 (二 一 添 作 五)	er4yi4tian1zuo4wu3
-(二 ㊀ 添 作 五)	er4yi4tian1zuo4wu3
-(㊁ 一 添 作 五)	er4yi4tian1zuo4wu3
-(二 一 添 作 ㊄)	er4yi4tian1zuo4wu3
 (二 十 一 世 紀)	er4shi2yi1shi4ji4
-(二 ㊉ 一 世 紀)	er4shi2yi1shi4ji4
-(二 十 ㊀ 世 紀)	er4shi2yi1shi4ji4
-(㊁ 十 一 世 紀)	er4shi2yi1shi4ji4
 (二 十 一 世 纪)	er4shi2yi1shi4ji4
-(二 ㊉ 一 世 纪)	er4shi2yi1shi4ji4
-(二 十 ㊀ 世 纪)	er4shi2yi1shi4ji4
-(㊁ 十 一 世 纪)	er4shi2yi1shi4ji4
 (二 十 四 節 氣)	er4shi2si4jie2qi4
-(二 ㊉ 四 節 氣)	er4shi2si4jie2qi4
-(二 十 ㊃ 節 氣)	er4shi2si4jie2qi4
-(㊁ 十 四 節 氣)	er4shi2si4jie2qi4
 (二 十 四 節 氣)	er4shi2si4jie2qi4
-(二 ㊉ 四 節 氣)	er4shi2si4jie2qi4
-(二 十 ㊃ 節 氣)	er4shi2si4jie2qi4
-(㊁ 十 四 節 氣)	er4shi2si4jie2qi4
 (二 十 四 節 氣)	er4shi2si4jie2qi4
-(二 ㊉ 四 節 氣)	er4shi2si4jie2qi4
-(二 十 ㊃ 節 氣)	er4shi2si4jie2qi4
-(㊁ 十 四 節 氣)	er4shi2si4jie2qi4
 (二 十 四 节 气)	er4shi2si4jie2qi4
-(二 ㊉ 四 节 气)	er4shi2si4jie2qi4
-(二 十 ㊃ 节 气)	er4shi2si4jie2qi4
-(㊁ 十 四 节 气)	er4shi2si4jie2qi4
 (二 合 一 复 数)	er4he2yi2fu4shu4
-(二 合 ㊀ 复 数)	er4he2yi2fu4shu4
-(㊁ 合 一 复 数)	er4he2yi2fu4shu4
 (二 合 一 複 數)	er4he2yi2fu4shu4
-(二 合 ㊀ 複 數)	er4he2yi2fu4shu4
-(㊁ 合 一 複 數)	er4he2yi2fu4shu4
 (二 合 一 複 數)	er4he2yi2fu4shu4
-(二 合 ㊀ 複 數)	er4he2yi2fu4shu4
-(㊁ 合 一 複 數)	er4he2yi2fu4shu4
 (五 一 六 通 知)	wu3yi2liu4tong1zhi1
-(五 ㊀ 六 通 知)	wu3yi2liu4tong1zhi1
-(㊄ 一 六 通 知)	wu3yi2liu4tong1zhi1
-(五 一 ㊅ 通 知)	wu3yi2liu4tong1zhi1
 (五 一 六 通 知)	wu3yi2liu4tong1zhi1
-(五 ㊀ 六 通 知)	wu3yi2liu4tong1zhi1
-(㊄ 一 六 通 知)	wu3yi2liu4tong1zhi1
 (五 一 劳 动 节)	wu3yi4lao2dong4jie2
-(五 ㊀ 劳 动 节)	wu3yi4lao2dong4jie2
-(㊄ 一 劳 动 节)	wu3yi4lao2dong4jie2
-(五 一 ㊘ 动 节)	wu3yi4lao2dong4jie2
 (五 一 勞 動 節)	wu3yi4lao2dong4jie2
-(五 ㊀ 勞 動 節)	wu3yi4lao2dong4jie2
-(㊄ 一 勞 動 節)	wu3yi4lao2dong4jie2
 (五 一 勞 動 節)	wu3yi4lao2dong4jie2
-(五 ㊀ 勞 動 節)	wu3yi4lao2dong4jie2
-(㊄ 一 勞 動 節)	wu3yi4lao2dong4jie2
 (五 一 勞 動 節)	wu3yi4lao2dong4jie2
-(五 ㊀ 勞 動 節)	wu3yi4lao2dong4jie2
-(㊄ 一 勞 動 節)	wu3yi4lao2dong4jie2
 (五 一 勞 動 節)	wu3yi4lao2dong4jie2
-(五 ㊀ 勞 動 節)	wu3yi4lao2dong4jie2
-(㊄ 一 勞 動 節)	wu3yi4lao2dong4jie2
 (亚 得 里 亚 海)	ya4de2li3ya4hai3
 (亚 得 里 亚 海)	ya4de2li3ya4hai3
 (亚 得 里 亚 海)	ya4de2li3ya4hai3
@@ -83484,16 +76708,11 @@ $textmode
 (何 樂 而 不 為)	he2le4er2bu4wei2
 (何 樂 而 不 為)	he2le4er2bu4wei2
 (依 地 酸 二 鈷)	yi1di4suan1er4gu3
-(依 地 酸 ㊁ 鈷)	yi1di4suan1er4gu3
 (依 地 酸 二 钴)	yi1di4suan1er4gu3
-(依 地 酸 ㊁ 钴)	yi1di4suan1er4gu3
 (儿 女 英 雄 传)	er2nv3ying1xiong2zhuan4
-(儿 ㊛ 英 雄 传)	er2nv3ying1xiong2zhuan4
 (儿 女 英 雄 传)	er2nv3ying1xiong2zhuan4
 (先 下 手 为 强)	xian1xia4shou3wei2qiang2
-(先 ㊦ 手 为 强)	xian1xia4shou3wei2qiang2
 (先 下 手 為 強)	xian1xia4shou3wei2qiang2
-(先 ㊦ 手 為 強)	xian1xia4shou3wei2qiang2
 (光 不 出 溜 儿)	guang1bu5chu5liu1r5
 (光 不 出 溜 儿)	guang1bu5chu5liu1r5
 (光 不 出 溜 儿)	guang1bu5chu5liu1r5
@@ -83506,48 +76725,23 @@ $textmode
 (克 裡 姆 林 宮)	ke4li3mu3lin2gong1
 (克 裡 姆 林 宮)	ke4li3mu3lin2gong1
 (克 裡 木 半 島)	ke4li3mu4ban4dao3
-(克 裡 ㊍ 半 島)	ke4li3mu4ban4dao3
 (克 裡 木 半 島)	ke4li3mu4ban4dao3
-(克 裡 ㊍ 半 島)	ke4li3mu4ban4dao3
 (克 裡 絲 蒂 娃)	ke4li3si1di4wa2
 (克 裡 絲 蒂 娃)	ke4li3si1di4wa2
 (兒 女 英 雄 傳)	er2nv3ying1xiong2zhuan4
-(兒 ㊛ 英 雄 傳)	er2nv3ying1xiong2zhuan4
 (兒 女 英 雄 傳)	er2nv3ying1xiong2zhuan4
 (八 一 建 军 节)	ba1yi2jian4jun1jie2
-(八 ㊀ 建 军 节)	ba1yi2jian4jun1jie2
-(㊇ 一 建 军 节)	ba1yi2jian4jun1jie2
 (八 一 建 軍 節)	ba1yi2jian4jun1jie2
-(八 ㊀ 建 軍 節)	ba1yi2jian4jun1jie2
-(㊇ 一 建 軍 節)	ba1yi2jian4jun1jie2
 (八 一 建 軍 節)	ba1yi2jian4jun1jie2
-(八 ㊀ 建 軍 節)	ba1yi2jian4jun1jie2
-(㊇ 一 建 軍 節)	ba1yi2jian4jun1jie2
 (八 一 建 軍 節)	ba1yi2jian4jun1jie2
-(八 ㊀ 建 軍 節)	ba1yi2jian4jun1jie2
-(㊇ 一 建 軍 節)	ba1yi2jian4jun1jie2
 (八 字 沒 一 撇)	ba1zi4mei2yi4pie3
-(八 字 沒 ㊀ 撇)	ba1zi4mei2yi4pie3
-(㊇ 字 沒 一 撇)	ba1zi4mei2yi4pie3
 (八 字 没 一 撇)	ba1zi4mei2yi4pie3
-(八 字 没 ㊀ 撇)	ba1zi4mei2yi4pie3
-(㊇ 字 没 一 撇)	ba1zi4mei2yi4pie3
 (六 一 儿 童 节)	liu4yi4er2tong2jie2
-(六 ㊀ 儿 童 节)	liu4yi4er2tong2jie2
-(㊅ 一 儿 童 节)	liu4yi4er2tong2jie2
 (六 一 儿 童 节)	liu4yi4er2tong2jie2
-(六 ㊀ 儿 童 节)	liu4yi4er2tong2jie2
 (六 一 兒 童 節)	liu4yi4er2tong2jie2
-(六 ㊀ 兒 童 節)	liu4yi4er2tong2jie2
-(㊅ 一 兒 童 節)	liu4yi4er2tong2jie2
 (六 一 兒 童 節)	liu4yi4er2tong2jie2
-(六 ㊀ 兒 童 節)	liu4yi4er2tong2jie2
 (六 一 兒 童 節)	liu4yi4er2tong2jie2
-(六 ㊀ 兒 童 節)	liu4yi4er2tong2jie2
-(㊅ 一 兒 童 節)	liu4yi4er2tong2jie2
 (六 一 兒 童 節)	liu4yi4er2tong2jie2
-(六 ㊀ 兒 童 節)	liu4yi4er2tong2jie2
-(㊅ 一 兒 童 節)	liu4yi4er2tong2jie2
 (兴 凯 刺 鳑 鲏)	xing1kai3ci4pang2pi2
 (兴 凯 刺 鳑 鲏)	xing1kai3ci4pang2pi2
 (兴 都 库 什 山)	xing1du1ku4shi2shan1
@@ -83562,7 +76756,6 @@ $textmode
 (出 不 了  包)	chu1bu5liao3song2bao1
 (出 不 了  包)	chu1bu5liao3song2bao1
 (分 子 生 物 学)	fen1zi3sheng1wu4xue2
-(分 子 生 物 ㊫)	fen1zi3sheng1wu4xue2
 (分 子 生 物 學)	fen1zi3sheng1wu4xue2
 (切 尔 诺 贝 利)	qie1er3nuo4bei4li4
 (切 尔 诺 贝 利)	qie1er3nuo4bei4li4
@@ -83575,13 +76768,9 @@ $textmode
 (別 赫 捷 列 夫)	bie2he4jie2lie4fu1
 (別 赫 捷 列 夫)	bie2he4jie2lie4fu1
 (利 西 馬 科 斯)	li4xi1ma3ke1si1
-(利 🀂 馬 科 斯)	li4xi1ma3ke1si1
 (利 西 馬 科 斯)	li4xi1ma3ke1si1
-(利 🀂 馬 科 斯)	li4xi1ma3ke1si1
 (利 西 马 科 斯)	li4xi1ma3ke1si1
-(利 🀂 马 科 斯)	li4xi1ma3ke1si1
 (利 西 马 科 斯)	li4xi1ma3ke1si1
-(利 🀂 马 科 斯)	li4xi1ma3ke1si1
 (别 赫 捷 列 夫)	bie2he4jie2lie4fu1
 (别 赫 捷 列 夫)	bie2he4jie2lie4fu1
 (到 那 个 时 候)	dao4na4ge4shi2hou4
@@ -83603,25 +76792,16 @@ $textmode
 (加 纳 利 码 头)	jia1na4li4ma3tou2
 (加 纳 利 码 头)	jia1na4li4ma3tou2
 (助 一 臂 之 力)	zhu4yi2bi4zhi5li4
-(助 ㊀ 臂 之 力)	zhu4yi2bi4zhi5li4
 (助 一 臂 之 力)	zhu4yi2bi4zhi5li4
-(助 ㊀ 臂 之 力)	zhu4yi2bi4zhi5li4
 (勃 列 日 涅 夫)	bo2lie4ri4nie4fu1
-(勃 列 ㊐ 涅 夫)	bo2lie4ri4nie4fu1
 (勃 列 日 涅 夫)	bo2lie4ri4nie4fu1
-(勃 列 ㊐ 涅 夫)	bo2lie4ri4nie4fu1
 (化 学 剂 量 计)	hua4xue2ji4liang4ji4
-(化 ㊫ 剂 量 计)	hua4xue2ji4liang4ji4
 (化 学 剂 量 计)	hua4xue2ji4liang4ji4
-(化 ㊫ 剂 量 计)	hua4xue2ji4liang4ji4
 (化 學 劑 量 計)	hua4xue2ji4liang4ji4
 (化 學 劑 量 計)	hua4xue2ji4liang4ji4
 (单 一 主 题 句)	dan1yi4zhu3ti2ju4
-(单 ㊀ 主 题 句)	dan1yi4zhu3ti2ju4
 (单 一 主 题 句)	dan1yi4zhu3ti2ju4
-(单 ㊀ 主 题 句)	dan1yi4zhu3ti2ju4
 (单 一 合 体 字)	dan1yi4he2ti3zi4
-(单 ㊀ 合 体 字)	dan1yi4he2ti3zi4
 (卡 門 柏 乳 酪)	ka3men2bo2ru3lao4
 (卡 門 柏 乳 酪)	ka3men2bo2ru3lao4
 (卡 门 柏 乳 酪)	ka3men2bo2ru3lao4
@@ -83632,9 +76812,7 @@ $textmode
 (吃 不 住 劲 儿)	chi1bu5zhu4jin4r5
 (吃 不 住 劲 儿)	chi1bu5zhu4jin4r5
 (咕 啾 在 一 块)	gu1jiu5zai4yi2kuai4
-(咕 啾 在 ㊀ 块)	gu1jiu5zai4yi2kuai4
 (咕 啾 在 一 塊)	gu1jiu5zai4yi2kuai4
-(咕 啾 在 ㊀ 塊)	gu1jiu5zai4yi2kuai4
 (哀 的 美 敦 书)	ai1di4mei3dun1shu1
 (哀 的 美 敦 書)	ai1di4mei3dun1shu1
 (啊 耳 忒 弥 斯)	a1er3te4mi2si1
@@ -83647,11 +76825,8 @@ $textmode
 (喀 喇 昆 侖 山)	ka1la1kun1lun2shan1
 (喀 喇 昆 侖 山)	ka1la1kun1lun2shan1
 (單 一 主 題 句)	dan1yi4zhu3ti2ju4
-(單 ㊀ 主 題 句)	dan1yi4zhu3ti2ju4
 (單 一 主 題 句)	dan1yi4zhu3ti2ju4
-(單 ㊀ 主 題 句)	dan1yi4zhu3ti2ju4
 (單 一 合 體 字)	dan1yi4he2ti3zi4
-(單 ㊀ 合 體 字)	dan1yi4he2ti3zi4
 (地 对 空 导 弹)	di4dui4kong1dao3dan4
 (地 對 空 導 彈)	di4dui4kong1dao3dan4
 (埃 克 巴 坦 那)	ai1ke4ba1tan3na4
@@ -83675,15 +76850,12 @@ $textmode
 (天 不 转 地 转)	tian1bu5zhuan4di4zhuan4
 (天 不 转 地 转)	tian1bu5zhuan4di4zhuan4
 (天 字 第 一 号)	tian1zi4di4yi1hao4
-(天 字 第 ㊀ 号)	tian1zi4di4yi1hao4
 (天 字 第 一 號)	tian1zi4di4yi1hao4
-(天 字 第 ㊀ 號)	tian1zi4di4yi1hao4
 (奴 儿 干 都 司)	nu2er2gan1du1shi1
 (奴 儿 干 都 司)	nu2er2gan1du1shi1
 (奴 兒 干 都 司)	nu2er2gan1du1shi1
 (奴 兒 干 都 司)	nu2er2gan1du1shi1
 (好 好 整 一 整)	hao3hao3zheng3yi5zheng3
-(好 好 整 ㊀ 整)	hao3hao3zheng3yi5zheng3
 (好 得 没 底 儿)	hao3de5mei2di3r5
 (妻 子 管 得 严)	qi1zi5guan3de2yan2
 (妻 子 管 得 嚴)	qi1zi5guan3de2yan2
@@ -83731,21 +76903,9 @@ $textmode
 (帕 拉 塞 爾 士)	pa4la1se4er3shi4
 (帕 拉 塞 爾 士)	pa4la1se4er3shi4
 (庇 西 特 拉 图)	bi4xi1te4la1tu2
-(庇 🀂 特 拉 图)	bi4xi1te4la1tu2
-(庇 西 ㊕ 拉 图)	bi4xi1te4la1tu2
-(庇 🀂 ㊕ 拉 图)	bi4xi1te4la1tu2
 (庇 西 特 拉 图)	bi4xi1te4la1tu2
-(庇 🀂 特 拉 图)	bi4xi1te4la1tu2
-(庇 西 ㊕ 拉 图)	bi4xi1te4la1tu2
-(庇 🀂 ㊕ 拉 图)	bi4xi1te4la1tu2
 (庇 西 特 拉 圖)	bi4xi1te4la1tu2
-(庇 🀂 特 拉 圖)	bi4xi1te4la1tu2
-(庇 西 ㊕ 拉 圖)	bi4xi1te4la1tu2
-(庇 🀂 ㊕ 拉 圖)	bi4xi1te4la1tu2
 (庇 西 特 拉 圖)	bi4xi1te4la1tu2
-(庇 🀂 特 拉 圖)	bi4xi1te4la1tu2
-(庇 西 ㊕ 拉 圖)	bi4xi1te4la1tu2
-(庇 🀂 ㊕ 拉 圖)	bi4xi1te4la1tu2
 (弗 洛 裡 斯 島)	fu2luo4li3si1dao3
 (弗 洛 裡 斯 島)	fu2luo4li3si1dao3
 (弗 洛 裡 斯 島)	fu2luo4li3si1dao3
@@ -83772,7 +76932,6 @@ $textmode
 (戰 略 核 力 量)	zhan4lve4he2li4liang4
 (戰 略 核 力 量)	zhan4lve4he2li4liang4
 (把 手 写 辩 识)	ba3shou3xie3bian4shi2
-(把 手 ㊢ 辩 识)	ba3shou3xie3bian4shi2
 (把 手 寫 辯 識)	ba3shou3xie3bian4shi2
 (把 手 寫 辯 識)	ba3shou3xie3bian4shi2
 (把 手 忙 脚 乱)	ba3shou3mang2jiao3luan4
@@ -83844,9 +77003,7 @@ $textmode
 (易 得 者 易 失)	yi4de2zhe3yi4shi1
 (易 得 者 易 失)	yi4de2zhe3yi4shi1
 (春 秋 左 氏 传)	chun1qiu1zuo3shi4zhuan4
-(春 秋 ㊧ 氏 传)	chun1qiu1zuo3shi4zhuan4
 (春 秋 左 氏 傳)	chun1qiu1zuo3shi4zhuan4
-(春 秋 ㊧ 氏 傳)	chun1qiu1zuo3shi4zhuan4
 (普 罗 夫 迪 夫)	pu3luo2fu1di2fu1
 (普 羅 夫 迪 夫)	pu3luo2fu1di2fu1
 (普 羅 夫 迪 夫)	pu3luo2fu1di2fu1
@@ -83857,25 +77014,15 @@ $textmode
 (普 里 什 蒂 纳)	pu3li3shi2di4na4
 (普 里 什 蒂 纳)	pu3li3shi2di4na4
 (有 苦 說 不 出)	you3ku3shuo1bu5chu1
-(㊒ 苦 說 不 出)	you3ku3shuo1bu5chu1
 (有 苦 說 不 出)	you3ku3shuo1bu5chu1
-(㊒ 苦 說 不 出)	you3ku3shuo1bu5chu1
 (有 苦 說 不 出)	you3ku3shuo1bu5chu1
-(㊒ 苦 說 不 出)	you3ku3shuo1bu5chu1
 (有 苦 說 不 出)	you3ku3shuo1bu5chu1
-(㊒ 苦 說 不 出)	you3ku3shuo1bu5chu1
 (有 苦 说 不 出)	you3ku3shuo1bu5chu1
-(㊒ 苦 说 不 出)	you3ku3shuo1bu5chu1
 (有 苦 说 不 出)	you3ku3shuo1bu5chu1
-(㊒ 苦 说 不 出)	you3ku3shuo1bu5chu1
 (李 卜 克 內 西)	li3bo5ke4nei4xi1
-(李 卜 克 內 🀂)	li3bo5ke4nei4xi1
 (李 卜 克 內 西)	li3bo5ke4nei4xi1
-(李 卜 克 內 🀂)	li3bo5ke4nei4xi1
 (李 卜 克 内 西)	li3bo5ke4nei4xi1
-(李 卜 克 内 🀂)	li3bo5ke4nei4xi1
 (李 卜 克 内 西)	li3bo5ke4nei4xi1
-(李 卜 克 内 🀂)	li3bo5ke4nei4xi1
 (杜 塞 尔 多 夫)	du4sai1er3duo1fu1
 (杜 塞 尔 多 夫)	du4sai1er3duo1fu1
 (杜 塞 爾 多 夫)	du4sai1er3duo1fu1
@@ -83888,9 +77035,7 @@ $textmode
 (柴 科 夫 斯 基)	chai2ke1fu1si1ji1
 (树 倒 猢 狲 散)	shu4dao3hu2sun1san4
 (格 尔 夫 波 特)	ge2er3fu1bo1te4
-(格 尔 夫 波 ㊕)	ge2er3fu1bo1te4
 (格 爾 夫 波 特)	ge2er3fu1bo1te4
-(格 爾 夫 波 ㊕)	ge2er3fu1bo1te4
 (樹 倒 猢 猻 散)	shu4dao3hu2sun1san4
 (欧 里 庇 得 斯)	ou1li3bi4de2si1
 (欧 里 庇 得 斯)	ou1li3bi4de2si1
@@ -83903,15 +77048,11 @@ $textmode
 (气 得 脸 发 黄)	qi4de5lian3fa1huang2
 (氣 得 臉 發 黃)	qi4de5lian3fa1huang2
 (灰 一 灰 房 子)	hui1yi4hui1fang2zi5
-(灰 ㊀ 灰 房 子)	hui1yi4hui1fang2zi5
 (烏 蘭 察 布 市)	wu1lan4cha2bu4shi4
 (烏 蘭 察 布 市)	wu1lan4cha2bu4shi4
 (琐 罗 亚 斯 特)	suo3luo1ya4si1te4
-(琐 罗 亚 斯 ㊕)	suo3luo1ya4si1te4
 (瑣 羅 亞 斯 特)	suo3luo1ya4si1te4
-(瑣 羅 亞 斯 ㊕)	suo3luo1ya4si1te4
 (瑣 羅 亞 斯 特)	suo3luo1ya4si1te4
-(瑣 羅 亞 斯 ㊕)	suo3luo1ya4si1te4
 (瓜 达 拉 哈 拉)	gua1da2la1ha1la1
 (瓜 达 拉 哈 拉)	gua1da2la1ha1la1
 (瓜 達 拉 哈 拉)	gua1da2la1ha1la1
@@ -83927,17 +77068,10 @@ $textmode
 (眼 不 见 为 淨)	yan3bu2jian4wei2jing4
 (眼 不 见 为 淨)	yan3bu2jian4wei2jing4
 (着 三 不 着 两)	zhao2san1bu4zhao2liang3
-(着 ㊂ 不 着 两)	zhao2san1bu4zhao2liang3
 (着 三 不 着 两)	zhao2san1bu4zhao2liang3
-(着 ㊂ 不 着 两)	zhao2san1bu4zhao2liang3
 (着 三 不 着 两)	zhao2san1bu4zhao2liang3
-(着 ㊂ 不 着 两)	zhao2san1bu4zhao2liang3
 (知 一 不 知 十)	zhi1yi2bu4zhi1shi2
-(知 一 不 知 ㊉)	zhi1yi2bu4zhi1shi2
-(知 ㊀ 不 知 十)	zhi1yi2bu4zhi1shi2
 (知 一 不 知 十)	zhi1yi2bu4zhi1shi2
-(知 一 不 知 ㊉)	zhi1yi2bu4zhi1shi2
-(知 ㊀ 不 知 十)	zhi1yi2bu4zhi1shi2
 (离 不 开 人 儿)	li2bu5kai1ren2r5
 (离 不 开 人 儿)	li2bu5kai1ren2r5
 (离 不 开 手 儿)	li2bu5kai1shou3r5
@@ -83951,43 +77085,26 @@ $textmode
 (稅 捐 稽 徵 處)	shui4juan1ji1zheng1chu4
 (税 捐 稽 征 处)	shui4juan1ji1zheng1chu4
 (第 一 个 层 次)	di4yi1ge4ceng2ci4
-(第 ㊀ 个 层 次)	di4yi1ge4ceng2ci4
 (第 一 個 層 次)	di4yi1ge4ceng2ci4
-(第 ㊀ 個 層 次)	di4yi1ge4ceng2ci4
 (第 一 個 層 次)	di4yi1ge4ceng2ci4
-(第 ㊀ 個 層 次)	di4yi1ge4ceng2ci4
 (第 一 类 物 资)	di4yi1lei4wu4zi1
-(第 ㊀ 类 物 资)	di4yi1lei4wu4zi1
 (第 一 类 物 资)	di4yi1lei4wu4zi1
-(第 ㊀ 类 物 资)	di4yi1lei4wu4zi1
 (第 一 類 物 資)	di4yi1lei4wu4zi1
-(第 一 類 物 ㊮)	di4yi1lei4wu4zi1
-(第 ㊀ 類 物 資)	di4yi1lei4wu4zi1
 (第 一 類 物 資)	di4yi1lei4wu4zi1
-(第 一 類 物 ㊮)	di4yi1lei4wu4zi1
-(第 ㊀ 類 物 資)	di4yi1lei4wu4zi1
 (米 德 爾 伯 裡)	mi3de2er3bo2li3
 (米 德 爾 伯 裡)	mi3de2er3bo2li3
 (紙 包 不 住 火)	zhi3bao1bu5zhu4huo3
-(紙 包 不 住 ㊋)	zhi3bao1bu5zhu4huo3
 (紙 包 不 住 火)	zhi3bao1bu5zhu4huo3
-(紙 包 不 住 ㊋)	zhi3bao1bu5zhu4huo3
 (索 福 克 裡 斯)	suo3fu2ke4li3si1
 (索 福 克 裡 斯)	suo3fu2ke4li3si1
 (索 福 克 裡 斯)	suo3fu2ke4li3si1
 (索 福 克 裡 斯)	suo3fu2ke4li3si1
 (給 他 一 大 哄)	gei3ta1yi2da4hong4
-(給 他 ㊀ 大 哄)	gei3ta1yi2da4hong4
 (統 一 價 格 法)	tong3yi2jia4ge2fa3
-(統 ㊀ 價 格 法)	tong3yi2jia4ge2fa3
 (纸 包 不 住 火)	zhi3bao1bu5zhu4huo3
-(纸 包 不 住 ㊋)	zhi3bao1bu5zhu4huo3
 (纸 包 不 住 火)	zhi3bao1bu5zhu4huo3
-(纸 包 不 住 ㊋)	zhi3bao1bu5zhu4huo3
 (给 他 一 大 哄)	gei3ta1yi2da4hong4
-(给 他 ㊀ 大 哄)	gei3ta1yi2da4hong4
 (统 一 价 格 法)	tong3yi2jia4ge2fa3
-(统 ㊀ 价 格 法)	tong3yi2jia4ge2fa3
 (绷 不 住 劲 儿)	beng3bu5zhu4jin4r5
 (绷 不 住 劲 儿)	beng3bu5zhu4jin4r5
 (罗 摩 诺 索 夫)	luo2mo2nuo4suo3fu1
@@ -84006,11 +77123,8 @@ $textmode
 (老 年 痴 獃 癥)	lao3nian2chi1dai1zheng4
 (老 年 痴 獃 癥)	lao3nian2chi1dai1zheng4
 (耶 和 华 尼 西)	ye1he2hua2ni2xi1
-(耶 和 华 尼 🀂)	ye1he2hua2ni2xi1
 (耶 和 華 尼 西)	ye1he2hua2ni2xi1
-(耶 和 華 尼 🀂)	ye1he2hua2ni2xi1
 (耶 和 華 尼 西)	ye1he2hua2ni2xi1
-(耶 和 華 尼 🀂)	ye1he2hua2ni2xi1
 (肿 瘤 切 除 术)	zhong3liu2qie4chu2shu4
 (肿 瘤 切 除 术)	zhong3liu2qie4chu2shu4
 (腫 瘤 切 除 術)	zhong3liu2qie4chu2shu4
@@ -84031,7 +77145,6 @@ $textmode
 (艾 爾 米 塔 什)	ai4er3mi3ta3shi2
 (艾 爾 米 塔 什)	ai4er3mi3ta3shi2
 (苏 联 之 友 社)	su1lian2zhi1you3she4
-(苏 联 之 友 ㊓)	su1lian2zhi1you3she4
 (苏 联 之 友 社)	su1lian2zhi1you3she4
 (苛 政 猛 於 虎)	ke1zheng4meng3yu2hu3
 (莫 卧 儿 王 朝)	mo4wo4r5wang2chao2
@@ -84039,13 +77152,9 @@ $textmode
 (萨 卡 什 维 利)	sa4ka3shi2wei2li4
 (萨 卡 什 维 利)	sa4ka3shi2wei2li4
 (著 三 不 著 兩)	zhao2san1bu4zhao2liang3
-(著 ㊂ 不 著 兩)	zhao2san1bu4zhao2liang3
 (著 三 不 著 兩)	zhao2san1bu4zhao2liang3
-(著 ㊂ 不 著 兩)	zhao2san1bu4zhao2liang3
 (著 三 不 著 兩)	zhao2san1bu4zhao2liang3
-(著 ㊂ 不 著 兩)	zhao2san1bu4zhao2liang3
 (著 三 不 著 兩)	zhao2san1bu4zhao2liang3
-(著 ㊂ 不 著 兩)	zhao2san1bu4zhao2liang3
 (蒙 得 維 的 亞)	meng2de2wei2di4ya4
 (蒙 得 维 的 亚)	meng2de2wei2di4ya4
 (蓋 革 計 數 器)	ge3ge2ji4shu4qi4
@@ -84058,9 +77167,7 @@ $textmode
 (薩 卡 什 維 利)	sa4ka3shi2wei2li4
 (薩 卡 什 維 利)	sa4ka3shi2wei2li4
 (蘇 聯 之 友 社)	su1lian2zhi1you3she4
-(蘇 聯 之 友 ㊓)	su1lian2zhi1you3she4
 (蘇 聯 之 友 社)	su1lian2zhi1you3she4
-(蘇 聯 之 友 ㊓)	su1lian2zhi1you3she4
 (蘇 聯 之 友 社)	su1lian2zhi1you3she4
 (虎 父 无 犬 子)	hu3fu4wu2quan3zi3
 (虎 父 無 犬 子)	hu3fu4wu2quan3zi3
@@ -84070,32 +77177,21 @@ $textmode
 (蛟 龍 得 雲 雨)	jiao1long2de2yun2yu3
 (蛟 龙 得 云 雨)	jiao1long2de2yun2yu3
 (蠢 動 於 一 時)	chun3dong4yu2yi4shi2
-(蠢 動 於 ㊀ 時)	chun3dong4yu2yi4shi2
 (行 行 出 状 元)	hang2hang2chu1zhuang4yuan5
 (行 行 出 状 元)	hang2hang2chu1zhuang4yuan5
 (行 行 出 狀 元)	hang2hang2chu1zhuang4yuan5
 (行 行 出 狀 元)	hang2hang2chu1zhuang4yuan5
 (行 行 出 狀 元)	hang2hang2chu1zhuang4yuan5
 (西 孟 加 拉 邦)	xi1meng4jia1la1bang1
-(🀂 孟 加 拉 邦)	xi1meng4jia1la1bang1
 (西 孟 加 拉 邦)	xi1meng4jia1la1bang1
-(🀂 孟 加 拉 邦)	xi1meng4jia1la1bang1
 (西 澳 大 利 亚)	xi1ao4da4li4ya4
-(🀂 澳 大 利 亚)	xi1ao4da4li4ya4
 (西 澳 大 利 亚)	xi1ao4da4li4ya4
-(🀂 澳 大 利 亚)	xi1ao4da4li4ya4
 (西 澳 大 利 亞)	xi1ao4da4li4ya4
-(🀂 澳 大 利 亞)	xi1ao4da4li4ya4
 (西 澳 大 利 亞)	xi1ao4da4li4ya4
-(🀂 澳 大 利 亞)	xi1ao4da4li4ya4
 (西 科 尔 斯 基)	xi1ke1er3si1ji1
-(🀂 科 尔 斯 基)	xi1ke1er3si1ji1
 (西 科 爾 斯 基)	xi1ke1er3si1ji1
-(🀂 科 爾 斯 基)	xi1ke1er3si1ji1
 (西 里 爾 字 母)	xi1li3er3zi4mu3
-(🀂 里 爾 字 母)	xi1li3er3zi4mu3
 (西 里 爾 字 母)	xi1li3er3zi4mu3
-(🀂 里 爾 字 母)	xi1li3er3zi4mu3
 (說 不 對 勁 兒)	shuo1bu5dui4jin4r5
 (說 不 對 勁 兒)	shuo1bu5dui4jin4r5
 (說 不 對 勁 兒)	shuo1bu5dui4jin4r5
@@ -84114,10 +77210,8 @@ $textmode
 (贪 多 嚼 不 烂)	tan1duo1jiao2bu5lan4
 (贪 多 嚼 不 烂)	tan1duo1jiao2bu5lan4
 (达 文 西 密 码)	da2wen2xi1mi4ma3
-(达 文 🀂 密 码)	da2wen2xi1mi4ma3
 (追 根 究 底 儿)	zhui1gen1jiu1di3r5
 (達 文 西 密 碼)	da2wen2xi1mi4ma3
-(達 文 🀂 密 碼)	da2wen2xi1mi4ma3
 (那 拉 提 草 原)	na4la1di1cao3yuan2
 (那 拉 提 草 原)	na4la1di1cao3yuan2
 (酸 不 唧 溜 儿)	suan1bu5ji1liu1r5
@@ -84139,17 +77233,13 @@ $textmode
 (阿 什 哈 巴 德)	a1shen2ha1ba1de2
 (阿 什 哈 巴 德)	a1shen2ha1ba1de2
 (阿 尔 瓦 塞 特)	a1er3wa3se4te4
-(阿 尔 瓦 塞 ㊕)	a1er3wa3se4te4
 (阿 尔 瓦 塞 特)	a1er3wa3se4te4
-(阿 尔 瓦 塞 ㊕)	a1er3wa3se4te4
 (阿 布 扎 比 市)	a1bu4zha1bi3shi4
 (阿 布 沙 耶 夫)	a1bu4sha1ye1fu1
 (阿 拉 乾 山 脈)	a1la1gan1shan1mai4
 (阿 拉 乾 山 脈)	a1la1gan1shan1mai4
 (阿 爾 瓦 塞 特)	a1er3wa3se4te4
-(阿 爾 瓦 塞 ㊕)	a1er3wa3se4te4
 (阿 爾 瓦 塞 特)	a1er3wa3se4te4
-(阿 爾 瓦 塞 ㊕)	a1er3wa3se4te4
 (雅 魯 藏 布 江)	ya3lu3zang4bu4jiang1
 (雅 魯 藏 布 江)	ya3lu3zang4bu4jiang1
 (雅 鲁 藏 布 江)	ya3lu3zang4bu4jiang1
@@ -84164,23 +77254,15 @@ $textmode
 (願 意 不 願 意)	yuan4yi5bu2yuan4yi4
 (願 意 不 願 意)	yuan4yi5bu2yuan4yi4
 (風 水 輪 流 轉)	feng1shui3lun2liu2zhuan4
-(風 ㊌ 輪 流 轉)	feng1shui3lun2liu2zhuan4
 (風 水 輪 流 轉)	feng1shui3lun2liu2zhuan4
-(風 ㊌ 輪 流 轉)	feng1shui3lun2liu2zhuan4
 (風 水 輪 流 轉)	feng1shui3lun2liu2zhuan4
-(風 ㊌ 輪 流 轉)	feng1shui3lun2liu2zhuan4
 (風 水 輪 流 轉)	feng1shui3lun2liu2zhuan4
-(風 ㊌ 輪 流 轉)	feng1shui3lun2liu2zhuan4
 (风 水 轮 流 转)	feng1shui3lun2liu2zhuan4
-(风 ㊌ 轮 流 转)	feng1shui3lun2liu2zhuan4
 (风 水 轮 流 转)	feng1shui3lun2liu2zhuan4
-(风 ㊌ 轮 流 转)	feng1shui3lun2liu2zhuan4
 (风 水 轮 流 转)	feng1shui3lun2liu2zhuan4
-(风 ㊌ 轮 流 转)	feng1shui3lun2liu2zhuan4
 (騰 格 裡 沙 漠)	teng2ge2li3sha1mo4
 (騰 格 裡 沙 漠)	teng2ge2li3sha1mo4
 (高 分 子 化 学)	gao1fen4zi3hua4xue2
-(高 分 子 化 ㊫)	gao1fen4zi3hua4xue2
 (高 分 子 化 學)	gao1fen4zi3hua4xue2
 (鳥 疫 衣 原 體)	niao3yi1yi1yuan2ti3
 (鴛 鴦 蝴 蝶 派)	yuan1yang1hu2die2pai4
@@ -84193,198 +77275,88 @@ $textmode
 (黑 塞 哥 维 那)	hei1se4ge1wei2na4
 (黑 塞 哥 维 那)	hei1se4ge1wei2na4
 (一 个 儿 不 个 儿)	yi2ge4r5bu2ge4r5
-(㊀ 个 儿 不 个 儿)	yi2ge4r5bu2ge4r5
 (一 个 儿 不 个 儿)	yi2ge4r5bu2ge4r5
-(㊀ 个 儿 不 个 儿)	yi2ge4r5bu2ge4r5
 (一 举 手 一 投 足)	yi4ju3shou3yi4tou2zu2
-(㊀ 举 手 ㊀ 投 足)	yi4ju3shou3yi4tou2zu2
 (一 亩 三 分 地 儿)	yi4mu3san1fen1di4r5
-(一 亩 ㊂ 分 地 儿)	yi4mu3san1fen1di4r5
-(㊀ 亩 三 分 地 儿)	yi4mu3san1fen1di4r5
 (一 個 兒 不 個 兒)	yi2ge4r5bu2ge4r5
-(㊀ 個 兒 不 個 兒)	yi2ge4r5bu2ge4r5
 (一 個 兒 不 個 兒)	yi2ge4r5bu2ge4r5
-(㊀ 個 兒 不 個 兒)	yi2ge4r5bu2ge4r5
 (一 分 錢 一 分 貨)	yi4fen1qian2yi4fen1huo4
-(㊀ 分 錢 ㊀ 分 貨)	yi4fen1qian2yi4fen1huo4
 (一 分 钱 一 分 货)	yi4fen1qian2yi4fen1huo4
-(㊀ 分 钱 ㊀ 分 货)	yi4fen1qian2yi4fen1huo4
 (一 动 不 如 一 静)	yi2dong4bu4ru2yi2jing4
-(㊀ 动 不 如 ㊀ 静)	yi2dong4bu4ru2yi2jing4
 (一 动 不 如 一 静)	yi2dong4bu4ru2yi2jing4
-(㊀ 动 不 如 ㊀ 静)	yi2dong4bu4ru2yi2jing4
 (一 動 不 如 一 靜)	yi2dong4bu4ru2yi2jing4
-(㊀ 動 不 如 ㊀ 靜)	yi2dong4bu4ru2yi2jing4
 (一 動 不 如 一 靜)	yi2dong4bu4ru2yi2jing4
-(㊀ 動 不 如 ㊀ 靜)	yi2dong4bu4ru2yi2jing4
 (一 发 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
-(㊀ 发 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
 (一 发 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
-(㊀ 发 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
 (一 发 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
-(㊀ 发 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
 (一 客 不 烦 二 主)	yi2ke4bu4fan2er4zhu3
-(㊀ 客 不 烦 二 主)	yi2ke4bu4fan2er4zhu3
-(一 客 不 烦 ㊁ 主)	yi2ke4bu4fan2er4zhu3
 (一 客 不 烦 二 主)	yi2ke4bu4fan2er4zhu3
-(㊀ 客 不 烦 二 主)	yi2ke4bu4fan2er4zhu3
-(一 客 不 烦 ㊁ 主)	yi2ke4bu4fan2er4zhu3
 (一 客 不 煩 二 主)	yi2ke4bu4fan2er4zhu3
-(㊀ 客 不 煩 二 主)	yi2ke4bu4fan2er4zhu3
-(一 客 不 煩 ㊁ 主)	yi2ke4bu4fan2er4zhu3
 (一 客 不 煩 二 主)	yi2ke4bu4fan2er4zhu3
-(㊀ 客 不 煩 二 主)	yi2ke4bu4fan2er4zhu3
-(一 客 不 煩 ㊁ 主)	yi2ke4bu4fan2er4zhu3
 (一 山 难 容 二 虎)	yi4shan1nan2rong2er4hu3
-(㊀ 山 难 容 二 虎)	yi4shan1nan2rong2er4hu3
-(一 山 难 容 ㊁ 虎)	yi4shan1nan2rong2er4hu3
 (一 山 難 容 二 虎)	yi4shan1nan2rong2er4hu3
-(㊀ 山 難 容 二 虎)	yi4shan1nan2rong2er4hu3
-(一 山 難 容 ㊁ 虎)	yi4shan1nan2rong2er4hu3
 (一 山 難 容 二 虎)	yi4shan1nan2rong2er4hu3
-(㊀ 山 難 容 二 虎)	yi4shan1nan2rong2er4hu3
-(一 山 難 容 ㊁ 虎)	yi4shan1nan2rong2er4hu3
 (一 山 難 容 二 虎)	yi4shan1nan2rong2er4hu3
-(㊀ 山 難 容 二 虎)	yi4shan1nan2rong2er4hu3
-(一 山 難 容 ㊁ 虎)	yi4shan1nan2rong2er4hu3
 (一 招 鮮 吃 遍 天)	yi4zhao1xian1chi1bian4tian1
-(㊀ 招 鮮 吃 遍 天)	yi4zhao1xian1chi1bian4tian1
 (一 招 鮮 走 遍 天)	yi4zhao1xian1zou3bian4tian1
-(㊀ 招 鮮 走 遍 天)	yi4zhao1xian1zou3bian4tian1
 (一 招 鲜 吃 遍 天)	yi4zhao1xian1chi1bian4tian1
-(㊀ 招 鲜 吃 遍 天)	yi4zhao1xian1chi1bian4tian1
 (一 招 鲜 走 遍 天)	yi4zhao1xian1zou3bian4tian1
-(㊀ 招 鲜 走 遍 天)	yi4zhao1xian1zou3bian4tian1
 (一 掬 同 情 之 泪)	yi4ju1tong2qing2zhi1lei4
-(㊀ 掬 同 情 之 泪)	yi4ju1tong2qing2zhi1lei4
 (一 掬 同 情 之 淚)	yi4ju1tong2qing2zhi1lei4
-(㊀ 掬 同 情 之 淚)	yi4ju1tong2qing2zhi1lei4
 (一 掬 同 情 之 淚)	yi4ju1tong2qing2zhi1lei4
-(㊀ 掬 同 情 之 淚)	yi4ju1tong2qing2zhi1lei4
 (一 步 一 个 脚 印)	yi2bu4yi2ge4jiao3yin4
-(㊀ 步 ㊀ 个 脚 印)	yi2bu4yi2ge4jiao3yin4
-(一 步 一 个 脚 ㊞)	yi2bu4yi2ge4jiao3yin4
 (一 步 一 個 腳 印)	yi2bu4yi2ge4jiao3yin4
-(㊀ 步 ㊀ 個 腳 印)	yi2bu4yi2ge4jiao3yin4
-(一 步 一 個 腳 ㊞)	yi2bu4yi2ge4jiao3yin4
 (一 死 以 平 民 愤)	yi4si3yi3ping2min2fen4
-(㊀ 死 以 平 民 愤)	yi4si3yi3ping2min2fen4
 (一 死 以 平 民 憤)	yi4si3yi3ping2min2fen4
-(㊀ 死 以 平 民 憤)	yi4si3yi3ping2min2fen4
 (一 点 水 一 个 泡)	yi4dian3shui3yi2ge4pao4
-(一 点 ㊌ 一 个 泡)	yi4dian3shui3yi2ge4pao4
-(㊀ 点 水 ㊀ 个 泡)	yi4dian3shui3yi2ge4pao4
 (一 环 折 全 链 断)	yi4huan2zhe2quan2lian4duan4
-(㊀ 环 折 全 链 断)	yi4huan2zhe2quan2lian4duan4
 (一 环 折 全 链 断)	yi4huan2zhe2quan2lian4duan4
-(㊀ 环 折 全 链 断)	yi4huan2zhe2quan2lian4duan4
 (一 環 折 全 鏈 斷)	yi4huan2zhe2quan2lian4duan4
-(㊀ 環 折 全 鏈 斷)	yi4huan2zhe2quan2lian4duan4
 (一 環 折 全 鏈 斷)	yi4huan2zhe2quan2lian4duan4
-(㊀ 環 折 全 鏈 斷)	yi4huan2zhe2quan2lian4duan4
 (一 畝 三 分 地 兒)	yi4mu3san1fen1di4r5
-(一 畝 ㊂ 分 地 兒)	yi4mu3san1fen1di4r5
-(㊀ 畝 三 分 地 兒)	yi4mu3san1fen1di4r5
 (一 發 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
-(㊀ 發 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
 (一 發 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
-(㊀ 發 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
 (一 發 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
-(㊀ 發 不 可 收 拾)	yi4fa1bu4ke3shou1shi2
 (一 竿 子 插 到 底)	yi4gan1zi5cha1dao4di3
-(㊀ 竿 子 插 到 底)	yi4gan1zi5cha1dao4di3
 (一 罪 不 可 两 治)	yi2zui4bu4ke3liang3zhi4
-(㊀ 罪 不 可 两 治)	yi2zui4bu4ke3liang3zhi4
 (一 罪 不 可 两 治)	yi2zui4bu4ke3liang3zhi4
-(㊀ 罪 不 可 两 治)	yi2zui4bu4ke3liang3zhi4
 (一 罪 不 可 兩 治)	yi2zui4bu4ke3liang3zhi4
-(㊀ 罪 不 可 兩 治)	yi2zui4bu4ke3liang3zhi4
 (一 罪 不 可 兩 治)	yi2zui4bu4ke3liang3zhi4
-(㊀ 罪 不 可 兩 治)	yi2zui4bu4ke3liang3zhi4
 (一 罪 不 可 兩 治)	yi2zui4bu4ke3liang3zhi4
-(㊀ 罪 不 可 兩 治)	yi2zui4bu4ke3liang3zhi4
 (一 肚 子 窝 囊 气)	yi2du4zi5wo1nang2qi4
-(㊀ 肚 子 窝 囊 气)	yi2du4zi5wo1nang2qi4
 (一 肚 子 窩 囊 氣)	yi2du4zi5wo1nang2qi4
-(㊀ 肚 子 窩 囊 氣)	yi2du4zi5wo1nang2qi4
 (一 肚 子 肮 脏 计)	yi2du4zi5ang1zang1ji4
-(㊀ 肚 子 肮 脏 计)	yi2du4zi5ang1zang1ji4
 (一 肚 子 骯 髒 計)	yi2du4zi5ang1zang1ji4
-(㊀ 肚 子 骯 髒 計)	yi2du4zi5ang1zang1ji4
 (一 脑 门 子 官 司)	yi4nao3men2zi5guan1si1
-(㊀ 脑 门 子 官 司)	yi4nao3men2zi5guan1si1
 (一 腦 門 子 官 司)	yi4nao3men2zi5guan1si1
-(㊀ 腦 門 子 官 司)	yi4nao3men2zi5guan1si1
 (一 臣 不 事 二 主)	yi4chen2bu2shi4er4zhu3
-(㊀ 臣 不 事 二 主)	yi4chen2bu2shi4er4zhu3
-(一 臣 不 事 ㊁ 主)	yi4chen2bu2shi4er4zhu3
 (一 臣 不 事 二 主)	yi4chen2bu2shi4er4zhu3
-(㊀ 臣 不 事 二 主)	yi4chen2bu2shi4er4zhu3
-(一 臣 不 事 ㊁ 主)	yi4chen2bu2shi4er4zhu3
 (一 舉 手 一 投 足)	yi4ju3shou3yi4tou2zu2
-(㊀ 舉 手 ㊀ 投 足)	yi4ju3shou3yi4tou2zu2
 (一 蟹 不 如 一 蟹)	yi2xie4bu4ru2yi2xie4
-(㊀ 蟹 不 如 ㊀ 蟹)	yi2xie4bu4ru2yi2xie4
 (一 蟹 不 如 一 蟹)	yi2xie4bu4ru2yi2xie4
-(㊀ 蟹 不 如 ㊀ 蟹)	yi2xie4bu4ru2yi2xie4
 (一 鞭 子 乖 板 子)	yi4bian1zi5guai1ban3zi5
-(㊀ 鞭 子 乖 板 子)	yi4bian1zi5guai1ban3zi5
 (一 馬 不 配 兩 鞍)	yi4ma3bu2pei4liang3an1
-(㊀ 馬 不 配 兩 鞍)	yi4ma3bu2pei4liang3an1
 (一 馬 不 配 兩 鞍)	yi4ma3bu2pei4liang3an1
-(㊀ 馬 不 配 兩 鞍)	yi4ma3bu2pei4liang3an1
 (一 馬 不 配 兩 鞍)	yi4ma3bu2pei4liang3an1
-(㊀ 馬 不 配 兩 鞍)	yi4ma3bu2pei4liang3an1
 (一 马 不 配 两 鞍)	yi4ma3bu2pei4liang3an1
-(㊀ 马 不 配 两 鞍)	yi4ma3bu2pei4liang3an1
 (一 马 不 配 两 鞍)	yi4ma3bu2pei4liang3an1
-(㊀ 马 不 配 两 鞍)	yi4ma3bu2pei4liang3an1
 (一 點 水 一 個 泡)	yi4dian3shui3yi2ge4pao4
-(一 點 ㊌ 一 個 泡)	yi4dian3shui3yi2ge4pao4
-(㊀ 點 水 ㊀ 個 泡)	yi4dian3shui3yi2ge4pao4
 (万 维 天 罗 地 网)	wan4wei2tian1luo2di4wang3
 (不 二 一 添 作 五)	bu2er4yi4tian1zuo4wu3
-(不 二 ㊀ 添 作 五)	bu2er4yi4tian1zuo4wu3
-(不 ㊁ 一 添 作 五)	bu2er4yi4tian1zuo4wu3
-(不 二 一 添 作 ㊄)	bu2er4yi4tian1zuo4wu3
 (不 二 一 添 作 五)	bu2er4yi4tian1zuo4wu3
-(不 二 ㊀ 添 作 五)	bu2er4yi4tian1zuo4wu3
-(不 ㊁ 一 添 作 五)	bu2er4yi4tian1zuo4wu3
-(不 二 一 添 作 ㊄)	bu2er4yi4tian1zuo4wu3
 (不 二 十 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 ㊉ 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 十 ㊃ 節 氣)	bu2er4shi2si4jie2qi4
-(不 ㊁ 十 四 節 氣)	bu2er4shi2si4jie2qi4
 (不 二 十 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 ㊉ 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 十 ㊃ 節 氣)	bu2er4shi2si4jie2qi4
-(不 ㊁ 十 四 節 氣)	bu2er4shi2si4jie2qi4
 (不 二 十 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 ㊉ 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 十 ㊃ 節 氣)	bu2er4shi2si4jie2qi4
-(不 ㊁ 十 四 節 氣)	bu2er4shi2si4jie2qi4
 (不 二 十 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 ㊉ 四 節 氣)	bu2er4shi2si4jie2qi4
-(不 二 十 ㊃ 節 氣)	bu2er4shi2si4jie2qi4
-(不 ㊁ 十 四 節 氣)	bu2er4shi2si4jie2qi4
 (不 二 十 四 节 气)	bu2er4shi2si4jie2qi4
-(不 二 ㊉ 四 节 气)	bu2er4shi2si4jie2qi4
-(不 二 十 ㊃ 节 气)	bu2er4shi2si4jie2qi4
-(不 ㊁ 十 四 节 气)	bu2er4shi2si4jie2qi4
 (不 二 十 四 节 气)	bu2er4shi2si4jie2qi4
-(不 二 ㊉ 四 节 气)	bu2er4shi2si4jie2qi4
-(不 二 十 ㊃ 节 气)	bu2er4shi2si4jie2qi4
-(不 ㊁ 十 四 节 气)	bu2er4shi2si4jie2qi4
 (不 到 那 个 时 候)	bu2dao4na4ge4shi2hou4
 (不 到 那 个 时 候)	bu2dao4na4ge4shi2hou4
 (不 到 那 個 時 候)	bu2dao4na4ge4shi2hou4
 (不 到 那 個 時 候)	bu2dao4na4ge4shi2hou4
 (不 化 学 剂 量 计)	bu2hua4xue2ji4liang4ji4
-(不 化 ㊫ 剂 量 计)	bu2hua4xue2ji4liang4ji4
 (不 化 学 剂 量 计)	bu2hua4xue2ji4liang4ji4
-(不 化 ㊫ 剂 量 计)	bu2hua4xue2ji4liang4ji4
 (不 化 学 剂 量 计)	bu2hua4xue2ji4liang4ji4
-(不 化 ㊫ 剂 量 计)	bu2hua4xue2ji4liang4ji4
 (不 化 學 劑 量 計)	bu2hua4xue2ji4liang4ji4
 (不 化 學 劑 量 計)	bu2hua4xue2ji4liang4ji4
 (不 化 學 劑 量 計)	bu2hua4xue2ji4liang4ji4
@@ -84393,21 +77365,13 @@ $textmode
 (不 地 對 空 導 彈)	bu2di4dui4kong1dao3dan4
 (不 地 對 空 導 彈)	bu2di4dui4kong1dao3dan4
 (不 墨 西 拿 海 峡)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峡)	bu2mo4xi1na2hai3xia2
 (不 墨 西 拿 海 峡)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峡)	bu2mo4xi1na2hai3xia2
 (不 墨 西 拿 海 峡)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峡)	bu2mo4xi1na2hai3xia2
 (不 墨 西 拿 海 峡)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峡)	bu2mo4xi1na2hai3xia2
 (不 墨 西 拿 海 峽)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峽)	bu2mo4xi1na2hai3xia2
 (不 墨 西 拿 海 峽)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峽)	bu2mo4xi1na2hai3xia2
 (不 墨 西 拿 海 峽)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峽)	bu2mo4xi1na2hai3xia2
 (不 墨 西 拿 海 峽)	bu2mo4xi1na2hai3xia2
-(不 墨 🀂 拿 海 峽)	bu2mo4xi1na2hai3xia2
 (不 壽 保 險 公 司)	bu2shou4bao3xian3gong1si1
 (不 壽 保 險 公 司)	bu2shou4bao3xian3gong1si1
 (不 大 洋 型 地 殻)	bu2da4yang2xing1di4qiao4
@@ -84444,36 +77408,14 @@ $textmode
 (不 豆 腐 渣 工 程)	bu2dou4fu3zha1gong1cheng2
 (不 豆 腐 渣 工 程)	bu2dou4fu3zha1gong1cheng2
 (不 費 一 兵 一 卒)	bu2fei4yi4bing1yi4zu2
-(不 費 ㊀ 兵 ㊀ 卒)	bu2fei4yi4bing1yi4zu2
 (不 費 一 兵 一 卒)	bu2fei4yi4bing1yi4zu2
-(不 費 ㊀ 兵 ㊀ 卒)	bu2fei4yi4bing1yi4zu2
 (不 费 一 兵 一 卒)	bu2fei4yi4bing1yi4zu2
-(不 费 ㊀ 兵 ㊀ 卒)	bu2fei4yi4bing1yi4zu2
 (不 费 一 兵 一 卒)	bu2fei4yi4bing1yi4zu2
-(不 费 ㊀ 兵 ㊀ 卒)	bu2fei4yi4bing1yi4zu2
 (不 願 意 不 願 意)	bu2yuan4yi5bu2yuan4yi4
 (不 願 意 不 願 意)	bu2yuan4yi5bu2yuan4yi4
 (东 一 下 西 一 下)	dong1yi2xia4xi1yi2xia4
-(东 一 下 🀂 一 下)	dong1yi2xia4xi1yi2xia4
-(🀀 一 下 西 一 下)	dong1yi2xia4xi1yi2xia4
-(东 一 ㊦ 西 一 ㊦)	dong1yi2xia4xi1yi2xia4
-(东 一 ㊦ 🀂 一 ㊦)	dong1yi2xia4xi1yi2xia4
-(🀀 一 ㊦ 西 一 ㊦)	dong1yi2xia4xi1yi2xia4
-(东 ㊀ 下 西 ㊀ 下)	dong1yi2xia4xi1yi2xia4
-(东 ㊀ 下 🀂 ㊀ 下)	dong1yi2xia4xi1yi2xia4
-(🀀 ㊀ 下 西 ㊀ 下)	dong1yi2xia4xi1yi2xia4
 (东 一 句 西 一 句)	dong1yi2ju4xi1yi2ju4
-(东 一 句 🀂 一 句)	dong1yi2ju4xi1yi2ju4
-(🀀 一 句 西 一 句)	dong1yi2ju4xi1yi2ju4
-(东 ㊀ 句 西 ㊀ 句)	dong1yi2ju4xi1yi2ju4
-(东 ㊀ 句 🀂 ㊀ 句)	dong1yi2ju4xi1yi2ju4
-(🀀 ㊀ 句 西 ㊀ 句)	dong1yi2ju4xi1yi2ju4
 (东 一 句 西 一 句)	dong1yi2ju4xi1yi2ju4
-(东 一 句 🀂 一 句)	dong1yi2ju4xi1yi2ju4
-(🀀 一 句 西 一 句)	dong1yi2ju4xi1yi2ju4
-(东 ㊀ 句 西 ㊀ 句)	dong1yi2ju4xi1yi2ju4
-(东 ㊀ 句 🀂 ㊀ 句)	dong1yi2ju4xi1yi2ju4
-(🀀 ㊀ 句 西 ㊀ 句)	dong1yi2ju4xi1yi2ju4
 (乐 得 心 痒 难 受)	le4de5xin1yang3nan2shou4
 (亚 历 山 大 里 亚)	ya4li4shan1da4li3ya4
 (亚 历 山 大 里 亚)	ya4li4shan1da4li3ya4
@@ -84489,91 +77431,43 @@ $textmode
 (兔 子 驾 不 了 辕)	tu4zi5jia4bu5liao3yuan2
 (兔 子 驾 不 了 辕)	tu4zi5jia4bu5liao3yuan2
 (八 一 南 昌 起 义)	ba1yi4nan2chang1qi3yi4
-(八 一 🀁 昌 起 义)	ba1yi4nan2chang1qi3yi4
-(八 ㊀ 南 昌 起 义)	ba1yi4nan2chang1qi3yi4
-(八 ㊀ 🀁 昌 起 义)	ba1yi4nan2chang1qi3yi4
-(㊇ 一 南 昌 起 义)	ba1yi4nan2chang1qi3yi4
-(㊇ 一 🀁 昌 起 义)	ba1yi4nan2chang1qi3yi4
 (八 一 南 昌 起 義)	ba1yi4nan2chang1qi3yi4
-(八 一 🀁 昌 起 義)	ba1yi4nan2chang1qi3yi4
-(八 ㊀ 南 昌 起 義)	ba1yi4nan2chang1qi3yi4
-(八 ㊀ 🀁 昌 起 義)	ba1yi4nan2chang1qi3yi4
-(㊇ 一 南 昌 起 義)	ba1yi4nan2chang1qi3yi4
-(㊇ 一 🀁 昌 起 義)	ba1yi4nan2chang1qi3yi4
 (八 竿 子 打 不 着)	ba1gan1zi3da3bu5zhao2
-(㊇ 竿 子 打 不 着)	ba1gan1zi3da3bu5zhao2
 (八 竿 子 打 不 着)	ba1gan1zi3da3bu5zhao2
-(㊇ 竿 子 打 不 着)	ba1gan1zi3da3bu5zhao2
 (八 竿 子 打 不 着)	ba1gan1zi3da3bu5zhao2
-(㊇ 竿 子 打 不 着)	ba1gan1zi3da3bu5zhao2
 (八 竿 子 打 不 著)	ba1gan1zi3da3bu5zhao2
-(㊇ 竿 子 打 不 著)	ba1gan1zi3da3bu5zhao2
 (八 竿 子 打 不 著)	ba1gan1zi3da3bu5zhao2
-(㊇ 竿 子 打 不 著)	ba1gan1zi3da3bu5zhao2
 (八 竿 子 打 不 著)	ba1gan1zi3da3bu5zhao2
-(㊇ 竿 子 打 不 著)	ba1gan1zi3da3bu5zhao2
 (出 一 磅 子 力 气)	chu1yi2bang4zi5li4qi5
-(出 ㊀ 磅 子 力 气)	chu1yi2bang4zi5li4qi5
 (出 一 磅 子 力 气)	chu1yi2bang4zi5li4qi5
-(出 ㊀ 磅 子 力 气)	chu1yi2bang4zi5li4qi5
 (出 一 磅 子 力 氣)	chu1yi2bang4zi5li4qi5
-(出 ㊀ 磅 子 力 氣)	chu1yi2bang4zi5li4qi5
 (出 一 磅 子 力 氣)	chu1yi2bang4zi5li4qi5
-(出 ㊀ 磅 子 力 氣)	chu1yi2bang4zi5li4qi5
 (十 賒 不 如 一 現)	shi2she1bu4ru2yi2xian4
-(㊉ 賒 不 如 一 現)	shi2she1bu4ru2yi2xian4
-(十 賒 不 如 ㊀ 現)	shi2she1bu4ru2yi2xian4
 (十 賒 不 如 一 現)	shi2she1bu4ru2yi2xian4
-(㊉ 賒 不 如 一 現)	shi2she1bu4ru2yi2xian4
-(十 賒 不 如 ㊀ 現)	shi2she1bu4ru2yi2xian4
 (十 赊 不 如 一 现)	shi2she1bu4ru2yi2xian4
-(㊉ 赊 不 如 一 现)	shi2she1bu4ru2yi2xian4
-(十 赊 不 如 ㊀ 现)	shi2she1bu4ru2yi2xian4
 (十 赊 不 如 一 现)	shi2she1bu4ru2yi2xian4
-(㊉ 赊 不 如 一 现)	shi2she1bu4ru2yi2xian4
-(十 赊 不 如 ㊀ 现)	shi2she1bu4ru2yi2xian4
 (千 金 难 买 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 ㊎ 难 买 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 金 难 买 ㊀ 笑)	qian1jin1nan2mai3yi2xiao4
 (千 金 难 买 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 金 难 买 ㊀ 笑)	qian1jin1nan2mai3yi2xiao4
 (千 金 難 買 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 ㊎ 難 買 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 金 難 買 ㊀ 笑)	qian1jin1nan2mai3yi2xiao4
 (千 金 難 買 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 金 難 買 ㊀ 笑)	qian1jin1nan2mai3yi2xiao4
 (千 金 難 買 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 ㊎ 難 買 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 金 難 買 ㊀ 笑)	qian1jin1nan2mai3yi2xiao4
 (千 金 難 買 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 ㊎ 難 買 一 笑)	qian1jin1nan2mai3yi2xiao4
-(千 金 難 買 ㊀ 笑)	qian1jin1nan2mai3yi2xiao4
 (华 纳 音 乐 集 团)	hua4na4yin1yue4ji2tuan2
 (卡 拉 什 尼 科 夫)	ka3la1shi2ni2ke1fu1
 (卡 拉 什 尼 科 夫)	ka3la1shi2ni2ke1fu1
 (卡 拉 什 尼 科 夫)	ka3la1shi2ni2ke1fu1
 (卡 波 西 氏 肉 瘤)	ka3bo1xi1shi4rou4liu2
-(卡 波 🀂 氏 肉 瘤)	ka3bo1xi1shi4rou4liu2
 (可 一 而 不 可 再)	ke3yi4er2bu4ke3zai4
-(可 ㊀ 而 不 可 再)	ke3yi4er2bu4ke3zai4
 (可 一 而 不 可 再)	ke3yi4er2bu4ke3zai4
-(可 ㊀ 而 不 可 再)	ke3yi4er2bu4ke3zai4
 (吃 一 堑 长 一 智)	chi1yi2qian4zhang3yi2zhi4
-(吃 ㊀ 堑 长 ㊀ 智)	chi1yi2qian4zhang3yi2zhi4
 (吃 一 塹 長 一 智)	chi1yi2qian4zhang3yi2zhi4
-(吃 ㊀ 塹 長 ㊀ 智)	chi1yi2qian4zhang3yi2zhi4
 (咕 啾 在 一 块 儿)	gu1jiu5zai4yi2kuai4r5
-(咕 啾 在 ㊀ 块 儿)	gu1jiu5zai4yi2kuai4r5
 (哈 裡 森 史 密 特)	ha1li3sen1shi3mi4te4
-(哈 裡 森 史 密 ㊕)	ha1li3sen1shi3mi4te4
 (哈 裡 森 史 密 特)	ha1li3sen1shi3mi4te4
-(哈 裡 森 史 密 ㊕)	ha1li3sen1shi3mi4te4
 (唵 嘛 呢 叭 咪 哞)	an3ma5ni2ba1mi1mou1
 (唵 嘛 咪 叭 呢 哞)	an3ma5mi1ba5ni2mou1
 (喀 拉 喀 托 火 山)	ke4la1ke4tuo1huo3shan1
-(喀 拉 喀 托 ㊋ 山)	ke4la1ke4tuo1huo3shan1
 (喀 拉 喀 托 火 山)	ke4la1ke4tuo1huo3shan1
-(喀 拉 喀 托 ㊋ 山)	ke4la1ke4tuo1huo3shan1
 (团 结 就 是 力 量)	tuan2jie2jiu4shi4li4liang4
 (团 结 就 是 力 量)	tuan2jie2jiu4shi4li4liang4
 (团 结 就 是 力 量)	tuan2jie2jiu4shi4li4liang4
@@ -84585,31 +77479,20 @@ $textmode
 (地 方 民 族 主 义)	di4fang1min2zu2zhu3yi4
 (地 方 民 族 主 義)	di4fang1min2zu2zhu3yi4
 (天 一 句 地 一 句)	tian1yi2ju4di4yi2ju4
-(天 ㊀ 句 地 ㊀ 句)	tian1yi2ju4di4yi2ju4
 (天 一 句 地 一 句)	tian1yi2ju4di4yi2ju4
-(天 ㊀ 句 地 ㊀ 句)	tian1yi2ju4di4yi2ju4
 (寄 予 很 大 期 望)	ji4yu2hen3da4qi1wang4
 (寄 予 很 大 期 望)	ji4yu2hen3da4qi1wang4
 (封 上 一 官 半 职)	feng1shang5yi4guan1ban4zhi2
-(封 ㊤ 一 官 半 职)	feng1shang5yi4guan1ban4zhi2
-(封 上 ㊀ 官 半 职)	feng1shang5yi4guan1ban4zhi2
 (封 上 一 官 半 職)	feng1shang5yi4guan1ban4zhi2
-(封 ㊤ 一 官 半 職)	feng1shang5yi4guan1ban4zhi2
-(封 上 ㊀ 官 半 職)	feng1shang5yi4guan1ban4zhi2
 (巴 尔 舍 夫 斯 基)	ba1er3she3fu1si1ji1
 (巴 爾 舍 夫 斯 基)	ba1er3she3fu1si1ji1
 (巴 音 布 克 草 原)	ba1yin1bu4ke4cao3yuan2
 (弄 得 大 伙 一 楞)	nong4de5da4huo3yi2leng4
-(弄 得 大 伙 ㊀ 楞)	nong4de5da4huo3yi2leng4
 (弄 得 大 伙 一 楞)	nong4de5da4huo3yi2leng4
-(弄 得 大 伙 ㊀ 楞)	nong4de5da4huo3yi2leng4
 (您 是 不 是 要 查)	nin2shi4bu2shi4yao1cha2
 (您 是 不 是 要 查)	nin2shi4bu2shi4yao1cha2
 (拆 东 墙 补 西 墙)	chai1dong1qiang2bu3xi1qiang2
-(拆 东 墙 补 🀂 墙)	chai1dong1qiang2bu3xi1qiang2
-(拆 🀀 墙 补 西 墙)	chai1dong1qiang2bu3xi1qiang2
 (拆 東 牆 補 西 牆)	chai1dong1qiang2bu3xi1qiang2
-(拆 東 牆 補 🀂 牆)	chai1dong1qiang2bu3xi1qiang2
 (拉 赫 曼 尼 諾 夫)	la1he4man4ni2nuo4fu1
 (拉 赫 曼 尼 諾 夫)	la1he4man4ni2nuo4fu1
 (拉 赫 曼 尼 諾 夫)	la1he4man4ni2nuo4fu1
@@ -84639,30 +77522,15 @@ $textmode
 (新 喀 裡 多 尼 亞)	xin1ka1li3duo1ni2ya4
 (新 喀 裡 多 尼 亞)	xin1ka1li3duo1ni2ya4
 (有 一 哈 无 一 哈)	you3yi4ha1wu2yi4ha1
-(有 ㊀ 哈 无 ㊀ 哈)	you3yi4ha1wu2yi4ha1
-(㊒ 一 哈 无 一 哈)	you3yi4ha1wu2yi4ha1
 (有 一 哈 無 一 哈)	you3yi4ha1wu2yi4ha1
-(有 ㊀ 哈 無 ㊀ 哈)	you3yi4ha1wu2yi4ha1
-(㊒ 一 哈 無 一 哈)	you3yi4ha1wu2yi4ha1
 (杜 布 罗 夫 尼 克)	du4bu4luo2fu1ni2ke4
 (杜 布 羅 夫 尼 克)	du4bu4luo2fu1ni2ke4
 (杜 布 羅 夫 尼 克)	du4bu4luo2fu1ni2ke4
 (杭 丁 頓 舞 蹈 癥)	hang2ding1dun4wu3dao4zheng4
 (杭 丁 顿 舞 蹈 症)	hang2ding1dun4wu3dao4zheng4
 (東 一 下 西 一 下)	dong1yi2xia4xi1yi2xia4
-(東 一 下 🀂 一 下)	dong1yi2xia4xi1yi2xia4
-(東 一 ㊦ 西 一 ㊦)	dong1yi2xia4xi1yi2xia4
-(東 一 ㊦ 🀂 一 ㊦)	dong1yi2xia4xi1yi2xia4
-(東 ㊀ 下 西 ㊀ 下)	dong1yi2xia4xi1yi2xia4
-(東 ㊀ 下 🀂 ㊀ 下)	dong1yi2xia4xi1yi2xia4
 (東 一 句 西 一 句)	dong1yi2ju4xi1yi2ju4
-(東 一 句 🀂 一 句)	dong1yi2ju4xi1yi2ju4
-(東 ㊀ 句 西 ㊀ 句)	dong1yi2ju4xi1yi2ju4
-(東 ㊀ 句 🀂 ㊀ 句)	dong1yi2ju4xi1yi2ju4
 (東 一 句 西 一 句)	dong1yi2ju4xi1yi2ju4
-(東 一 句 🀂 一 句)	dong1yi2ju4xi1yi2ju4
-(東 ㊀ 句 西 ㊀ 句)	dong1yi2ju4xi1yi2ju4
-(東 ㊀ 句 🀂 ㊀ 句)	dong1yi2ju4xi1yi2ju4
 (樂 得 心 癢 難 受)	le4de5xin1yang3nan2shou4
 (樂 得 心 癢 難 受)	le4de5xin1yang3nan2shou4
 (樂 得 心 癢 難 受)	le4de5xin1yang3nan2shou4
@@ -84672,7 +77540,6 @@ $textmode
 (母 子 垂 直 感 染)	mu3zi3chui2zhi2gan3ran3
 (母 子 垂 直 感 染)	mu3zi3chui2zhi2gan3ran3
 (毕 其 功 于 一 役)	bi4qi2gong1yu2yi2yi4
-(毕 其 功 于 ㊀ 役)	bi4qi2gong1yu2yi2yi4
 (沙 利 科 什 維 利)	sha1li4ke1shi2wei2li4
 (沙 利 科 什 維 利)	sha1li4ke1shi2wei2li4
 (沙 利 科 什 維 利)	sha1li4ke1shi2wei2li4
@@ -84680,29 +77547,15 @@ $textmode
 (沙 利 科 什 维 利)	sha1li4ke1shi2wei2li4
 (沙 利 科 什 维 利)	sha1li4ke1shi2wei2li4
 (無 求 備 於 一 人)	wu2qiu2bei4yu2yi4ren2
-(無 求 備 於 ㊀ 人)	wu2qiu2bei4yu2yi4ren2
 (特 古 西 加 尔 巴)	te4gu3xi1jia1er3ba1
-(特 古 🀂 加 尔 巴)	te4gu3xi1jia1er3ba1
-(㊕ 古 西 加 尔 巴)	te4gu3xi1jia1er3ba1
-(㊕ 古 🀂 加 尔 巴)	te4gu3xi1jia1er3ba1
 (特 古 西 加 爾 巴)	te4gu3xi1jia1er3ba1
-(特 古 🀂 加 爾 巴)	te4gu3xi1jia1er3ba1
-(㊕ 古 西 加 爾 巴)	te4gu3xi1jia1er3ba1
-(㊕ 古 🀂 加 爾 巴)	te4gu3xi1jia1er3ba1
 (畢 其 功 於 一 役)	bi4qi2gong1yu2yi2yi4
-(畢 其 功 於 ㊀ 役)	bi4qi2gong1yu2yi2yi4
 (百 聞 不 如 一 見)	bai3wen2bu4ru2yi2jian4
-(百 聞 不 如 ㊀ 見)	bai3wen2bu4ru2yi2jian4
 (百 聞 不 如 一 見)	bai3wen2bu4ru2yi2jian4
-(百 聞 不 如 ㊀ 見)	bai3wen2bu4ru2yi2jian4
 (百 聞 不 如 一 見)	bai3wen2bu4ru2yi2jian4
-(百 聞 不 如 ㊀ 見)	bai3wen2bu4ru2yi2jian4
 (百 闻 不 如 一 见)	bai3wen2bu4ru2yi2jian4
-(百 闻 不 如 ㊀ 见)	bai3wen2bu4ru2yi2jian4
 (百 闻 不 如 一 见)	bai3wen2bu4ru2yi2jian4
-(百 闻 不 如 ㊀ 见)	bai3wen2bu4ru2yi2jian4
 (盐 酸 克 仑 特 罗)	yan2suan1ke4lun2te4luo1
-(盐 酸 克 仑 ㊕ 罗)	yan2suan1ke4lun2te4luo1
 (目 前 还 不 清 楚)	mu4qian2hai2bu4qing1chu3
 (目 前 还 不 清 楚)	mu4qian2hai2bu4qing1chu3
 (目 前 還 不 清 楚)	mu4qian2hai2bu4qing1chu3
@@ -84717,34 +77570,23 @@ $textmode
 (矮 子 里 拔 将 军)	ai3zi5li5ba2jiang1jun1
 (矮 子 里 拔 将 军)	ai3zi5li5ba2jiang1jun1
 (破 题 儿 第 一 遭)	po4ti2r5di4yi1zao1
-(破 题 儿 第 ㊀ 遭)	po4ti2r5di4yi1zao1
 (笛 卡 儿 座 标 制)	di2ka3er2zuo4biao1zhi4
 (笛 卡 兒 座 標 制)	di2ka3er2zuo4biao1zhi4
 (紅 了 一 個 時 期)	hong2le5yi2ge4shi2qi1
-(紅 了 ㊀ 個 時 期)	hong2le5yi2ge4shi2qi1
 (紅 了 一 個 時 期)	hong2le5yi2ge4shi2qi1
-(紅 了 ㊀ 個 時 期)	hong2le5yi2ge4shi2qi1
 (納 扎 爾 巴 耶 夫)	na4zha1er3ba1ye1fu1
 (編 派 一 套 瞎 話)	bian1pai5yi2tao4xia1hua4
-(編 派 ㊀ 套 瞎 話)	bian1pai5yi2tao4xia1hua4
 (红 了 一 个 时 期)	hong2le5yi2ge4shi2qi1
-(红 了 ㊀ 个 时 期)	hong2le5yi2ge4shi2qi1
 (红 了 一 个 时 期)	hong2le5yi2ge4shi2qi1
-(红 了 ㊀ 个 时 期)	hong2le5yi2ge4shi2qi1
 (纳 扎 尔 巴 耶 夫)	na4zha1er3ba1ye1fu1
 (编 派 一 套 瞎 话)	bian1pai5yi2tao4xia1hua4
-(编 派 ㊀ 套 瞎 话)	bian1pai5yi2tao4xia1hua4
 (罗 巴 切 夫 斯 基)	luo2ba1qie4fu1si1ji1
 (罗 巴 切 夫 斯 基)	luo2ba1qie4fu1si1ji1
 (羅 巴 切 夫 斯 基)	luo2ba1qie4fu1si1ji1
 (羅 巴 切 夫 斯 基)	luo2ba1qie4fu1si1ji1
 (羅 巴 切 夫 斯 基)	luo2ba1qie4fu1si1ji1
 (老 子 天 下 第 一)	lao3zi5tian1xia4di4yi1
-(老 子 天 ㊦ 第 一)	lao3zi5tian1xia4di4yi1
-(老 子 天 下 第 ㊀)	lao3zi5tian1xia4di4yi1
 (老 子 天 下 第 一)	lao3zi5tian1xia4di4yi1
-(老 子 天 ㊦ 第 一)	lao3zi5tian1xia4di4yi1
-(老 子 天 下 第 ㊀)	lao3zi5tian1xia4di4yi1
 (老 年 性 痴 獃 症)	lao3nian2xing4chi1dai1zheng4
 (老 年 性 痴 獃 症)	lao3nian2xing4chi1dai1zheng4
 (老 年 性 痴 獃 症)	lao3nian2xing4chi1dai1zheng4
@@ -84763,9 +77605,7 @@ $textmode
 (萬 維 天 羅 地 網)	wan4wei2tian1luo2di4wang3
 (薩 達 姆 侯 賽 因)	sa4da2mu3hou4sai4yin1
 (西 乌 珠 穆 沁 旗)	xi1wu1zhu1mu4qin4qi2
-(🀂 乌 珠 穆 沁 旗)	xi1wu1zhu1mu4qin4qi2
 (西 烏 珠 穆 沁 旗)	xi1wu1zhu1mu4qin4qi2
-(🀂 烏 珠 穆 沁 旗)	xi1wu1zhu1mu4qin4qi2
 (角 色 扮 演 遊 戏)	jue2se4ban4yan3you2xi4
 (角 色 扮 演 遊 戲)	jue2se4ban4yan3you2xi4
 (訊 息 處 理 系 統)	xun4xi1chu4li3xi4tong3
@@ -84779,14 +77619,11 @@ $textmode
 (说 不 清 道 不 明)	shuo1bu5qing1dao4bu5ming2
 (说 不 清 道 不 明)	shuo1bu5qing1dao4bu5ming2
 (貝 婭 特 麗 克 絲)	bei4ya4te4li2ke4si1
-(貝 婭 ㊕ 麗 克 絲)	bei4ya4te4li2ke4si1
 (貝 婭 特 麗 克 絲)	bei4ya4te4li2ke4si1
-(貝 婭 ㊕ 麗 克 絲)	bei4ya4te4li2ke4si1
 (貧 無 立 錐 之 地)	pin2wu2li4zhui1zhi1di4
 (貧 無 立 錐 之 地)	pin2wu2li4zhui1zhi1di4
 (費 爾 干 納 槃 地)	fei4er3gan4na4pan2di4
 (贝 娅 特 丽 克 丝)	bei4ya4te4li2ke4si1
-(贝 娅 ㊕ 丽 克 丝)	bei4ya4te4li2ke4si1
 (贫 无 立 锥 之 地)	pin2wu2li4zhui1zhi1di4
 (贫 无 立 锥 之 地)	pin2wu2li4zhui1zhi1di4
 (费 尔 干 纳 槃 地)	fei4er3gan4na4pan2di4
@@ -84802,142 +77639,62 @@ $textmode
 (里 瓦 幾 亞 條 約)	li3wa3ji1ya4tiao2yue1
 (里 瓦 幾 亞 條 約)	li3wa3ji1ya4tiao2yue1
 (非 洲 統 一 組 織)	fei1zhou1tong3yi4zu3zhi1
-(非 洲 統 ㊀ 組 織)	fei1zhou1tong3yi4zu3zhi1
 (非 洲 统 一 组 织)	fei1zhou1tong3yi4zu3zhi1
-(非 洲 统 ㊀ 组 织)	fei1zhou1tong3yi4zu3zhi1
 (馬 斯 特 裡 赫 特)	ma3si1te4li3he4te4
-(馬 斯 ㊕ 裡 赫 ㊕)	ma3si1te4li3he4te4
 (馬 斯 特 裡 赫 特)	ma3si1te4li3he4te4
-(馬 斯 ㊕ 裡 赫 ㊕)	ma3si1te4li3he4te4
 (一 人 难 称 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
-(㊀ 人 难 称 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
 (一 人 難 稱 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
-(㊀ 人 難 稱 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
 (一 人 難 稱 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
-(㊀ 人 難 稱 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
 (一 人 難 稱 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
-(㊀ 人 難 稱 百 人 意)	yi4ren2nan2chen4bai3ren2yi4
 (一 分 价 钱 一 分 货)	yi4fen1jia4qian2yi4fen1huo4
-(㊀ 分 价 钱 ㊀ 分 货)	yi4fen1jia4qian2yi4fen1huo4
 (一 分 價 錢 一 分 貨)	yi4fen1jia4qian2yi4fen1huo4
-(㊀ 分 價 錢 ㊀ 分 貨)	yi4fen1jia4qian2yi4fen1huo4
 (一 夜 夫 妻 百 夜 恩)	yi2ye4fu1qi1bai3ye4en1
-(一 ㊰ 夫 妻 百 ㊰ 恩)	yi2ye4fu1qi1bai3ye4en1
-(㊀ 夜 夫 妻 百 夜 恩)	yi2ye4fu1qi1bai3ye4en1
 (一 失 足 成 千 古 恨)	yi4shi1zu2cheng2qian1gu3hen4
-(㊀ 失 足 成 千 古 恨)	yi4shi1zu2cheng2qian1gu3hen4
 (一 寸 光 阴 一 寸 金)	yi2cun4guang1yin1yi2cun4jin1
-(一 寸 光 阴 一 寸 ㊎)	yi2cun4guang1yin1yi2cun4jin1
-(㊀ 寸 光 阴 ㊀ 寸 金)	yi2cun4guang1yin1yi2cun4jin1
 (一 寸 光 阴 一 寸 金)	yi2cun4guang1yin1yi2cun4jin1
-(㊀ 寸 光 阴 ㊀ 寸 金)	yi2cun4guang1yin1yi2cun4jin1
 (一 寸 光 陰 一 寸 金)	yi2cun4guang1yin1yi2cun4jin1
-(一 寸 光 陰 一 寸 ㊎)	yi2cun4guang1yin1yi2cun4jin1
-(㊀ 寸 光 陰 ㊀ 寸 金)	yi2cun4guang1yin1yi2cun4jin1
 (一 寸 光 陰 一 寸 金)	yi2cun4guang1yin1yi2cun4jin1
-(㊀ 寸 光 陰 ㊀ 寸 金)	yi2cun4guang1yin1yi2cun4jin1
 (一 将 功 成 万 骨 枯)	yi2jiang4gong1cheng2wan4gu3ku1
-(㊀ 将 功 成 万 骨 枯)	yi2jiang4gong1cheng2wan4gu3ku1
 (一 將 功 成 萬 骨 枯)	yi2jiang4gong1cheng2wan4gu3ku1
-(㊀ 將 功 成 萬 骨 枯)	yi2jiang4gong1cheng2wan4gu3ku1
 (一 日 之 計 在 於 晨)	yi2ri4zhi1ji4zai4yu2chen2
-(㊀ 日 之 計 在 於 晨)	yi2ri4zhi1ji4zai4yu2chen2
-(一 ㊐ 之 計 在 於 晨)	yi2ri4zhi1ji4zai4yu2chen2
 (一 日 之 计 在 于 晨)	yi2ri4zhi1ji4zai4yu2chen2
-(㊀ 日 之 计 在 于 晨)	yi2ri4zhi1ji4zai4yu2chen2
-(一 ㊐ 之 计 在 于 晨)	yi2ri4zhi1ji4zai4yu2chen2
 (一 日 夫 妻 百 日 恩)	yi2ri4fu1qi1bai3ri4en1
-(㊀ 日 夫 妻 百 日 恩)	yi2ri4fu1qi1bai3ri4en1
-(一 ㊐ 夫 妻 百 ㊐ 恩)	yi2ri4fu1qi1bai3ri4en1
 (一 日 官 司 十 日 打)	yi2ri4guan1si5shi2ri4da3
-(一 日 官 司 ㊉ 日 打)	yi2ri4guan1si5shi2ri4da3
-(㊀ 日 官 司 十 日 打)	yi2ri4guan1si5shi2ri4da3
-(一 ㊐ 官 司 十 ㊐ 打)	yi2ri4guan1si5shi2ri4da3
 (一 朝 天 子 一 朝 臣)	yi4chao2tian1zi3yi4chao2chen2
-(㊀ 朝 天 子 ㊀ 朝 臣)	yi4chao2tian1zi3yi4chao2chen2
 (一 条 道 儿 跑 到 黑)	yi4tiao2dao4r5pao3dao4hei1
-(㊀ 条 道 儿 跑 到 黑)	yi4tiao2dao4r5pao3dao4hei1
 (一 树 梨 花 压 海 棠)	yi2shu4li2hua1ya1hai3tang2
-(㊀ 树 梨 花 压 海 棠)	yi2shu4li2hua1ya1hai3tang2
 (一 树 梨 花 压 海 棠)	yi2shu4li2hua1ya1hai3tang2
-(㊀ 树 梨 花 压 海 棠)	yi2shu4li2hua1ya1hai3tang2
 (一 树 梨 花 压 海 棠)	yi2shu4li2hua1ya1hai3tang2
-(㊀ 树 梨 花 压 海 棠)	yi2shu4li2hua1ya1hai3tang2
 (一 樹 梨 花 壓 海 棠)	yi2shu4li2hua1ya1hai3tang2
-(㊀ 樹 梨 花 壓 海 棠)	yi2shu4li2hua1ya1hai3tang2
 (一 樹 梨 花 壓 海 棠)	yi2shu4li2hua1ya1hai3tang2
-(㊀ 樹 梨 花 壓 海 棠)	yi2shu4li2hua1ya1hai3tang2
 (一 樹 梨 花 壓 海 棠)	yi2shu4li2hua1ya1hai3tang2
-(㊀ 樹 梨 花 壓 海 棠)	yi2shu4li2hua1ya1hai3tang2
 (一 步 一 个 脚 印 儿)	yi2bu4yi2ge4jiao3yin4r5
-(㊀ 步 ㊀ 个 脚 印 儿)	yi2bu4yi2ge4jiao3yin4r5
-(一 步 一 个 脚 ㊞ 儿)	yi2bu4yi2ge4jiao3yin4r5
 (一 江 春 水 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 水 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
 (一 江 春 水 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 水 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
 (一 江 春 水 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 水 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 东 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 🀀 流)	yi4jiang1chun1shui3xiang4dong1liu2
 (一 江 春 水 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
 (一 江 春 水 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
 (一 江 春 水 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(一 江 春 ㊌ 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
-(㊀ 江 春 水 向 東 流)	yi4jiang1chun1shui3xiang4dong1liu2
 (不 可 一 日 无 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 ㊀ 日 无 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 一 ㊐ 无 此 君)	bu4ke3yi2ri4wu2ci3jun1
 (不 可 一 日 无 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 ㊀ 日 无 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 一 ㊐ 无 此 君)	bu4ke3yi2ri4wu2ci3jun1
 (不 可 一 日 無 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 ㊀ 日 無 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 一 ㊐ 無 此 君)	bu4ke3yi2ri4wu2ci3jun1
 (不 可 一 日 無 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 ㊀ 日 無 此 君)	bu4ke3yi2ri4wu2ci3jun1
-(不 可 一 ㊐ 無 此 君)	bu4ke3yi2ri4wu2ci3jun1
 (不 定 治 了 治 不 了)	bu2ding4zhi4liao3zhi4bu5liao3
 (不 定 治 了 治 不 了)	bu2ding4zhi4liao3zhi4bu5liao3
 (不 定 治 了 治 不 了)	bu2ding4zhi4liao3zhi4bu5liao3
 (不 消 一 会 儿 工 夫)	bu4xiao1yi2hui4r5gong1fu5
-(不 消 ㊀ 会 儿 工 夫)	bu4xiao1yi2hui4r5gong1fu5
 (不 消 一 会 儿 工 夫)	bu4xiao1yi2hui4r5gong1fu5
-(不 消 ㊀ 会 儿 工 夫)	bu4xiao1yi2hui4r5gong1fu5
 (不 消 一 會 兒 工 夫)	bu4xiao1yi2hui4r5gong1fu5
-(不 消 ㊀ 會 兒 工 夫)	bu4xiao1yi2hui4r5gong1fu5
 (不 消 一 會 兒 工 夫)	bu4xiao1yi2hui4r5gong1fu5
-(不 消 ㊀ 會 兒 工 夫)	bu4xiao1yi2hui4r5gong1fu5
 (世 界 文 化 遗 产 地)	shi4jie4wen2hua4yi2chan3di4
 (世 界 文 化 遺 產 地)	shi4jie4wen2hua4yi2chan3di4
 (两 个 或 两 个 以 上)	liang3ge4huo4liang3ge4yi3shang4
-(两 个 或 两 个 以 ㊤)	liang3ge4huo4liang3ge4yi3shang4
 (串 行 点 阵 打 印 机)	chuan4xing2dian3zhen4da3yin4ji1
-(串 行 点 阵 打 ㊞ 机)	chuan4xing2dian3zhen4da3yin4ji1
 (串 行 点 阵 打 印 机)	chuan4xing2dian3zhen4da3yin4ji1
-(串 行 点 阵 打 ㊞ 机)	chuan4xing2dian3zhen4da3yin4ji1
 (串 行 点 阵 打 印 机)	chuan4xing2dian3zhen4da3yin4ji1
-(串 行 点 阵 打 ㊞ 机)	chuan4xing2dian3zhen4da3yin4ji1
 (串 行 點 陣 打 印 機)	chuan4xing2dian3zhen4da3yin4ji1
-(串 行 點 陣 打 ㊞ 機)	chuan4xing2dian3zhen4da3yin4ji1
 (串 行 點 陣 打 印 機)	chuan4xing2dian3zhen4da3yin4ji1
-(串 行 點 陣 打 ㊞ 機)	chuan4xing2dian3zhen4da3yin4ji1
 (串 行 點 陣 打 印 機)	chuan4xing2dian3zhen4da3yin4ji1
-(串 行 點 陣 打 ㊞ 機)	chuan4xing2dian3zhen4da3yin4ji1
 (偷 雞 不 著 蝕 把 米)	tou1ji1bu4zhao2shi2ba3mi3
 (偷 雞 不 著 蝕 把 米)	tou1ji1bu4zhao2shi2ba3mi3
 (偷 雞 不 著 蝕 把 米)	tou1ji1bu4zhao2shi2ba3mi3
@@ -84947,27 +77704,13 @@ $textmode
 (先 到 灶 头 先 得 食)	xian1dao4zao4tou5xian1de2shi2
 (先 到 灶 頭 先 得 食)	xian1dao4zao4tou5xian1de2shi2
 (八 一 电 影 制 片 厂)	ba1yi2dian4ying3zhi4pian4chang3
-(八 ㊀ 电 影 制 片 厂)	ba1yi2dian4ying3zhi4pian4chang3
-(㊇ 一 电 影 制 片 厂)	ba1yi2dian4ying3zhi4pian4chang3
 (八 一 電 影 制 片 廠)	ba1yi2dian4ying3zhi4pian4chang3
-(八 ㊀ 電 影 制 片 廠)	ba1yi2dian4ying3zhi4pian4chang3
-(㊇ 一 電 影 制 片 廠)	ba1yi2dian4ying3zhi4pian4chang3
 (六 一 国 际 儿 童 节)	liu4yi4guo2ji4er2tong2jie2
-(六 ㊀ 国 际 儿 童 节)	liu4yi4guo2ji4er2tong2jie2
-(㊅ 一 国 际 儿 童 节)	liu4yi4guo2ji4er2tong2jie2
 (六 一 国 际 儿 童 节)	liu4yi4guo2ji4er2tong2jie2
-(六 ㊀ 国 际 儿 童 节)	liu4yi4guo2ji4er2tong2jie2
 (六 一 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
-(六 ㊀ 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
-(㊅ 一 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
 (六 一 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
-(六 ㊀ 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
 (六 一 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
-(六 ㊀ 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
-(㊅ 一 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
 (六 一 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
-(六 ㊀ 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
-(㊅ 一 國 際 兒 童 節)	liu4yi4guo2ji4er2tong2jie2
 (千 里 达 和 多 巴 哥)	qian1li3da2he2duo1ba1ge1
 (千 里 达 和 多 巴 哥)	qian1li3da2he2duo1ba1ge1
 (千 里 達 和 多 巴 哥)	qian1li3da2he2duo1ba1ge1
@@ -84984,7 +77727,6 @@ $textmode
 (咬 人 狗 兒 不 露 齒)	yao3ren2gou3r5bu2lu4chi3
 (咬 人 狗 兒 不 露 齒)	yao3ren2gou3r5bu2lu4chi3
 (唬 得 一 愣 一 愣 的)	hu3de5yi2leng4yi2leng4de5
-(唬 得 ㊀ 愣 ㊀ 愣 的)	hu3de5yi2leng4yi2leng4de5
 (基 裡 巴 斯 共 和 國)	ji1li3ba1si1gong4he2guo2
 (基 裡 巴 斯 共 和 國)	ji1li3ba1si1gong4he2guo2
 (塔 克 拉 玛 干 沙 漠)	ta3ke4la1ma3gan1sha1mo4
@@ -84992,26 +77734,16 @@ $textmode
 (塔 克 拉 瑪 干 沙 漠)	ta3ke4la1ma3gan1sha1mo4
 (塔 克 拉 瑪 干 沙 漠)	ta3ke4la1ma3gan1sha1mo4
 (天 下 文 章 一 大 抄)	tian1xia4wen2zhang1yi2da4chao1
-(天 ㊦ 文 章 一 大 抄)	tian1xia4wen2zhang1yi2da4chao1
-(天 下 文 章 ㊀ 大 抄)	tian1xia4wen2zhang1yi2da4chao1
 (学 百 艺 而 无 一 精)	xue2bai3yi4er2wu2yi4jing1
-(㊫ 百 艺 而 无 一 精)	xue2bai3yi4er2wu2yi4jing1
-(学 百 艺 而 无 ㊀ 精)	xue2bai3yi4er2wu2yi4jing1
 (学 百 艺 而 无 一 精)	xue2bai3yi4er2wu2yi4jing1
-(㊫ 百 艺 而 无 一 精)	xue2bai3yi4er2wu2yi4jing1
-(学 百 艺 而 无 ㊀ 精)	xue2bai3yi4er2wu2yi4jing1
 (學 百 藝 而 無 一 精)	xue2bai3yi4er2wu2yi4jing1
-(學 百 藝 而 無 ㊀ 精)	xue2bai3yi4er2wu2yi4jing1
 (學 百 藝 而 無 一 精)	xue2bai3yi4er2wu2yi4jing1
-(學 百 藝 而 無 ㊀ 精)	xue2bai3yi4er2wu2yi4jing1
 (安 提 瓜 和 巴 布 达)	an1ti2gua1he2ba1bu4da2
 (安 提 瓜 和 巴 布 達)	an1ti2gua1he2ba1bu4da2
 (巴 布 亚 新 几 内 亚)	ba1bu4ya4xin1ji3nei4ya4
 (巴 布 亞 新 幾 內 亞)	ba1bu4ya4xin1ji3nei4ya4
 (巴 貝 西 亞 原 蟲 病)	ba1bei4xi1ya4yuan2chong2bing4
-(巴 貝 🀂 亞 原 蟲 病)	ba1bei4xi1ya4yuan2chong2bing4
 (巴 贝 西 亚 原 虫 病)	ba1bei4xi1ya4yuan2chong2bing4
-(巴 贝 🀂 亚 原 虫 病)	ba1bei4xi1ya4yuan2chong2bing4
 (巴 馬 瑤 族 自 治 縣)	ba1ma3yao2zu2zi4zhi4xian4
 (巴 马 瑶 族 自 治 县)	ba1ma3yao2zu2zi4zhi4xian4
 (布 宜 諾 斯 艾 利 斯)	bu4yi2nuo4si1ai4li4si1
@@ -85021,107 +77753,68 @@ $textmode
 (布 宜 诺 斯 艾 利 斯)	bu4yi2nuo4si1ai4li4si1
 (布 宜 诺 斯 艾 利 斯)	bu4yi2nuo4si1ai4li4si1
 (強 將 手 下 無 弱 兵)	qiang2jiang4shou3xia4wu2ruo4bing1
-(強 將 手 ㊦ 無 弱 兵)	qiang2jiang4shou3xia4wu2ruo4bing1
 (強 龍 不 壓 地 頭 蛇)	qiang2long2bu4ya1di4tou2she2
 (強 龍 不 壓 地 頭 蛇)	qiang2long2bu4ya1di4tou2she2
 (強 龍 不 壓 地 頭 蛇)	qiang2long2bu4ya1di4tou2she2
 (强 将 手 下 无 弱 兵)	qiang2jiang4shou3xia4wu2ruo4bing1
-(强 将 手 ㊦ 无 弱 兵)	qiang2jiang4shou3xia4wu2ruo4bing1
 (强 龙 不 压 地 头 蛇)	qiang2long2bu4ya1di4tou2she2
 (强 龙 不 压 地 头 蛇)	qiang2long2bu4ya1di4tou2she2
 (得 饒 人 處 且 饒 人)	de2rao2ren2chu4qie3rao2ren2
 (得 饶 人 处 且 饶 人)	de2rao2ren2chu4qie3rao2ren2
 (德 国 统 一 社 会 党)	de2guo2tong3yi2she4hui4dang3
-(德 国 统 ㊀ 社 会 党)	de2guo2tong3yi2she4hui4dang3
-(德 国 统 一 ㊓ 会 党)	de2guo2tong3yi2she4hui4dang3
 (德 国 统 一 社 会 党)	de2guo2tong3yi2she4hui4dang3
-(德 国 统 ㊀ 社 会 党)	de2guo2tong3yi2she4hui4dang3
 (德 國 統 一 社 會 黨)	de2guo2tong3yi2she4hui4dang3
-(德 國 統 ㊀ 社 會 黨)	de2guo2tong3yi2she4hui4dang3
-(德 國 統 一 ㊓ 會 黨)	de2guo2tong3yi2she4hui4dang3
 (德 國 統 一 社 會 黨)	de2guo2tong3yi2she4hui4dang3
-(德 國 統 ㊀ 社 會 黨)	de2guo2tong3yi2she4hui4dang3
 (心 病 还 得 心 药 治)	xin1bing4hai2dei3xin1yao4zhi4
 (心 病 還 得 心 藥 治)	xin1bing4hai2dei3xin1yao4zhi4
 (懒 驴 上 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
-(懒 驴 ㊤ 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
 (懒 驴 上 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
-(懒 驴 ㊤ 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
 (懶 驢 上 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
-(懶 驢 ㊤ 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
 (懶 驢 上 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
-(懶 驢 ㊤ 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
 (懶 驢 上 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
-(懶 驢 ㊤ 磨 屎 尿 多)	lan3lv2shang4mo4shi3niao4duo1
 (把 手 无 缚 鸡 之 力)	ba3shou3wu2fu4ji1zhi1li4
 (把 手 无 缚 鸡 之 力)	ba3shou3wu2fu4ji1zhi1li4
 (把 手 無 縛 雞 之 力)	ba3shou3wu2fu4ji1zhi1li4
 (把 手 無 縛 雞 之 力)	ba3shou3wu2fu4ji1zhi1li4
 (按 下 葫 芦 浮 起 瓢)	an4xia4hu2lu5fu2qi3piao2
-(按 ㊦ 葫 芦 浮 起 瓢)	an4xia4hu2lu5fu2qi3piao2
 (按 下 葫 蘆 浮 起 瓢)	an4xia4hu2lu5fu2qi3piao2
-(按 ㊦ 葫 蘆 浮 起 瓢)	an4xia4hu2lu5fu2qi3piao2
 (按 下 葫 蘆 浮 起 瓢)	an4xia4hu2lu5fu2qi3piao2
-(按 ㊦ 葫 蘆 浮 起 瓢)	an4xia4hu2lu5fu2qi3piao2
 (新 晃 侗 族 自 治 县)	xin1huang3dong4zu2zi4zhi4xian4
 (新 晃 侗 族 自 治 縣)	xin1huang3dong4zu2zi4zhi4xian4
 (早 起 三 朝 当 一 天)	zao3qi3san1zhao1dang1yi4tian1
-(早 起 ㊂ 朝 当 一 天)	zao3qi3san1zhao1dang1yi4tian1
-(早 起 三 朝 当 ㊀ 天)	zao3qi3san1zhao1dang1yi4tian1
 (早 起 三 朝 當 一 天)	zao3qi3san1zhao1dang1yi4tian1
-(早 起 ㊂ 朝 當 一 天)	zao3qi3san1zhao1dang1yi4tian1
-(早 起 三 朝 當 ㊀ 天)	zao3qi3san1zhao1dang1yi4tian1
 (有 一 利 必 有 一 弊)	you3yi2li4bi4you3yi2bi4
-(有 ㊀ 利 必 有 ㊀ 弊)	you3yi2li4bi4you3yi2bi4
-(㊒ 一 利 必 ㊒ 一 弊)	you3yi2li4bi4you3yi2bi4
 (有 一 利 必 有 一 弊)	you3yi2li4bi4you3yi2bi4
-(有 ㊀ 利 必 有 ㊀ 弊)	you3yi2li4bi4you3yi2bi4
-(㊒ 一 利 必 ㊒ 一 弊)	you3yi2li4bi4you3yi2bi4
 (有 其 父 必 有 其 子)	you3qi2fu4bi4you3qi2zi3
-(㊒ 其 父 必 ㊒ 其 子)	you3qi2fu4bi4you3qi2zi3
 (木 裡 藏 族 自 治 縣)	mu4li3zang4zu2zi4zhi4xian4
-(㊍ 裡 藏 族 自 治 縣)	mu4li3zang4zu2zi4zhi4xian4
 (木 裡 藏 族 自 治 縣)	mu4li3zang4zu2zi4zhi4xian4
-(㊍ 裡 藏 族 自 治 縣)	mu4li3zang4zu2zi4zhi4xian4
 (杀 人 不 过 头 点 地)	sha1ren2bu2guo4tou2dian3di4
 (杀 人 不 过 头 点 地)	sha1ren2bu2guo4tou2dian3di4
 (柏 克 里 克 千 佛 洞)	bo2ke4li3ke4qian1fo2dong4
 (柏 克 里 克 千 佛 洞)	bo2ke4li3ke4qian1fo2dong4
 (柏 克 里 克 千 佛 洞)	bo2ke4li3ke4qian1fo2dong4
 (柳 暗 花 明 又 一 村)	liu3an4hua1ming2you4yi4cun1
-(柳 暗 花 明 又 ㊀ 村)	liu3an4hua1ming2you4yi4cun1
 (柳 暗 花 明 又 一 村)	liu3an4hua1ming2you4yi4cun1
-(柳 暗 花 明 又 ㊀ 村)	liu3an4hua1ming2you4yi4cun1
 (棋 錯 一 著 滿 盤 輸)	qi2cuo4yi4zhao1man3pan2shu1
-(棋 錯 ㊀ 著 滿 盤 輸)	qi2cuo4yi4zhao1man3pan2shu1
 (棋 錯 一 著 滿 盤 輸)	qi2cuo4yi4zhao1man3pan2shu1
-(棋 錯 ㊀ 著 滿 盤 輸)	qi2cuo4yi4zhao1man3pan2shu1
 (棋 錯 一 著 滿 盤 輸)	qi2cuo4yi4zhao1man3pan2shu1
-(棋 錯 ㊀ 著 滿 盤 輸)	qi2cuo4yi4zhao1man3pan2shu1
 (棋 错 一 着 满 盘 输)	qi2cuo4yi4zhao1man3pan2shu1
-(棋 错 ㊀ 着 满 盘 输)	qi2cuo4yi4zhao1man3pan2shu1
 (棋 错 一 着 满 盘 输)	qi2cuo4yi4zhao1man3pan2shu1
-(棋 错 ㊀ 着 满 盘 输)	qi2cuo4yi4zhao1man3pan2shu1
 (殺 人 不 過 頭 點 地)	sha1ren2bu2guo4tou2dian3di4
 (殺 人 不 過 頭 點 地)	sha1ren2bu2guo4tou2dian3di4
 (殺 人 不 過 頭 點 地)	sha1ren2bu2guo4tou2dian3di4
 (殺 人 不 過 頭 點 地)	sha1ren2bu2guo4tou2dian3di4
 (滿 城 盡 帶 黃 金 甲)	man3cheng2jin4dai4huang2jin1jia3
-(滿 城 盡 帶 黃 ㊎ 甲)	man3cheng2jin4dai4huang2jin1jia3
 (滿 城 盡 帶 黃 金 甲)	man3cheng2jin4dai4huang2jin1jia3
 (漾 濞 彝 族 自 治 县)	yang4bi4yi2zu2zi4zhi4xian4
 (漾 濞 彞 族 自 治 縣)	yang4bi4yi2zu2zi4zhi4xian4
 (牽 一 髮 而 動 全 身)	qian1yi2fa4er2dong4quan2shen1
-(牽 ㊀ 髮 而 動 全 身)	qian1yi2fa4er2dong4quan2shen1
 (牽 一 髮 而 動 全 身)	qian1yi2fa4er2dong4quan2shen1
-(牽 ㊀ 髮 而 動 全 身)	qian1yi2fa4er2dong4quan2shen1
 (独 在 异 乡 为 异 客)	du2zai4yi4xiang1wei2yi4ke4
 (獨 在 異 鄉 為 異 客)	du2zai4yi4xiang1wei2yi4ke4
 (獨 在 異 鄉 為 異 客)	du2zai4yi4xiang1wei2yi4ke4
 (玫 瑰 不 管 叫 啥 名)	mei2gui1bu4guan3jiao4sha2ming2
-(玫 瑰 不 管 叫 啥 ㊔)	mei2gui1bu4guan3jiao4sha2ming2
 (玫 瑰 不 管 叫 啥 名)	mei2gui1bu4guan3jiao4sha2ming2
-(玫 瑰 不 管 叫 啥 ㊔)	mei2gui1bu4guan3jiao4sha2ming2
 (称 砣 虽 小 压 千 斤)	cheng4tuo2sui1xiao3ya1qian1jin1
 (稱 砣 雖 小 壓 千 斤)	cheng4tuo2sui1xiao3ya1qian1jin1
 (老 虎 屁 股 摸 不 得)	lao3hu3pi4gu5mo1bu5de5
@@ -85132,15 +77825,10 @@ $textmode
 (華 嚴 經 大 方 廣 佛)	hua2yan2jing1da4fang1guang3fo2
 (華 嚴 經 大 方 廣 佛)	hua2yan2jing1da4fang1guang3fo2
 (褶 皱 山 系 火 地 岛)	zhe3zhou4shan1xi4huo3di4dao3
-(褶 皱 山 系 ㊋ 地 岛)	zhe3zhou4shan1xi4huo3di4dao3
 (褶 皺 山 系 火 地 島)	zhe3zhou4shan1xi4huo3di4dao3
-(褶 皺 山 系 ㊋ 地 島)	zhe3zhou4shan1xi4huo3di4dao3
 (西 盟 佤 族 自 治 县)	xi1meng2wa3zu2zi4zhi4xian4
-(🀂 盟 佤 族 自 治 县)	xi1meng2wa3zu2zi4zhi4xian4
 (西 盟 佤 族 自 治 縣)	xi1meng2wa3zu2zi4zhi4xian4
-(🀂 盟 佤 族 自 治 縣)	xi1meng2wa3zu2zi4zhi4xian4
 (詩 書 畫 合 而 為 一)	shi1shu1hua4he2er5wei2yi1
-(詩 書 畫 合 而 為 ㊀)	shi1shu1hua4he2er5wei2yi1
 (識 時 務 者 為 俊 傑)	shi2shi2wu4zhe3wei2jun4jie2
 (識 時 務 者 為 俊 傑)	shi2shi2wu4zhe3wei2jun4jie2
 (識 時 務 者 為 俊 傑)	shi2shi2wu4zhe3wei2jun4jie2
@@ -85149,33 +77837,19 @@ $textmode
 (识 时 务 者 为 俊 杰)	shi2shi2wu4zhe3wei2jun4jie2
 (识 时 务 者 为 俊 杰)	shi2shi2wu4zhe3wei2jun4jie2
 (诗 书 画 合 而 为 一)	shi1shu1hua4he2er5wei2yi1
-(诗 书 画 合 而 为 ㊀)	shi1shu1hua4he2er5wei2yi1
 (诗 书 画 合 而 为 一)	shi1shu1hua4he2er5wei2yi1
-(诗 书 画 合 而 为 ㊀)	shi1shu1hua4he2er5wei2yi1
 (車 爾 尼 雪 夫 斯 基)	che1er3ni2xue3fu1si1ji1
 (車 爾 尼 雪 夫 斯 基)	che1er3ni2xue3fu1si1ji1
 (车 尔 尼 雪 夫 斯 基)	che1er3ni2xue3fu1si1ji1
 (近 水 楼 台 先 得 月)	jin4shui3lou2tai2xian1de2yue4
-(近 水 楼 台 先 得 ㊊)	jin4shui3lou2tai2xian1de2yue4
-(近 ㊌ 楼 台 先 得 月)	jin4shui3lou2tai2xian1de2yue4
 (近 水 樓 臺 先 得 月)	jin4shui3lou2tai2xian1de2yue4
-(近 水 樓 臺 先 得 ㊊)	jin4shui3lou2tai2xian1de2yue4
-(近 ㊌ 樓 臺 先 得 月)	jin4shui3lou2tai2xian1de2yue4
 (近 水 樓 臺 先 得 月)	jin4shui3lou2tai2xian1de2yue4
-(近 水 樓 臺 先 得 ㊊)	jin4shui3lou2tai2xian1de2yue4
-(近 ㊌ 樓 臺 先 得 月)	jin4shui3lou2tai2xian1de2yue4
 (远 水 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
-(远 ㊌ 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
 (远 水 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
-(远 ㊌ 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
 (远 水 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
-(远 ㊌ 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
 (遠 水 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
-(遠 ㊌ 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
 (遠 水 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
-(遠 ㊌ 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
 (遠 水 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
-(遠 ㊌ 解 不 了 近 渴)	yuan3shui3jie3bu5liao3jin4ke3
 (都 安 瑤 族 自 治 縣)	du1an1yao2zu2zi4zhi4xian4
 (都 安 瑤 族 自 治 縣)	du1an1yao2zu2zi4zhi4xian4
 (都 安 瑶 族 自 治 县)	du1an1yao2zu2zi4zhi4xian4
@@ -85190,10 +77864,6 @@ $textmode
 (雅 魯 藏 布 大 峽 谷)	ya3lu3zang4bu4da4xia2gu3
 (雅 鲁 藏 布 大 峡 谷)	ya3lu3zang4bu4da4xia2gu3
 (馬 哈 拉 施 特 拉 邦)	ma3ha1la1shi1te4la1bang1
-(馬 哈 拉 施 ㊕ 拉 邦)	ma3ha1la1shi1te4la1bang1
 (馬 哈 拉 施 特 拉 邦)	ma3ha1la1shi1te4la1bang1
-(馬 哈 拉 施 ㊕ 拉 邦)	ma3ha1la1shi1te4la1bang1
 (马 哈 拉 施 特 拉 邦)	ma3ha1la1shi1te4la1bang1
-(马 哈 拉 施 ㊕ 拉 邦)	ma3ha1la1shi1te4la1bang1
 (马 哈 拉 施 特 拉 邦)	ma3ha1la1shi1te4la1bang1
-(马 哈 拉 施 ㊕ 拉 邦)	ma3ha1la1shi1te4la1bang1

--- a/ekho-data/zhy_list
+++ b/ekho-data/zhy_list
@@ -5719,441 +5719,200 @@ _9      gau2||
 ㊀	jat1
 🈩	jat1
 (一 覺 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
-(㊀ 覺 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
 (一 覺 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
-(㊀ 覺 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
 (一 觉 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
-(㊀ 觉 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
 (一 觉 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
-(㊀ 觉 睡 到 天 亮)	jat1|gaau3|seoi6|dou3|tin1|loeng6
 (一 問 三 不 知)	jat1|man6|saam1|bat1|zi1
-(一 問 ㊂ 不 知)	jat1|man6|saam1|bat1|zi1
-(㊀ 問 三 不 知)	jat1|man6|saam1|bat1|zi1
 (一 問 三 不 知)	jat1|man6|saam1|bat1|zi1
-(一 問 ㊂ 不 知)	jat1|man6|saam1|bat1|zi1
-(㊀ 問 三 不 知)	jat1|man6|saam1|bat1|zi1
 (一 问 三 不 知)	jat1|man6|saam1|bat1|zi1
-(一 问 ㊂ 不 知)	jat1|man6|saam1|bat1|zi1
-(㊀ 问 三 不 知)	jat1|man6|saam1|bat1|zi1
 (一 问 三 不 知)	jat1|man6|saam1|bat1|zi1
-(一 问 ㊂ 不 知)	jat1|man6|saam1|bat1|zi1
-(㊀ 问 三 不 知)	jat1|man6|saam1|bat1|zi1
 (一 物 降 一 物)	jat1|mat6|hong4|jat1|mat6
-(㊀ 物 降 ㊀ 物)	jat1|mat6|hong4|jat1|mat6
 (一 物 降 一 物)	jat1|mat6|hong4|jat1|mat6
-(㊀ 物 降 ㊀ 物)	jat1|mat6|hong4|jat1|mat6
 (一 沐 三 握 發)	jat1|muk6|saam3|aak1|faat3
-(一 沐 ㊂ 握 發)	jat1|muk6|saam3|aak1|faat3
-(㊀ 沐 三 握 發)	jat1|muk6|saam3|aak1|faat3
 (一 沐 三 握 发)	jat1|muk6|saam3|aak1|faat3
-(一 沐 ㊂ 握 发)	jat1|muk6|saam3|aak1|faat3
-(㊀ 沐 三 握 发)	jat1|muk6|saam3|aak1|faat3
 (一 沐 三 握 髮)	jat1|muk6|saam3|aak1|faat3
-(一 沐 ㊂ 握 髮)	jat1|muk6|saam3|aak1|faat3
-(㊀ 沐 三 握 髮)	jat1|muk6|saam3|aak1|faat3
 (一 乾 二 淨)	jat1|gon1|ji6|zeng6
-(㊀ 乾 二 淨)	jat1|gon1|ji6|zeng6
-(一 乾 ㊁ 淨)	jat1|gon1|ji6|zeng6
 (一 刀 兩 斷)	jat1|dou1|loeng5|dyun6
-(㊀ 刀 兩 斷)	jat1|dou1|loeng5|dyun6
 (一 刀 兩 斷)	jat1|dou1|loeng5|dyun6
-(㊀ 刀 兩 斷)	jat1|dou1|loeng5|dyun6
 (一 刀 两 断)	jat1|dou1|loeng5|dyun6
-(㊀ 刀 两 断)	jat1|dou1|loeng5|dyun6
 (一 分 為 二)	jat1|fan6|wai4|ji6
-(㊀ 分 為 二)	jat1|fan6|wai4|ji6
-(一 分 為 ㊁)	jat1|fan6|wai4|ji6
 (一 分 为 二)	jat1|fan6|wai4|ji6
-(㊀ 分 为 二)	jat1|fan6|wai4|ji6
-(一 分 为 ㊁)	jat1|fan6|wai4|ji6
 (一 哄 而 散)	jat1|hung6|ji4|saan3
-(㊀ 哄 而 散)	jat1|hung6|ji4|saan3
 (一 唱 一 和)	jat1|coeng3|jat1|wo6
-(㊀ 唱 ㊀ 和)	jat1|coeng3|jat1|wo6
 (一 掃 而 空)	jat1|sou3|ji4|hung3
-(㊀ 掃 而 空)	jat1|sou3|ji4|hung3
 (一 扫 而 空)	jat1|sou3|ji4|hung3
-(㊀ 扫 而 空)	jat1|sou3|ji4|hung3
 (一 本 正 經)	jat1|bun2|zing1|ging1
-(一 本 ㊣ 經)	jat1|bun2|zing1|ging1
-(㊀ 本 正 經)	jat1|bun2|zing1|ging1
 (一 本 正 经)	jat1|bun2|zing1|ging1
-(一 本 ㊣ 经)	jat1|bun2|zing1|ging1
-(㊀ 本 正 经)	jat1|bun2|zing1|ging1
 (一 波 三 折)	jat1|bo1|saam1|zit3
-(一 波 ㊂ 折)	jat1|bo1|saam1|zit3
-(㊀ 波 三 折)	jat1|bo1|saam1|zit3
 (一 盤 散 沙)	jat1|pun4|saan2|saa1
-(㊀ 盤 散 沙)	jat1|pun4|saan2|saa1
 (一 盘 散 沙)	jat1|pun4|saan2|saa1
-(㊀ 盘 散 沙)	jat1|pun4|saan2|saa1
 (一 目 了 然)	jat1|muk6|liu5|jin4
-(㊀ 目 了 然)	jat1|muk6|liu5|jin4
 (一 目 了 然)	jat1|muk6|liu5|jin4
-(㊀ 目 了 然)	jat1|muk6|liu5|jin4
 (一 目 瞭 然)	jat1|muk6|liu5|jin4
-(㊀ 目 瞭 然)	jat1|muk6|liu5|jin4
 (一 知 半 解)	jat1|zi3|bun3|gaai2
-(㊀ 知 半 解)	jat1|zi3|bun3|gaai2
 (一 脈 相 承)	jat1|mak6|soeng3|sing4
-(㊀ 脈 相 承)	jat1|mak6|soeng3|sing4
 (一 脉 相 承)	jat1|mak6|soeng3|sing4
-(㊀ 脉 相 承)	jat1|mak6|soeng3|sing4
 (一 蹶 不 振)	jat1|kyut3|bat1|zan3
-(㊀ 蹶 不 振)	jat1|kyut3|bat1|zan3
 (一 蹶 不 振)	jat1|kyut3|bat1|zan3
-(㊀ 蹶 不 振)	jat1|kyut3|bat1|zan3
 (一 看 之 下)	jat1|hon3|zi1|haa5
-(一 看 之 ㊦)	jat1|hon3|zi1|haa5
-(㊀ 看 之 下)	jat1|hon3|zi1|haa5
 (一 試 之 下)	jat1|si5|zi1|haa6
-(一 試 之 ㊦)	jat1|si5|zi1|haa6
-(㊀ 試 之 下)	jat1|si5|zi1|haa6
 (一 试 之 下)	jat1|si5|zi1|haa6
-(一 试 之 ㊦)	jat1|si5|zi1|haa6
-(㊀ 试 之 下)	jat1|si5|zi1|haa6
 (一 併 處 理)	jat1|bing3|cyu2|lei5
-(㊀ 併 處 理)	jat1|bing3|cyu2|lei5
 (一 併 處 理)	jat1|bing3|cyu2|lei5
-(㊀ 併 處 理)	jat1|bing3|cyu2|lei5
 (一 併 处 理)	jat1|bing3|cyu2|lei5
-(㊀ 併 处 理)	jat1|bing3|cyu2|lei5
 (一 併 处 理)	jat1|bing3|cyu2|lei5
-(㊀ 併 处 理)	jat1|bing3|cyu2|lei5
 (一 聽 之 下)	jat1|teng1|zi1|haa6
-(一 聽 之 ㊦)	jat1|teng1|zi1|haa6
-(㊀ 聽 之 下)	jat1|teng1|zi1|haa6
 (一 听 之 下)	jat1|teng1|zi1|haa6
-(一 听 之 ㊦)	jat1|teng1|zi1|haa6
-(㊀ 听 之 下)	jat1|teng1|zi1|haa6
 (一 時 三 刻)	jat1|si4|saam1|hak1
-(一 時 ㊂ 刻)	jat1|si4|saam1|hak1
-(㊀ 時 三 刻)	jat1|si4|saam1|hak1
 (一 时 三 刻)	jat1|si4|saam1|hak1
-(一 时 ㊂ 刻)	jat1|si4|saam1|hak1
-(㊀ 时 三 刻)	jat1|si4|saam1|hak1
 (一 倡 三 嘆)	jat1|coeng1|saam3|taan3
-(一 倡 ㊂ 嘆)	jat1|coeng1|saam3|taan3
-(㊀ 倡 三 嘆)	jat1|coeng1|saam3|taan3
 (一 倡 三 嘆)	jat1|coeng1|saam3|taan3
-(一 倡 ㊂ 嘆)	jat1|coeng1|saam3|taan3
-(㊀ 倡 三 嘆)	jat1|coeng1|saam3|taan3
 (一 倡 三 叹)	jat1|coeng1|saam3|taan3
-(一 倡 ㊂ 叹)	jat1|coeng1|saam3|taan3
-(㊀ 倡 三 叹)	jat1|coeng1|saam3|taan3
 (一 了 百 當)	jat1|liu5|baak3|dong3
-(㊀ 了 百 當)	jat1|liu5|baak3|dong3
 (一 了 百 當)	jat1|liu5|baak3|dong3
-(㊀ 了 百 當)	jat1|liu5|baak3|dong3
 (一 了 百 当)	jat1|liu5|baak3|dong3
-(㊀ 了 百 当)	jat1|liu5|baak3|dong3
 (一 了 百 当)	jat1|liu5|baak3|dong3
-(㊀ 了 百 当)	jat1|liu5|baak3|dong3
 (一 分 收 獲)	jat1|fan6|sau1|wok6
-(㊀ 分 收 獲)	jat1|fan6|sau1|wok6
 (一 分 收 获)	jat1|fan6|sau1|wok6
-(㊀ 分 收 获)	jat1|fan6|sau1|wok6
 (一 切 都 是)	jat1|cit3|dou1|si6
-(㊀ 切 都 是)	jat1|cit3|dou1|si6
 (一 切 都 是)	jat1|cit3|dou1|si6
-(㊀ 切 都 是)	jat1|cit3|dou1|si6
 (一 切 都 是)	jat1|cit3|dou1|si6
-(㊀ 切 都 是)	jat1|cit3|dou1|si6
 (一 並 處 理)	jat1|bing3|cyu2|lei5
-(㊀ 並 處 理)	jat1|bing3|cyu2|lei5
 (一 並 處 理)	jat1|bing3|cyu2|lei5
-(㊀ 並 處 理)	jat1|bing3|cyu2|lei5
 (一 並 處 理)	jat1|bing3|cyu2|lei5
-(㊀ 並 處 理)	jat1|bing3|cyu2|lei5
 (一 并 处 理)	jat1|bing3|cyu2|lei5
-(㊀ 并 处 理)	jat1|bing3|cyu2|lei5
 (一 并 处 理)	jat1|bing3|cyu2|lei5
-(㊀ 并 处 理)	jat1|bing3|cyu2|lei5
 (一 飯 一 啄)	jat1|faan6|jat1|doek3
-(㊀ 飯 ㊀ 啄)	jat1|faan6|jat1|doek3
 (一 飯 一 啄)	jat1|faan6|jat1|doek3
-(㊀ 飯 ㊀ 啄)	jat1|faan6|jat1|doek3
 (一 饭 一 啄)	jat1|faan6|jat1|doek3
-(㊀ 饭 ㊀ 啄)	jat1|faan6|jat1|doek3
 (一 品 夫 人)	jat1|ban2|fu4|jan4
-(㊀ 品 夫 人)	jat1|ban2|fu4|jan4
 (一 爭 長 短)	jat1|zang1|zoeng2|dyun2
-(㊀ 爭 長 短)	jat1|zang1|zoeng2|dyun2
 (一 争 长 短)	jat1|zang1|zoeng2|dyun2
-(㊀ 争 长 短)	jat1|zang1|zoeng2|dyun2
 (一 哄 而 上)	jat1|hung6|ji4|soeng5
-(一 哄 而 ㊤)	jat1|hung6|ji4|soeng5
-(㊀ 哄 而 上)	jat1|hung6|ji4|soeng5
 (一 夫 當 關)	jat1|fu1|dong3|gwaan1
-(㊀ 夫 當 關)	jat1|fu1|dong3|gwaan1
 (一 夫 当 关)	jat1|fu1|dong3|gwaan1
-(㊀ 夫 当 关)	jat1|fu1|dong3|gwaan1
 (一 九 九 三)	jat1|gau2|gau2|saam1
-(一 ㊈ ㊈ 三)	jat1|gau2|gau2|saam1
-(一 九 九 ㊂)	jat1|gau2|gau2|saam1
-(㊀ 九 九 三)	jat1|gau2|gau2|saam1
 (一 泻 千 里)	jat1|se3|cin1|lei5
-(㊀ 泻 千 里)	jat1|se3|cin1|lei5
 (一 泻 千 里)	jat1|se3|cin1|lei5
-(㊀ 泻 千 里)	jat1|se3|cin1|lei5
 (一 分 耕 耘)	jat1|fan6|gaang1|wan4
-(㊀ 分 耕 耘)	jat1|fan6|gaang1|wan4
 (一 妻 多 夫)	jat1|cai3|do1|fu4
-(㊀ 妻 多 夫)	jat1|cai3|do1|fu4
 (一 語 中 的)	jat1|jyu5|zung3|dik1
-(一 語 🀄 的)	jat1|jyu5|zung3|dik1
-(一 語 ㊥ 的)	jat1|jyu5|zung3|dik1
-(㊀ 語 中 的)	jat1|jyu5|zung3|dik1
-(㊀ 語 🀄 的)	jat1|jyu5|zung3|dik1
 (一 语 中 的)	jat1|jyu5|zung3|dik1
-(一 语 🀄 的)	jat1|jyu5|zung3|dik1
-(一 语 ㊥ 的)	jat1|jyu5|zung3|dik1
-(㊀ 语 中 的)	jat1|jyu5|zung3|dik1
-(㊀ 语 🀄 的)	jat1|jyu5|zung3|dik1
 (一 飲 一 啄)	jat1|jam2|jat1|doek3
-(㊀ 飲 ㊀ 啄)	jat1|jam2|jat1|doek3
 (一 饮 一 啄)	jat1|jam2|jat1|doek3
-(㊀ 饮 ㊀ 啄)	jat1|jam2|jat1|doek3
 (一 言 興 邦)	jat1|jin4|hing3|bong1
-(㊀ 言 興 邦)	jat1|jin4|hing3|bong1
 (一 言 兴 邦)	jat1|jin4|hing3|bong1
-(㊀ 言 兴 邦)	jat1|jin4|hing3|bong1
 (一 倡 三 歎)	jat1|coeng1|saam3|taan3
-(一 倡 ㊂ 歎)	jat1|coeng1|saam3|taan3
-(㊀ 倡 三 歎)	jat1|coeng1|saam3|taan3
 (一 分 一 秒)	jat1|fan6|jat1|miu5
-(㊀ 分 ㊀ 秒)	jat1|fan6|jat1|miu5
 (一 切 都 在)	jat1|cit3|dou1|zoi6
-(㊀ 切 都 在)	jat1|cit3|dou1|zoi6
 (一 切 都 在)	jat1|cit3|dou1|zoi6
-(㊀ 切 都 在)	jat1|cit3|dou1|zoi6
 (一 切 都 在)	jat1|cit3|dou1|zoi6
-(㊀ 切 都 在)	jat1|cit3|dou1|zoi6
 (一 日 三 市)	jat1|jat6|saam1|si5
-(一 日 ㊂ 市)	jat1|jat6|saam1|si5
-(㊀ 日 三 市)	jat1|jat6|saam1|si5
-(一 ㊐ 三 市)	jat1|jat6|saam1|si5
 (一 馬 當 先)	jat1|maa5|dong3|sin3
-(㊀ 馬 當 先)	jat1|maa5|dong3|sin3
 (一 马 当 先)	jat1|maa5|dong3|sin3
-(㊀ 马 当 先)	jat1|maa5|dong3|sin3
 (一 夫 多 妻)	jat1|fu4|do1|cai3
-(㊀ 夫 多 妻)	jat1|fu4|do1|cai3
 (一 言 中 的)	jat1|jin4|zung3|dik1
-(一 言 🀄 的)	jat1|jin4|zung3|dik1
-(一 言 ㊥ 的)	jat1|jin4|zung3|dik1
-(㊀ 言 中 的)	jat1|jin4|zung3|dik1
-(㊀ 言 🀄 的)	jat1|jin4|zung3|dik1
 (一 分 收 穫)	jat1|fan6|sau1|wok6
-(㊀ 分 收 穫)	jat1|fan6|sau1|wok6
 (一 倡 百 和)	jat1|coeng1|baak3|wo6
-(㊀ 倡 百 和)	jat1|coeng1|baak3|wo6
 (一 著 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 著 不 慎)	jat1|zoek6|bat1|san6
 (一 著 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 著 不 慎)	jat1|zoek6|bat1|san6
 (一 著 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 著 不 慎)	jat1|zoek6|bat1|san6
 (一 著 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 著 不 慎)	jat1|zoek6|bat1|san6
 (一 着 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 着 不 慎)	jat1|zoek6|bat1|san6
 (一 着 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 着 不 慎)	jat1|zoek6|bat1|san6
 (一 着 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 着 不 慎)	jat1|zoek6|bat1|san6
 (一 着 不 慎)	jat1|zoek6|bat1|san6
-(㊀ 着 不 慎)	jat1|zoek6|bat1|san6
 (一 分 錢)	jat1|fan1|cin4
-(㊀ 分 錢)	jat1|fan1|cin4
 (一 分 钱)	jat1|fan1|cin4
-(㊀ 分 钱)	jat1|fan1|cin4
 (一 轉 眼)	jat1|zyun2|ngaan5
-(㊀ 轉 眼)	jat1|zyun2|ngaan5
 (一 转 眼)	jat1|zyun2|ngaan5
-(㊀ 转 眼)	jat1|zyun2|ngaan5
 (一 毛 錢)	jat1|mou4|cin4
-(㊀ 毛 錢)	jat1|mou4|cin4
 (一 毛 钱)	jat1|mou4|cin4
-(㊀ 毛 钱)	jat1|mou4|cin4
 (一 下 來)	jat1|haa6|loi4
-(一 ㊦ 來)	jat1|haa6|loi4
-(㊀ 下 來)	jat1|haa6|loi4
 (一 下 來)	jat1|haa6|loi4
-(一 ㊦ 來)	jat1|haa6|loi4
-(㊀ 下 來)	jat1|haa6|loi4
 (一 下 来)	jat1|haa6|loi4
-(一 ㊦ 来)	jat1|haa6|loi4
-(㊀ 下 来)	jat1|haa6|loi4
 (一 下 去)	jat1|haa6|heoi3
-(一 ㊦ 去)	jat1|haa6|heoi3
-(㊀ 下 去)	jat1|haa6|heoi3
 (一 貫 道)	jat1|gun3|dou3
-(㊀ 貫 道)	jat1|gun3|dou3
 (一 贯 道)	jat1|gun3|dou3
-(㊀ 贯 道)	jat1|gun3|dou3
 (一 行 行)	jat1|hong4|hong4
-(㊀ 行 行)	jat1|hong4|hong4
 (一 行 行)	jat1|hong4|hong4
-(㊀ 行 行)	jat1|hong4|hong4
 (一 定 會)	jat1|ding6|wui6
-(㊀ 定 會)	jat1|ding6|wui6
 (一 定 会)	jat1|ding6|wui6
-(㊀ 定 会)	jat1|ding6|wui6
 (一 角 錢)	jat1|gok3|cin4
-(㊀ 角 錢)	jat1|gok3|cin4
 (一 角 钱)	jat1|gok3|cin4
-(㊀ 角 钱)	jat1|gok3|cin4
 (一 文 錢)	jat1|man4|cin4
-(㊀ 文 錢)	jat1|man4|cin4
 (一 文 钱)	jat1|man4|cin4
-(㊀ 文 钱)	jat1|man4|cin4
 (一 行 人)	jat1|hang6|jan4
-(㊀ 行 人)	jat1|hang6|jan4
 (一 行 人)	jat1|hang6|jan4
-(㊀ 行 人)	jat1|hang6|jan4
 (一 切 都)	jat1|cit3|dou1
-(㊀ 切 都)	jat1|cit3|dou1
 (一 切 都)	jat1|cit3|dou1
-(㊀ 切 都)	jat1|cit3|dou1
 (一 切 都)	jat1|cit3|dou1
-(㊀ 切 都)	jat1|cit3|dou1
 (一 只 只)	jat1|zek3|zek3
-(㊀ 只 只)	jat1|zek3|zek3
 (一 籮 筐)	jat1|lo4|kwaang1
-(㊀ 籮 筐)	jat1|lo4|kwaang1
 (一 箩 筐)	jat1|lo4|kwaang1
-(㊀ 箩 筐)	jat1|lo4|kwaang1
 (一 等 親)	jat1|dang2|can3
-(㊀ 等 親)	jat1|dang2|can3
 (一 等 亲)	jat1|dang2|can3
-(㊀ 等 亲)	jat1|dang2|can3
 (一 鑊 泡)	jat1|wok6|pou5
-(㊀ 鑊 泡)	jat1|wok6|pou5
 (一 镬 泡)	jat1|wok6|pou5
-(㊀ 镬 泡)	jat1|wok6|pou5
 (一 樣 會)	jat1|joeng6|wui5
-(㊀ 樣 會)	jat1|joeng6|wui5
 (一 样 会)	jat1|joeng6|wui5
-(㊀ 样 会)	jat1|joeng6|wui5
 (一 下 臺)	jat1|haa6|toi4
-(一 ㊦ 臺)	jat1|haa6|toi4
-(㊀ 下 臺)	jat1|haa6|toi4
 (一 下 台)	jat1|haa6|toi4
-(一 ㊦ 台)	jat1|haa6|toi4
-(㊀ 下 台)	jat1|haa6|toi4
 (一 打 聽)	jat1|daa2|ting3
-(㊀ 打 聽)	jat1|daa2|ting3
 (一 打 听)	jat1|daa2|ting3
-(㊀ 打 听)	jat1|daa2|ting3
 (一 塊 錢)	jat1|faai3|cin4
-(㊀ 塊 錢)	jat1|faai3|cin4
 (一 块 钱)	jat1|faai3|cin4
-(㊀ 块 钱)	jat1|faai3|cin4
 (一 下 下)	jat1|haa6|heoi3
-(一 ㊦ ㊦)	jat1|haa6|heoi3
-(㊀ 下 下)	jat1|haa6|heoi3
 (一 票 人)	jat1|biu1|jan4
-(㊀ 票 人)	jat1|biu1|jan4
 (一 下)	jat1|haa5
-(一 ㊦)	jat1|haa5
-(㊀ 下)	jat1|haa5
 (一 并)	jat1|bing3
-(㊀ 并)	jat1|bing3
 (一 切)	jat1|cai3
-(㊀ 切)	jat1|cai3
 (一 切)	jat1|cai3
-(㊀ 切)	jat1|cai3
 (一 匙)	jat1|ci4
-(㊀ 匙)	jat1|ci4
 (一 打)	jat1|daa1
-(㊀ 打)	jat1|daa1
 (一 行)	jat1|hong4
-(㊀ 行)	jat1|hong4
 (一 行)	jat1|hong4
-(㊀ 行)	jat1|hong4
 (一 蓋)	jat1|koi3
-(㊀ 蓋)	jat1|koi3
 (一 盖)	jat1|koi3
-(㊀ 盖)	jat1|koi3
 (一 房)	jat1|fong2
-(㊀ 房)	jat1|fong2
 (一 喊)	jat1|ham6
-(㊀ 喊)	jat1|ham6
 (一 劑)	jat1|zai6
-(㊀ 劑)	jat1|zai6
 (一 剂)	jat1|zai6
-(㊀ 剂)	jat1|zai6
 (一 聽)	jat1|ting1
-(㊀ 聽)	jat1|ting1
 (一 听)	jat1|ting1
-(㊀ 听)	jat1|ting1
 (一 訂)	jat1|ding6
-(㊀ 訂)	jat1|ding6
 (一 订)	jat1|ding6
-(㊀ 订)	jat1|ding6
 (一 畫)	jat1|waak6
-(㊀ 畫)	jat1|waak6
 (一 画)	jat1|waak6
-(㊀ 画)	jat1|waak6
 (一 画)	jat1|waak6
-(㊀ 画)	jat1|waak6
 (一 疊)	jat1|daap6
-(㊀ 疊)	jat1|daap6
 (一 叠)	jat1|daap6
-(㊀ 叠)	jat1|daap6
 (一 擔)	jat1|daam3
-(㊀ 擔)	jat1|daam3
 (一 担)	jat1|daam3
-(㊀ 担)	jat1|daam3
 (一 轉)	jat1|zyun3
-(㊀ 轉)	jat1|zyun3
 (一 转)	jat1|zyun3
-(㊀ 转)	jat1|zyun3
 (一 筒)	jat1|tung4
-(㊀ 筒)	jat1|tung4
 (一 頂)	jat1|deng2
-(㊀ 頂)	jat1|deng2
 (一 顶)	jat1|deng2
-(㊀ 顶)	jat1|deng2
 (一 妻)	jat1|cai3
-(㊀ 妻)	jat1|cai3
 (一 沖)	jat1|cung3
-(㊀ 沖)	jat1|cung3
 (一 冲)	jat1|cung3
-(㊀ 冲)	jat1|cung3
 (一 迭)	jat1|daap6
-(㊀ 迭)	jat1|daap6
 (一 仗)	jat1|zoeng3
-(㊀ 仗)	jat1|zoeng3
 (一 夫)	jat1|fu4
-(㊀ 夫)	jat1|fu4
 (一 錢)	jat1|cin4
-(㊀ 錢)	jat1|cin4
 (一 钱)	jat1|cin4
-(㊀ 钱)	jat1|cin4
 (一 券)	jat1|gyun3
-(㊀ 券)	jat1|gyun3
 (一 彈)	jat1|taan4
-(㊀ 彈)	jat1|taan4
 (一 弹)	jat1|taan4
-(㊀ 弹)	jat1|taan4
 (一 朝)	jat1|ziu1
-(㊀ 朝)	jat1|ziu1
 (一 衝)	jat1|cung3
-(㊀ 衝)	jat1|cung3
 (一 躍)	jat1|joek6
-(㊀ 躍)	jat1|joek6
 (一 跃)	jat1|joek6
-(㊀ 跃)	jat1|joek6
 (一 槓)	jat1|gung3
-(㊀ 槓)	jat1|gung3
 (一 只)	jat1|zek3
-(㊀ 只)	jat1|zek3
 (一 檔)	jat1|dong2
-(㊀ 檔)	jat1|dong2
 (一 档)	jat1|dong2
-(㊀ 档)	jat1|dong2
 丁	ding1
 (丁 鈴 當 啷)	ding1|ling1|dong1|long1
 (丁 鈴 當 啷)	ding1|ling1|dong1|long1
@@ -6162,27 +5921,17 @@ _9      gau2||
 (丁 鈴 噹 啷)	ding1|ling1|dong1|long1
 (丁 铃 噹 啷)	ding1|ling1|dong1|long1
 (丁 下)	ding1|haa5
-(丁 ㊦)	ding1|haa5
 (丁 上)	ding1|soeng6
-(丁 ㊤)	ding1|soeng6
 七	cat1
 ㊆	cat1
 (七 世 夫 妻)	cat1|sai3|fu1|cai3
-(㊆ 世 夫 妻)	cat1|sai3|fu1|cai3
 (七 里 河)	cat1|leoi5|ho4
-(㊆ 里 河)	cat1|leoi5|ho4
 (七 里 河)	cat1|leoi5|ho4
-(㊆ 里 河)	cat1|leoi5|ho4
 (七 聲)	cat1|seng1
-(㊆ 聲)	cat1|seng1
 (七 声)	cat1|seng1
-(㊆ 声)	cat1|seng1
 (七 票)	cat1|biu1
-(㊆ 票)	cat1|biu1
 (七 行)	cat1|hong4
-(㊆ 行)	cat1|hong4
 (七 行)	cat1|hong4
-(㊆ 行)	cat1|hong4
 丄	soeng5
 丅	ti1
 万	maan6
@@ -6196,1731 +5945,813 @@ _9      gau2||
 🈪	saam7
 🉁	saam7
 (三 個 和 尚 沒 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(三 個 和 尚 沒 ㊌ 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(㊂ 個 和 尚 沒 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
 (三 個 和 尚 沒 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(三 個 和 尚 沒 ㊌ 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(㊂ 個 和 尚 沒 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
 (三 個 和 尚 沒 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(三 個 和 尚 沒 ㊌ 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(㊂ 個 和 尚 沒 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
 (三 个 和 尚 没 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(三 个 和 尚 没 ㊌ 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(㊂ 个 和 尚 没 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
 (三 个 和 尚 没 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(三 个 和 尚 没 ㊌ 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(㊂ 个 和 尚 没 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
 (三 个 和 尚 没 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(三 个 和 尚 没 ㊌ 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
-(㊂ 个 和 尚 没 水 喝)	saam1|go3|wo4|soeng6|mut6|seoi2|hot3
 (三 百 六 十 行)	saam1|baak3|luk6|sap6|hong4
-(三 百 六 ㊉ 行)	saam1|baak3|luk6|sap6|hong4
-(㊂ 百 六 十 行)	saam1|baak3|luk6|sap6|hong4
-(三 百 ㊅ 十 行)	saam1|baak3|luk6|sap6|hong4
 (三 百 六 十 行)	saam1|baak3|luk6|sap6|hong4
-(三 百 六 ㊉ 行)	saam1|baak3|luk6|sap6|hong4
-(㊂ 百 六 十 行)	saam1|baak3|luk6|sap6|hong4
-(三 百 ㊅ 十 行)	saam1|baak3|luk6|sap6|hong4
 (三 百 六 十 行)	saam1|baak3|luk6|sap6|hong4
-(三 百 六 ㊉ 行)	saam1|baak3|luk6|sap6|hong4
-(㊂ 百 六 十 行)	saam1|baak3|luk6|sap6|hong4
 (三 三 兩 兩)	saam1|saam1|loeng5|loeng5
-(㊂ ㊂ 兩 兩)	saam1|saam1|loeng5|loeng5
 (三 三 兩 兩)	saam1|saam1|loeng5|loeng5
-(㊂ ㊂ 兩 兩)	saam1|saam1|loeng5|loeng5
 (三 三 两 两)	saam1|saam1|loeng5|loeng5
-(㊂ ㊂ 两 两)	saam1|saam1|loeng5|loeng5
 (三 五 成 群)	saam1|ng5|sing4|kwan4
-(㊂ 五 成 群)	saam1|ng5|sing4|kwan4
-(三 ㊄ 成 群)	saam1|ng5|sing4|kwan4
 (三 位 一 體)	saam1|wai6|jat1|tai2
-(㊂ 位 一 體)	saam1|wai6|jat1|tai2
-(三 位 ㊀ 體)	saam1|wai6|jat1|tai2
 (三 位 一 体)	saam1|wai6|jat1|tai2
-(㊂ 位 一 体)	saam1|wai6|jat1|tai2
-(三 位 ㊀ 体)	saam1|wai6|jat1|tai2
 (三 俠 五 義)	saam1|hap6|ng5|ji6
-(㊂ 俠 五 義)	saam1|hap6|ng5|ji6
-(三 俠 ㊄ 義)	saam1|hap6|ng5|ji6
 (三 侠 五 义)	saam1|hap6|ng5|ji6
-(㊂ 侠 五 义)	saam1|hap6|ng5|ji6
-(三 侠 ㊄ 义)	saam1|hap6|ng5|ji6
 (三 催 四 請)	saam1|ceoi1|sei3|cing2
-(㊂ 催 四 請)	saam1|ceoi1|sei3|cing2
-(三 催 ㊃ 請)	saam1|ceoi1|sei3|cing2
 (三 催 四 請)	saam1|ceoi1|sei3|cing2
-(㊂ 催 四 請)	saam1|ceoi1|sei3|cing2
-(三 催 ㊃ 請)	saam1|ceoi1|sei3|cing2
 (三 催 四 请)	saam1|ceoi1|sei3|cing2
-(㊂ 催 四 请)	saam1|ceoi1|sei3|cing2
-(三 催 ㊃ 请)	saam1|ceoi1|sei3|cing2
 (三 分 之 一)	saam1|fan6|zi1|jat1
-(㊂ 分 之 一)	saam1|fan6|zi1|jat1
-(三 分 之 ㊀)	saam1|fan6|zi1|jat1
 (三 心 二 意)	saam1|sam1|ji6|ji3
-(㊂ 心 二 意)	saam1|sam1|ji6|ji3
-(三 心 ㊁ 意)	saam1|sam1|ji6|ji3
 (三 教 九 流)	saam1|gaau3|gau2|lau4
-(三 教 ㊈ 流)	saam1|gaau3|gau2|lau4
-(㊂ 教 九 流)	saam1|gaau3|gau2|lau4
 (三 教 九 流)	saam1|gaau3|gau2|lau4
-(三 教 ㊈ 流)	saam1|gaau3|gau2|lau4
-(㊂ 教 九 流)	saam1|gaau3|gau2|lau4
 (三 教 九 流)	saam1|gaau3|gau2|lau4
-(三 教 ㊈ 流)	saam1|gaau3|gau2|lau4
-(㊂ 教 九 流)	saam1|gaau3|gau2|lau4
 (三 更 半 夜)	saam1|gang1|bun3|je6
-(三 更 半 ㊰)	saam1|gang1|bun3|je6
-(㊂ 更 半 夜)	saam1|gang1|bun3|je6
 (三 更 半 夜)	saam1|gang1|bun3|je6
-(三 更 半 ㊰)	saam1|gang1|bun3|je6
-(㊂ 更 半 夜)	saam1|gang1|bun3|je6
 (三 權 分 立)	saam1|kyun4|fan1|lap6
-(㊂ 權 分 立)	saam1|kyun4|fan1|lap6
 (三 權 分 立)	saam1|kyun4|fan1|lap6
-(㊂ 權 分 立)	saam1|kyun4|fan1|lap6
 (三 权 分 立)	saam1|kyun4|fan1|lap6
-(㊂ 权 分 立)	saam1|kyun4|fan1|lap6
 (三 权 分 立)	saam1|kyun4|fan1|lap6
-(㊂ 权 分 立)	saam1|kyun4|fan1|lap6
 (三 氯 甲 烷)	saam1|luk6|gaap3|jyun2
-(㊂ 氯 甲 烷)	saam1|luk6|gaap3|jyun2
 (三 番 五 次)	saam1|faan1|ng5|ci3
-(㊂ 番 五 次)	saam1|faan1|ng5|ci3
-(三 番 ㊄ 次)	saam1|faan1|ng5|ci3
 (三 皇 五 帝)	saam1|wong4|ng5|dai3
-(㊂ 皇 五 帝)	saam1|wong4|ng5|dai3
-(三 皇 ㊄ 帝)	saam1|wong4|ng5|dai3
 (三 言 兩 語)	saam1|jin4|loeng5|jyu5
-(㊂ 言 兩 語)	saam1|jin4|loeng5|jyu5
 (三 言 兩 語)	saam1|jin4|loeng5|jyu5
-(㊂ 言 兩 語)	saam1|jin4|loeng5|jyu5
 (三 言 两 语)	saam1|jin4|loeng5|jyu5
-(㊂ 言 两 语)	saam1|jin4|loeng5|jyu5
 (三 跪 九 叩)	saam1|gwai6|gau2|kau3
-(三 跪 ㊈ 叩)	saam1|gwai6|gau2|kau3
-(㊂ 跪 九 叩)	saam1|gwai6|gau2|kau3
 (三 長 兩 短)	saam1|coeng4|loeng5|dyun2
-(㊂ 長 兩 短)	saam1|coeng4|loeng5|dyun2
 (三 長 兩 短)	saam1|coeng4|loeng5|dyun2
-(㊂ 長 兩 短)	saam1|coeng4|loeng5|dyun2
 (三 长 两 短)	saam1|coeng4|loeng5|dyun2
-(㊂ 长 两 短)	saam1|coeng4|loeng5|dyun2
 (三 顧 茅 廬)	saam1|gu3|maau4|lou4
-(㊂ 顧 茅 廬)	saam1|gu3|maau4|lou4
 (三 顧 茅 廬)	saam1|gu3|maau4|lou4
-(㊂ 顧 茅 廬)	saam1|gu3|maau4|lou4
 (三 顾 茅 庐)	saam1|gu3|maau4|lou4
-(㊂ 顾 茅 庐)	saam1|gu3|maau4|lou4
 (三 魂 七 魄)	saam1|wan4|cat1|paak3
-(㊂ 魂 七 魄)	saam1|wan4|cat1|paak3
-(三 魂 ㊆ 魄)	saam1|wan4|cat1|paak3
 (三 風 十 愆)	saam1|fung1|sap6|hin1
-(三 風 ㊉ 愆)	saam1|fung1|sap6|hin1
-(㊂ 風 十 愆)	saam1|fung1|sap6|hin1
 (三 风 十 愆)	saam1|fung1|sap6|hin1
-(三 风 ㊉ 愆)	saam1|fung1|sap6|hin1
-(㊂ 风 十 愆)	saam1|fung1|sap6|hin1
 (三 五 好 友)	saam1|ng5|hou2|jau5
-(㊂ 五 好 友)	saam1|ng5|hou2|jau5
-(三 ㊄ 好 友)	saam1|ng5|hou2|jau5
 (三 氯 化 鉍)	saam1|luk6|faa3|bit1
-(㊂ 氯 化 鉍)	saam1|luk6|faa3|bit1
 (三 氯 化 铋)	saam1|luk6|faa3|bit1
-(㊂ 氯 化 铋)	saam1|luk6|faa3|bit1
 (三 山 五 嶽)	saam1|saan1|ng5|ngok6
-(㊂ 山 五 嶽)	saam1|saan1|ng5|ngok6
-(三 山 ㊄ 嶽)	saam1|saan1|ng5|ngok6
 (三 山 五 岳)	saam1|saan1|ng5|ngok6
-(㊂ 山 五 岳)	saam1|saan1|ng5|ngok6
-(三 山 ㊄ 岳)	saam1|saan1|ng5|ngok6
 (三 座 大 山)	saam1|zo6|daai6|saan1
-(㊂ 座 大 山)	saam1|zo6|daai6|saan1
 (三 一 學 院)	saam1|jat1|hok6|jyun2
-(㊂ 一 學 院)	saam1|jat1|hok6|jyun2
-(三 ㊀ 學 院)	saam1|jat1|hok6|jyun2
 (三 一 学 院)	saam1|jat1|hok6|jyun2
-(三 一 ㊫ 院)	saam1|jat1|hok6|jyun2
-(㊂ 一 学 院)	saam1|jat1|hok6|jyun2
-(三 ㊀ 学 院)	saam1|jat1|hok6|jyun2
 (三 不 五 時)	saam1|bat1|ng5|si4
-(㊂ 不 五 時)	saam1|bat1|ng5|si4
-(三 不 ㊄ 時)	saam1|bat1|ng5|si4
 (三 不 五 時)	saam1|bat1|ng5|si4
-(㊂ 不 五 時)	saam1|bat1|ng5|si4
-(三 不 ㊄ 時)	saam1|bat1|ng5|si4
 (三 不 五 时)	saam1|bat1|ng5|si4
-(㊂ 不 五 时)	saam1|bat1|ng5|si4
-(三 不 ㊄ 时)	saam1|bat1|ng5|si4
 (三 不 五 时)	saam1|bat1|ng5|si4
-(㊂ 不 五 时)	saam1|bat1|ng5|si4
-(三 不 ㊄ 时)	saam1|bat1|ng5|si4
 (三 緘 其 口)	saam1|gaam1|kei4|hau2
-(㊂ 緘 其 口)	saam1|gaam1|kei4|hau2
 (三 缄 其 口)	saam1|gaam1|kei4|hau2
-(㊂ 缄 其 口)	saam1|gaam1|kei4|hau2
 (三 斑 家 蚊)	saam1|baan1|gaa1|man1
-(㊂ 斑 家 蚊)	saam1|baan1|gaa1|man1
 (三 閭 大 夫)	saam1|leoi5|daai6|fu1
-(㊂ 閭 大 夫)	saam1|leoi5|daai6|fu1
 (三 閭 大 夫)	saam1|leoi5|daai6|fu1
-(㊂ 閭 大 夫)	saam1|leoi5|daai6|fu1
 (三 闾 大 夫)	saam1|leoi5|daai6|fu1
-(㊂ 闾 大 夫)	saam1|leoi5|daai6|fu1
 (三 足 鼎 立)	saam1|zuk1|ding2|lap6
-(㊂ 足 鼎 立)	saam1|zuk1|ding2|lap6
 (三 足 鼎 立)	saam1|zuk1|ding2|lap6
-(㊂ 足 鼎 立)	saam1|zuk1|ding2|lap6
 (三 請 四 喚)	saam1|cing2|sei3|wun6
-(㊂ 請 四 喚)	saam1|cing2|sei3|wun6
-(三 請 ㊃ 喚)	saam1|cing2|sei3|wun6
 (三 請 四 喚)	saam1|cing2|sei3|wun6
-(㊂ 請 四 喚)	saam1|cing2|sei3|wun6
-(三 請 ㊃ 喚)	saam1|cing2|sei3|wun6
 (三 请 四 唤)	saam1|cing2|sei3|wun6
-(㊂ 请 四 唤)	saam1|cing2|sei3|wun6
-(三 请 ㊃ 唤)	saam1|cing2|sei3|wun6
 (三 番 兩 次)	saam1|faan1|loeng5|ci3
-(㊂ 番 兩 次)	saam1|faan1|loeng5|ci3
 (三 番 兩 次)	saam1|faan1|loeng5|ci3
-(㊂ 番 兩 次)	saam1|faan1|loeng5|ci3
 (三 番 两 次)	saam1|faan1|loeng5|ci3
-(㊂ 番 两 次)	saam1|faan1|loeng5|ci3
 (三 保 太 監)	saam1|bou2|taai3|gaam3
-(三 保 太 ㊬)	saam1|bou2|taai3|gaam3
-(㊂ 保 太 監)	saam1|bou2|taai3|gaam3
 (三 保 太 监)	saam1|bou2|taai3|gaam3
-(㊂ 保 太 监)	saam1|bou2|taai3|gaam3
 (三 令 五 申)	saam1|ling6|ng5|san1
-(㊂ 令 五 申)	saam1|ling6|ng5|san1
-(三 令 ㊄ 申)	saam1|ling6|ng5|san1
 (三 令 五 申)	saam1|ling6|ng5|san1
-(㊂ 令 五 申)	saam1|ling6|ng5|san1
-(三 令 ㊄ 申)	saam1|ling6|ng5|san1
 (三 朝 元 老)	saam1|ciu4|jyun4|lou5
-(㊂ 朝 元 老)	saam1|ciu4|jyun4|lou5
 (三 朝 元 老)	saam1|ciu4|jyun4|lou5
-(㊂ 朝 元 老)	saam1|ciu4|jyun4|lou5
 (三 分 之 二)	saam1|fan6|zi1|ji6
-(㊂ 分 之 二)	saam1|fan6|zi1|ji6
-(三 分 之 ㊁)	saam1|fan6|zi1|ji6
 (三 年 五 載)	saam1|nin4|ng5|zoi2
-(㊂ 年 五 載)	saam1|nin4|ng5|zoi2
-(三 年 ㊄ 載)	saam1|nin4|ng5|zoi2
 (三 年 五 載)	saam1|nin4|ng5|zoi2
-(㊂ 年 五 載)	saam1|nin4|ng5|zoi2
-(三 年 ㊄ 載)	saam1|nin4|ng5|zoi2
 (三 年 五 载)	saam1|nin4|ng5|zoi2
-(㊂ 年 五 载)	saam1|nin4|ng5|zoi2
-(三 年 ㊄ 载)	saam1|nin4|ng5|zoi2
 (三 年 五 载)	saam1|nin4|ng5|zoi2
-(㊂ 年 五 载)	saam1|nin4|ng5|zoi2
-(三 年 ㊄ 载)	saam1|nin4|ng5|zoi2
 (三 妻 四 妾)	saam1|cai1|sei3|cip3
-(㊂ 妻 四 妾)	saam1|cai1|sei3|cip3
-(三 妻 ㊃ 妾)	saam1|cai1|sei3|cip3
 (三 申 五 令)	saam1|san1|ng5|ling6
-(㊂ 申 五 令)	saam1|san1|ng5|ling6
-(三 申 ㊄ 令)	saam1|san1|ng5|ling6
 (三 申 五 令)	saam1|san1|ng5|ling6
-(㊂ 申 五 令)	saam1|san1|ng5|ling6
-(三 申 ㊄ 令)	saam1|san1|ng5|ling6
 (三 不 管)	saam1|bat1|gun2
-(㊂ 不 管)	saam1|bat1|gun2
 (三 不 管)	saam1|bat1|gun2
-(㊂ 不 管)	saam1|bat1|gun2
 (三 叉 戟)	saam1|caa1|gik1
-(㊂ 叉 戟)	saam1|caa1|gik1
 (三 和 弦)	saam1|wo4|jin4
-(㊂ 和 弦)	saam1|wo4|jin4
 (三 岔 口)	saam1|caa1|hau2
-(㊂ 岔 口)	saam1|caa1|hau2
 (三 明 治)	saam1|ming4|zi6
-(㊂ 明 治)	saam1|ming4|zi6
 (三 溫 暖)	saam1|wan1|nyun5
-(㊂ 溫 暖)	saam1|wan1|nyun5
 (三 温 暖)	saam1|wan1|nyun5
-(㊂ 温 暖)	saam1|wan1|nyun5
 (三 稜 鏡)	saam1|ling4|geng3
-(㊂ 稜 鏡)	saam1|ling4|geng3
 (三 稜 鏡)	saam1|ling4|geng3
-(㊂ 稜 鏡)	saam1|ling4|geng3
 (三 棱 镜)	saam1|ling4|geng3
-(㊂ 棱 镜)	saam1|ling4|geng3
 (三 腳 架)	saam1|goek3|gaa2
-(㊂ 腳 架)	saam1|goek3|gaa2
 (三 脚 架)	saam1|goek3|gaa2
-(㊂ 脚 架)	saam1|goek3|gaa2
 (三 葉 蟲)	saam1|jip6|cung4
-(㊂ 葉 蟲)	saam1|jip6|cung4
 (三 葉 蟲)	saam1|jip6|cung4
-(㊂ 葉 蟲)	saam1|jip6|cung4
 (三 叶 虫)	saam1|jip6|cung4
-(㊂ 叶 虫)	saam1|jip6|cung4
 (三 藩 市)	saam1|faan4|si5
-(㊂ 藩 市)	saam1|faan4|si5
 (三 里 屯)	saam7|leoi5|tyun4
-(㊂ 里 屯)	saam7|leoi5|tyun4
 (三 里 屯)	saam7|leoi5|tyun4
-(㊂ 里 屯)	saam7|leoi5|tyun4
 (三 里 河)	saam7|leoi5|ho4
-(㊂ 里 河)	saam7|leoi5|ho4
 (三 里 河)	saam7|leoi5|ho4
-(㊂ 里 河)	saam7|leoi5|ho4
 (三 青 團)	saam1|ceng1|tyun4
-(㊂ 青 團)	saam1|ceng1|tyun4
 (三 青 团)	saam1|ceng1|tyun4
-(㊂ 青 团)	saam1|ceng1|tyun4
 (三 達 德)	saam1|daat6|dak1
-(㊂ 達 德)	saam1|daat6|dak1
 (三 达 德)	saam1|daat6|dak1
-(㊂ 达 德)	saam1|daat6|dak1
 (三 缺 一)	saam1|kyut3|jat1
-(㊂ 缺 一)	saam1|kyut3|jat1
-(三 缺 ㊀)	saam1|kyut3|jat1
 (三 塊 錢)	saam1|faai3|cin4
-(㊂ 塊 錢)	saam1|faai3|cin4
 (三 块 钱)	saam1|faai3|cin4
-(㊂ 块 钱)	saam1|faai3|cin4
 (三 夾 板)	saam1|gaap3|baan2
-(㊂ 夾 板)	saam1|gaap3|baan2
 (三 夹 板)	saam1|gaap3|baan2
-(㊂ 夹 板)	saam1|gaap3|baan2
 (三 不 朽)	saam1|bat1|nau2
-(㊂ 不 朽)	saam1|bat1|nau2
 (三 不 朽)	saam1|bat1|nau2
-(㊂ 不 朽)	saam1|bat1|nau2
 (三 葉 期)	saam1|jip6|kei4
-(㊂ 葉 期)	saam1|jip6|kei4
 (三 葉 期)	saam1|jip6|kei4
-(㊂ 葉 期)	saam1|jip6|kei4
 (三 叶 期)	saam1|jip6|kei4
-(㊂ 叶 期)	saam1|jip6|kei4
 (三 結 合)	saam1|git3|hap6
-(㊂ 結 合)	saam1|git3|hap6
 (三 结 合)	saam1|git3|hap6
-(㊂ 结 合)	saam1|git3|hap6
 (三 棱 錐)	saam1|ling4|zeoi1
-(㊂ 棱 錐)	saam1|ling4|zeoi1
 (三 棱 锥)	saam1|ling4|zeoi1
-(㊂ 棱 锥)	saam1|ling4|zeoi1
 (三 叉 骨)	saam1|caa1|gwat1
-(㊂ 叉 骨)	saam1|caa1|gwat1
 (三 長 制)	saam1|coeng4|zai3
-(㊂ 長 制)	saam1|coeng4|zai3
 (三 长 制)	saam1|coeng4|zai3
-(㊂ 长 制)	saam1|coeng4|zai3
 (三 商 行)	saam1|soeng1|hong4
-(㊂ 商 行)	saam1|soeng1|hong4
 (三 商 行)	saam1|soeng1|hong4
-(㊂ 商 行)	saam1|soeng1|hong4
 (三 棱 鏡)	saam1|ling4|geng3
-(㊂ 棱 鏡)	saam1|ling4|geng3
 (三 壘 手)	saam1|leoi5|sau2
-(㊂ 壘 手)	saam1|leoi5|sau2
 (三 壘 手)	saam1|leoi5|sau2
-(㊂ 壘 手)	saam1|leoi5|sau2
 (三 垒 手)	saam1|leoi5|sau2
-(㊂ 垒 手)	saam1|leoi5|sau2
 (三 春 柳)	saam1|ceon1|lau5
-(㊂ 春 柳)	saam1|ceon1|lau5
 (三 春 柳)	saam1|ceon1|lau5
-(㊂ 春 柳)	saam1|ceon1|lau5
 (三 岔 路)	saam1|caa1|lou6
-(㊂ 岔 路)	saam1|caa1|lou6
 (三 岔 路)	saam1|caa1|lou6
-(㊂ 岔 路)	saam1|caa1|lou6
 (三 重 人)	saam1|cung5|jan4
-(㊂ 重 人)	saam1|cung5|jan4
 (三 專 生)	saam1|zyun1|sang1
-(㊂ 專 生)	saam1|zyun1|sang1
 (三 专 生)	saam1|zyun1|sang1
-(㊂ 专 生)	saam1|zyun1|sang1
 (三 角 錢)	saam1|gok3|cin4
-(㊂ 角 錢)	saam1|gok3|cin4
 (三 角 钱)	saam1|gok3|cin4
-(㊂ 角 钱)	saam1|gok3|cin4
 (三 稜 錐)	saam1|ling4|zeoi1
-(㊂ 稜 錐)	saam1|ling4|zeoi1
 (三 稜 錐)	saam1|ling4|zeoi1
-(㊂ 稜 錐)	saam1|ling4|zeoi1
 (三 稜 锥)	saam1|ling4|zeoi1
-(㊂ 稜 锥)	saam1|ling4|zeoi1
 (三 稜 锥)	saam1|ling4|zeoi1
-(㊂ 稜 锥)	saam1|ling4|zeoi1
 (三 年 生)	saam1|nin4|sang1
-(㊂ 年 生)	saam1|nin4|sang1
 (三 年 生)	saam1|nin4|sang1
-(㊂ 年 生)	saam1|nin4|sang1
 (三 胞 胎)	saam1|baau1|toi1
-(㊂ 胞 胎)	saam1|baau1|toi1
 (三 和 路)	saam1|wo4|lou6
-(㊂ 和 路)	saam1|wo4|lou6
 (三 和 路)	saam1|wo4|lou6
-(㊂ 和 路)	saam1|wo4|lou6
 (三 善 根)	saam1|sin6|gan1
-(㊂ 善 根)	saam1|sin6|gan1
 (三 商 銀)	saam1|soeng1|ngan2
-(㊂ 商 銀)	saam1|soeng1|ngan2
 (三 商 银)	saam1|soeng1|ngan2
-(㊂ 商 银)	saam1|soeng1|ngan2
 (三 劍 客)	saam1|gim3|haak3
-(㊂ 劍 客)	saam1|gim3|haak3
 (三 剑 客)	saam1|gim3|haak3
-(㊂ 剑 客)	saam1|gim3|haak3
 (三 角 架)	saam1|gok3|gaa2
-(㊂ 角 架)	saam1|gok3|gaa2
 (三 元 裡)	saam1|jyun4|lei5
-(㊂ 元 裡)	saam1|jyun4|lei5
 (三 元 裡)	saam1|jyun4|lei5
-(㊂ 元 裡)	saam1|jyun4|lei5
 (三 易 详)	saam7|jik6|coeng4
-(㊂ 易 详)	saam7|jik6|coeng4
 (三 易 详)	saam7|jik6|coeng4
-(㊂ 易 详)	saam7|jik6|coeng4
 (三 易 詳)	saam7|jik6|coeng4
-(㊂ 易 詳)	saam7|jik6|coeng4
 (三 易 詳)	saam7|jik6|coeng4
-(㊂ 易 詳)	saam7|jik6|coeng4
 (三 传 者)	saam7|zyun6|ze2
-(㊂ 传 者)	saam7|zyun6|ze2
 (三 传 者)	saam7|zyun6|ze2
-(㊂ 传 者)	saam7|zyun6|ze2
 (三 传 者)	saam7|zyun6|ze2
-(㊂ 传 者)	saam7|zyun6|ze2
 (三 傳 者)	saam7|zyun6|ze2
-(㊂ 傳 者)	saam7|zyun6|ze2
 (三 傳 者)	saam7|zyun6|ze2
-(㊂ 傳 者)	saam7|zyun6|ze2
 (三 傳 者)	saam7|zyun6|ze2
-(㊂ 傳 者)	saam7|zyun6|ze2
 (三 百 载)	saam1|baak3|zoi2
-(㊂ 百 载)	saam1|baak3|zoi2
 (三 百 載)	saam1|baak3|zoi2
-(㊂ 百 載)	saam1|baak3|zoi2
 (三 世)	saam1|sai3
-(㊂ 世)	saam1|sai3
 (三 代)	saam1|doi6
-(㊂ 代)	saam1|doi6
 (三 伏)	saam1|fuk6
-(㊂ 伏)	saam1|fuk6
 (三 倍)	saam1|pui5
-(㊂ 倍)	saam1|pui5
 (三 八)	saam1|baat3
-(㊂ 八)	saam1|baat3
-(三 ㊇)	saam1|baat3
 (三 十)	saam1|sap6
-(三 ㊉)	saam1|sap6
-(㊂ 十)	saam1|sap6
 (三 原)	saam1|jyun4
-(㊂ 原)	saam1|jyun4
 (三 台)	saam1|toi4
-(㊂ 台)	saam1|toi4
 (三 國)	saam1|gwok3
-(㊂ 國)	saam1|gwok3
 (三 国)	saam1|gwok3
-(㊂ 国)	saam1|gwok3
 (三 寶)	saam1|bou2
-(㊂ 寶)	saam1|bou2
 (三 宝)	saam1|bou2
-(㊂ 宝)	saam1|bou2
 (三 峽)	saam1|haap6
-(㊂ 峽)	saam1|haap6
 (三 峡)	saam1|haap6
-(㊂ 峡)	saam1|haap6
 (三 度)	saam1|dou6
-(㊂ 度)	saam1|dou6
 (三 度)	saam1|dou6
-(㊂ 度)	saam1|dou6
 (三 廢)	saam1|fai3
-(㊂ 廢)	saam1|fai3
 (三 废)	saam1|fai3
-(㊂ 废)	saam1|fai3
 (三 弦)	saam1|jin4
-(㊂ 弦)	saam1|jin4
 (三 星)	saam1|sing1
-(㊂ 星)	saam1|sing1
 (三 更)	saam1|gaang7
-(㊂ 更)	saam1|gaang7
 (三 更)	saam1|gaang7
-(㊂ 更)	saam1|gaang7
 (三 月)	saam1|jyut6
-(三 ㊊)	saam1|jyut6
-(㊂ 月)	saam1|jyut6
 (三 次)	saam1|ci3
-(㊂ 次)	saam1|ci3
 (三 民)	saam1|man4
-(㊂ 民)	saam1|man4
 (三 水)	saam1|seoi2
-(三 ㊌)	saam1|seoi2
-(㊂ 水)	saam1|seoi2
 (三 焦)	saam1|ziu1
-(㊂ 焦)	saam1|ziu1
 (三 級)	saam1|kap1
-(㊂ 級)	saam1|kap1
 (三 级)	saam1|kap1
-(㊂ 级)	saam1|kap1
 (三 維)	saam1|wai4
-(㊂ 維)	saam1|wai4
 (三 维)	saam1|wai4
-(㊂ 维)	saam1|wai4
 (三 義)	saam1|ji6
-(㊂ 義)	saam1|ji6
 (三 义)	saam1|ji6
-(㊂ 义)	saam1|ji6
 (三 色)	saam1|sik1
-(㊂ 色)	saam1|sik1
 (三 芝)	saam1|zi1
-(㊂ 芝)	saam1|zi1
 (三 菱)	saam1|ling4
-(㊂ 菱)	saam1|ling4
 (三 菱)	saam1|ling4
-(㊂ 菱)	saam1|ling4
 (三 藏)	saam1|cong4
-(㊂ 藏)	saam1|cong4
 (三 角)	saam1|gok3
-(㊂ 角)	saam1|gok3
 (三 軍)	saam1|gwan1
-(㊂ 軍)	saam1|gwan1
 (三 军)	saam1|gwan1
-(㊂ 军)	saam1|gwan1
 (三 通)	saam1|tung1
-(㊂ 通)	saam1|tung1
 (三 重)	saam1|cung4
-(㊂ 重)	saam1|cung4
 (三 門)	saam1|mun4
-(㊂ 門)	saam1|mun4
 (三 门)	saam1|mun4
-(㊂ 门)	saam1|mun4
 (三 項)	saam1|hong6
-(三 ㊠)	saam1|hong6
-(㊂ 項)	saam1|hong6
 (三 项)	saam1|hong6
-(㊂ 项)	saam1|hong6
 (三 鮮)	saam1|sin1
-(㊂ 鮮)	saam1|sin1
 (三 鲜)	saam1|sin1
-(㊂ 鲜)	saam1|sin1
 (三 任)	saam1|jam6
-(㊂ 任)	saam1|jam6
 (三 顆)	saam1|fo2
-(㊂ 顆)	saam1|fo2
 (三 颗)	saam1|fo2
-(㊂ 颗)	saam1|fo2
 (三 截)	saam1|zit6
-(㊂ 截)	saam1|zit6
 (三 樓)	saam1|lau4
-(㊂ 樓)	saam1|lau4
 (三 樓)	saam1|lau4
-(㊂ 樓)	saam1|lau4
 (三 楼)	saam1|lau4
-(㊂ 楼)	saam1|lau4
 (三 大)	saam1|daai6
-(㊂ 大)	saam1|daai6
 (三 節)	saam1|zit3
-(㊂ 節)	saam1|zit3
 (三 節)	saam1|zit3
-(㊂ 節)	saam1|zit3
 (三 節)	saam1|zit3
-(㊂ 節)	saam1|zit3
 (三 节)	saam1|zit3
-(㊂ 节)	saam1|zit3
 (三 禮)	saam1|lai5
-(㊂ 禮)	saam1|lai5
 (三 禮)	saam1|lai5
-(㊂ 禮)	saam1|lai5
 (三 礼)	saam1|lai5
-(㊂ 礼)	saam1|lai5
 (三 礼)	saam1|lai5
-(㊂ 礼)	saam1|lai5
 (三 振)	saam1|zan3
-(㊂ 振)	saam1|zan3
 (三 盞)	saam1|zaan2
-(㊂ 盞)	saam1|zaan2
 (三 盏)	saam1|zaan2
-(㊂ 盏)	saam1|zaan2
 (三 員)	saam1|jyun4
-(㊂ 員)	saam1|jyun4
 (三 员)	saam1|jyun4
-(㊂ 员)	saam1|jyun4
 (三 號)	saam1|hou6
-(㊂ 號)	saam1|hou6
 (三 号)	saam1|hou6
-(㊂ 号)	saam1|hou6
 (三 光)	saam1|gwong1
-(㊂ 光)	saam1|gwong1
 (三 課)	saam1|fo3
-(㊂ 課)	saam1|fo3
 (三 课)	saam1|fo3
-(㊂ 课)	saam1|fo3
 (三 時)	saam1|si4
-(㊂ 時)	saam1|si4
 (三 时)	saam1|si4
-(㊂ 时)	saam1|si4
 (三 向)	saam1|hoeng3
-(㊂ 向)	saam1|hoeng3
 (三 乙)	saam1|jyut6
-(㊂ 乙)	saam1|jyut6
 (三 房)	saam1|fong2
-(㊂ 房)	saam1|fong2
 (三 連)	saam1|lin4
-(㊂ 連)	saam1|lin4
 (三 連)	saam1|lin4
-(㊂ 連)	saam1|lin4
 (三 连)	saam1|lin4
-(㊂ 连)	saam1|lin4
 (三 七)	saam1|cat1
-(㊂ 七)	saam1|cat1
-(三 ㊆)	saam1|cat1
 (三 具)	saam1|geoi6
-(㊂ 具)	saam1|geoi6
 (三 行)	saam1|hong4
-(㊂ 行)	saam1|hong4
 (三 行)	saam1|hong4
-(㊂ 行)	saam1|hong4
 (三 支)	saam1|zi1
-(㊂ 支)	saam1|zi1
 (三 復)	saam1|fuk6
-(㊂ 復)	saam1|fuk6
 (三 復)	saam1|fuk6
-(㊂ 復)	saam1|fuk6
 (三 复)	saam1|fuk6
-(㊂ 复)	saam1|fuk6
 (三 場)	saam1|coeng4
-(㊂ 場)	saam1|coeng4
 (三 场)	saam1|coeng4
-(㊂ 场)	saam1|coeng4
 (三 百)	saam1|baak3
-(㊂ 百)	saam1|baak3
 (三 街)	saam1|gaai1
-(㊂ 街)	saam1|gaai1
 (三 碗)	saam1|wun2
-(㊂ 碗)	saam1|wun2
 (三 科)	saam1|fo1
-(㊂ 科)	saam1|fo1
 (三 秋)	saam1|cau1
-(㊂ 秋)	saam1|cau1
 (三 周)	saam1|zau1
-(㊂ 周)	saam1|zau1
 (三 戰)	saam1|zin3
-(㊂ 戰)	saam1|zin3
 (三 战)	saam1|zin3
-(㊂ 战)	saam1|zin3
 (三 生)	saam1|sang1
-(㊂ 生)	saam1|sang1
 (三 綱)	saam1|gong1
-(㊂ 綱)	saam1|gong1
 (三 纲)	saam1|gong1
-(㊂ 纲)	saam1|gong1
 (三 張)	saam1|zoeng1
-(㊂ 張)	saam1|zoeng1
 (三 张)	saam1|zoeng1
-(㊂ 张)	saam1|zoeng1
 (三 輕)	saam1|hing1
-(㊂ 輕)	saam1|hing1
 (三 轻)	saam1|hing1
-(㊂ 轻)	saam1|hing1
 (三 害)	saam1|hoi6
-(㊂ 害)	saam1|hoi6
 (三 正)	saam1|zing1
-(三 ㊣)	saam1|zing1
-(㊂ 正)	saam1|zing1
 (三 師)	saam1|si1
-(㊂ 師)	saam1|si1
 (三 师)	saam1|si1
-(㊂ 师)	saam1|si1
 (三 棵)	saam1|po1
-(㊂ 棵)	saam1|po1
 (三 頭)	saam1|tau4
-(㊂ 頭)	saam1|tau4
 (三 头)	saam1|tau4
-(㊂ 头)	saam1|tau4
 (三 相)	saam1|soeng3
-(㊂ 相)	saam1|soeng3
 (三 層)	saam1|cang4
-(㊂ 層)	saam1|cang4
 (三 層)	saam1|cang4
-(㊂ 層)	saam1|cang4
 (三 层)	saam1|cang4
-(㊂ 层)	saam1|cang4
 (三 樣)	saam1|joeng6
-(㊂ 樣)	saam1|joeng6
 (三 样)	saam1|joeng6
-(㊂ 样)	saam1|joeng6
 (三 週)	saam1|zau1
-(㊂ 週)	saam1|zau1
 (三 步)	saam1|bou6
-(㊂ 步)	saam1|bou6
 (三 瓣)	saam1|faan6
-(㊂ 瓣)	saam1|faan6
 (三 戶)	saam1|wu6
-(㊂ 戶)	saam1|wu6
 (三 户)	saam1|wu6
-(㊂ 户)	saam1|wu6
 (三 版)	saam1|baan2
-(㊂ 版)	saam1|baan2
 (三 寸)	saam1|cyun3
-(㊂ 寸)	saam1|cyun3
 (三 族)	saam1|zuk6
-(㊂ 族)	saam1|zuk6
 (三 晉)	saam1|zeon3
-(㊂ 晉)	saam1|zeon3
 (三 晋)	saam1|zeon3
-(㊂ 晋)	saam1|zeon3
 (三 箱)	saam1|soeng1
-(㊂ 箱)	saam1|soeng1
 (三 點)	saam1|dim2
-(㊂ 點)	saam1|dim2
 (三 点)	saam1|dim2
-(㊂ 点)	saam1|dim2
 (三 孝)	saam1|haau3
-(㊂ 孝)	saam1|haau3
 (三 班)	saam1|baan1
-(㊂ 班)	saam1|baan1
 (三 陽)	saam1|joeng4
-(㊂ 陽)	saam1|joeng4
 (三 阳)	saam1|joeng4
-(㊂ 阳)	saam1|joeng4
 (三 晚)	saam1|maan5
-(㊂ 晚)	saam1|maan5
 (三 公)	saam1|gung1
-(㊂ 公)	saam1|gung1
 (三 聯)	saam1|lyun4
-(㊂ 聯)	saam1|lyun4
 (三 聯)	saam1|lyun4
-(㊂ 聯)	saam1|lyun4
 (三 联)	saam1|lyun4
-(㊂ 联)	saam1|lyun4
 (三 份)	saam1|fan6
-(㊂ 份)	saam1|fan6
 (三 專)	saam1|zyun1
-(㊂ 專)	saam1|zyun1
 (三 专)	saam1|zyun1
-(㊂ 专)	saam1|zyun1
 (三 成)	saam1|sing4
-(㊂ 成)	saam1|sing4
 (三 讀)	saam1|duk6
-(㊂ 讀)	saam1|duk6
 (三 讀)	saam1|duk6
-(㊂ 讀)	saam1|duk6
 (三 读)	saam1|duk6
-(㊂ 读)	saam1|duk6
 (三 章)	saam1|zoeng1
-(㊂ 章)	saam1|zoeng1
 (三 年)	saam1|nin4
-(㊂ 年)	saam1|nin4
 (三 年)	saam1|nin4
-(㊂ 年)	saam1|nin4
 (三 位)	saam1|wai2
-(㊂ 位)	saam1|wai2
 (三 麥)	saam1|mak6
-(㊂ 麥)	saam1|mak6
 (三 麦)	saam1|mak6
-(㊂ 麦)	saam1|mak6
 (三 隻)	saam1|zek3
-(㊂ 隻)	saam1|zek3
 (三 日)	saam1|jat6
-(㊂ 日)	saam1|jat6
-(三 ㊐)	saam1|jat6
 (三 客)	saam1|haak3
-(㊂ 客)	saam1|haak3
 (三 億)	saam1|jik1
-(㊂ 億)	saam1|jik1
 (三 亿)	saam1|jik1
-(㊂ 亿)	saam1|jik1
 (三 腳)	saam1|goek3
-(㊂ 腳)	saam1|goek3
 (三 脚)	saam1|goek3
-(㊂ 脚)	saam1|goek3
 (三 上)	saam1|soeng6
-(三 ㊤)	saam1|soeng6
-(㊂ 上)	saam1|soeng6
 (三 聲)	saam1|sing1
-(㊂ 聲)	saam1|sing1
 (三 声)	saam1|sing1
-(㊂ 声)	saam1|sing1
 (三 鍋)	saam1|wo1
-(㊂ 鍋)	saam1|wo1
 (三 锅)	saam1|wo1
-(㊂ 锅)	saam1|wo1
 (三 缸)	saam1|gong1
-(㊂ 缸)	saam1|gong1
 (三 定)	saam1|ding6
-(㊂ 定)	saam1|ding6
 (三 小)	saam1|siu2
-(㊂ 小)	saam1|siu2
 (三 股)	saam1|gu2
-(㊂ 股)	saam1|gu2
 (三 極)	saam1|gik6
-(㊂ 極)	saam1|gik6
 (三 极)	saam1|gik6
-(㊂ 极)	saam1|gik6
 (三 輪)	saam1|leon4
-(㊂ 輪)	saam1|leon4
 (三 輪)	saam1|leon4
-(㊂ 輪)	saam1|leon4
 (三 轮)	saam1|leon4
-(㊂ 轮)	saam1|leon4
 (三 萬)	saam1|maan6
-(㊂ 萬)	saam1|maan6
 (三 万)	saam1|maan6
-(㊂ 万)	saam1|maan6
 (三 個)	saam1|go3
-(㊂ 個)	saam1|go3
 (三 个)	saam1|go3
-(㊂ 个)	saam1|go3
 (三 頁)	saam1|jip6
-(㊂ 頁)	saam1|jip6
 (三 页)	saam1|jip6
-(㊂ 页)	saam1|jip6
 (三 克)	saam1|hak1
-(㊂ 克)	saam1|hak1
 (三 針)	saam1|zam1
-(㊂ 針)	saam1|zam1
 (三 针)	saam1|zam1
-(㊂ 针)	saam1|zam1
 (三 眼)	saam1|ngaan5
-(㊂ 眼)	saam1|ngaan5
 (三 拍)	saam1|paak3
-(㊂ 拍)	saam1|paak3
 (三 爺)	saam1|je4
-(㊂ 爺)	saam1|je4
 (三 爷)	saam1|je4
-(㊂ 爷)	saam1|je4
 (三 字)	saam1|zi6
-(㊂ 字)	saam1|zi6
 (三 屆)	saam1|gaai3
-(㊂ 屆)	saam1|gaai3
 (三 届)	saam1|gaai3
-(㊂ 届)	saam1|gaai3
 (三 站)	saam1|zaam6
-(㊂ 站)	saam1|zaam6
 (三 九)	saam1|gau2
-(三 ㊈)	saam1|gau2
-(㊂ 九)	saam1|gau2
 (三 丙)	saam1|bing2
-(㊂ 丙)	saam1|bing2
 (三 杯)	saam1|bui1
-(㊂ 杯)	saam1|bui1
 (三 吳)	saam1|ng4
-(㊂ 吳)	saam1|ng4
 (三 吴)	saam1|ng4
-(㊂ 吴)	saam1|ng4
 (三 等)	saam1|dang2
-(㊂ 等)	saam1|dang2
 (三 關)	saam1|gwaan1
-(㊂ 關)	saam1|gwaan1
 (三 关)	saam1|gwaan1
-(㊂ 关)	saam1|gwaan1
 (三 樁)	saam1|zong1
-(㊂ 樁)	saam1|zong1
 (三 桩)	saam1|zong1
-(㊂ 桩)	saam1|zong1
 (三 圓)	saam1|jyun4
-(㊂ 圓)	saam1|jyun4
 (三 圆)	saam1|jyun4
-(㊂ 圆)	saam1|jyun4
 (三 餐)	saam1|caan1
-(㊂ 餐)	saam1|caan1
 (三 排)	saam1|paai4
-(㊂ 排)	saam1|paai4
 (三 智)	saam1|zi3
-(㊂ 智)	saam1|zi3
 (三 夜)	saam1|je6
-(三 ㊰)	saam1|je6
-(㊂ 夜)	saam1|je6
 (三 統)	saam1|tung2
-(㊂ 統)	saam1|tung2
 (三 统)	saam1|tung2
-(㊂ 统)	saam1|tung2
 (三 吋)	saam1|cyun3
-(㊂ 吋)	saam1|cyun3
 (三 堆)	saam1|deoi1
-(㊂ 堆)	saam1|deoi1
 (三 元)	saam1|jyun4
-(㊂ 元)	saam1|jyun4
 (三 集)	saam1|zaap6
-(㊂ 集)	saam1|zaap6
 (三 態)	saam1|taai3
-(㊂ 態)	saam1|taai3
 (三 态)	saam1|taai3
-(㊂ 态)	saam1|taai3
 (三 隊)	saam1|deoi6
-(㊂ 隊)	saam1|deoi6
 (三 队)	saam1|deoi6
-(㊂ 队)	saam1|deoi6
 (三 對)	saam1|deoi3
-(㊂ 對)	saam1|deoi3
 (三 对)	saam1|deoi3
-(㊂ 对)	saam1|deoi3
 (三 合)	saam1|hap6
-(㊂ 合)	saam1|hap6
 (三 歲)	saam1|seoi3
-(㊂ 歲)	saam1|seoi3
 (三 岁)	saam1|seoi3
-(㊂ 岁)	saam1|seoi3
 (三 巷)	saam1|hong6
-(㊂ 巷)	saam1|hong6
 (三 板)	saam1|baan2
-(㊂ 板)	saam1|baan2
 (三 陣)	saam1|zan6
-(㊂ 陣)	saam1|zan6
 (三 阵)	saam1|zan6
-(㊂ 阵)	saam1|zan6
 (三 階)	saam1|gaai1
-(㊂ 階)	saam1|gaai1
 (三 阶)	saam1|gaai1
-(㊂ 阶)	saam1|gaai1
 (三 人)	saam1|jan4
-(㊂ 人)	saam1|jan4
 (三 姓)	saam1|sing3
-(㊂ 姓)	saam1|sing3
 (三 朝)	saam1|ziu1
-(㊂ 朝)	saam1|ziu1
 (三 塊)	saam1|faai3
-(㊂ 塊)	saam1|faai3
 (三 块)	saam1|faai3
-(㊂ 块)	saam1|faai3
 (三 複)	saam1|fuk1
-(㊂ 複)	saam1|fuk1
 (三 總)	saam1|zung2
-(㊂ 總)	saam1|zung2
 (三 总)	saam1|zung2
-(㊂ 总)	saam1|zung2
 (三 同)	saam1|tung4
-(㊂ 同)	saam1|tung4
 (三 流)	saam1|lau4
-(㊂ 流)	saam1|lau4
 (三 流)	saam1|lau4
-(㊂ 流)	saam1|lau4
 (三 流)	saam1|lau4
-(㊂ 流)	saam1|lau4
 (三 袋)	saam1|doi6
-(㊂ 袋)	saam1|doi6
 (三 打)	saam1|daa1
-(㊂ 打)	saam1|daa1
 (三 錢)	saam1|cin4
-(㊂ 錢)	saam1|cin4
 (三 钱)	saam1|cin4
-(㊂ 钱)	saam1|cin4
 (三 伍)	saam1|ng5
-(㊂ 伍)	saam1|ng5
 (三 面)	saam1|min6
-(㊂ 面)	saam1|min6
 (三 老)	saam1|lou5
-(㊂ 老)	saam1|lou5
 (三 老)	saam1|lou5
-(㊂ 老)	saam1|lou5
 (三 信)	saam1|seon3
-(㊂ 信)	saam1|seon3
 (三 部)	saam1|bou6
-(㊂ 部)	saam1|bou6
 (三 天)	saam1|tin1
-(㊂ 天)	saam1|tin1
 (三 槓)	saam1|gung3
-(㊂ 槓)	saam1|gung3
 (三 段)	saam1|dyun6
-(㊂ 段)	saam1|dyun6
 (三 秒)	saam1|miu5
-(㊂ 秒)	saam1|miu5
 (三 枝)	saam1|zi1
-(㊂ 枝)	saam1|zi1
 (三 伯)	saam1|baa3
-(㊂ 伯)	saam1|baa3
 (三 從)	saam1|cung4
-(㊂ 從)	saam1|cung4
 (三 从)	saam1|cung4
-(㊂ 从)	saam1|cung4
 (三 千)	saam1|cin1
-(㊂ 千)	saam1|cin1
 (三 多)	saam1|do1
-(㊂ 多)	saam1|do1
 (三 格)	saam1|gaak3
-(㊂ 格)	saam1|gaak3
 (三 貢)	saam1|gung3
-(㊂ 貢)	saam1|gung3
 (三 贡)	saam1|gung3
-(㊂ 贡)	saam1|gung3
 (三 句)	saam1|geoi3
-(㊂ 句)	saam1|geoi3
 (三 句)	saam1|geoi3
-(㊂ 句)	saam1|geoi3
 (三 季)	saam1|gwai3
-(㊂ 季)	saam1|gwai3
 (三 姑)	saam1|gu1
-(㊂ 姑)	saam1|gu1
 (三 局)	saam1|guk6
-(㊂ 局)	saam1|guk6
 (三 才)	saam1|coi4
-(㊂ 才)	saam1|coi4
 (三 分)	saam1|fan1
-(㊂ 分)	saam1|fan1
 (三 商)	saam1|soeng1
-(㊂ 商)	saam1|soeng1
 (三 思)	saam1|si1
-(㊂ 思)	saam1|si1
 (三 尺)	saam1|cek3
-(㊂ 尺)	saam1|cek3
 (三 式)	saam1|sik1
-(㊂ 式)	saam1|sik1
 (三 仁)	saam1|jan4
-(㊂ 仁)	saam1|jan4
 (三 掌)	saam1|zoeng2
-(㊂ 掌)	saam1|zoeng2
 (三 好)	saam1|hou2
-(㊂ 好)	saam1|hou2
 (三 胎)	saam1|toi1
-(㊂ 胎)	saam1|toi1
 (三 下)	saam1|haa5
-(三 ㊦)	saam1|haa5
-(㊂ 下)	saam1|haa5
 (三 品)	saam1|ban2
-(㊂ 品)	saam1|ban2
 (三 牲)	saam1|sang1
-(㊂ 牲)	saam1|sang1
 (三 方)	saam1|fong1
-(㊂ 方)	saam1|fong1
 (三 法)	saam1|faat3
-(㊂ 法)	saam1|faat3
 (三 只)	saam1|zek3
-(㊂ 只)	saam1|zek3
 (三 哥)	saam1|go1
-(㊂ 哥)	saam1|go1
 (三 盒)	saam1|hap6
-(㊂ 盒)	saam1|hap6
 上	soeng5
 ㊤	soeng5
 (上 氣 不 接 下 氣)	soeng6|hei3|bat1|zip3|haa6|hei3
-(上 氣 不 接 ㊦ 氣)	soeng6|hei3|bat1|zip3|haa6|hei3
-(㊤ 氣 不 接 下 氣)	soeng6|hei3|bat1|zip3|haa6|hei3
 (上 氣 不 接 下 氣)	soeng6|hei3|bat1|zip3|haa6|hei3
-(上 氣 不 接 ㊦ 氣)	soeng6|hei3|bat1|zip3|haa6|hei3
-(㊤ 氣 不 接 下 氣)	soeng6|hei3|bat1|zip3|haa6|hei3
 (上 气 不 接 下 气)	soeng6|hei3|bat1|zip3|haa6|hei3
-(上 气 不 接 ㊦ 气)	soeng6|hei3|bat1|zip3|haa6|hei3
-(㊤ 气 不 接 下 气)	soeng6|hei3|bat1|zip3|haa6|hei3
 (上 气 不 接 下 气)	soeng6|hei3|bat1|zip3|haa6|hei3
-(上 气 不 接 ㊦ 气)	soeng6|hei3|bat1|zip3|haa6|hei3
-(㊤ 气 不 接 下 气)	soeng6|hei3|bat1|zip3|haa6|hei3
 (上 下 班 時 間)	soeng5|haa6|baan1|si4|gaan3
-(上 ㊦ 班 時 間)	soeng5|haa6|baan1|si4|gaan3
-(㊤ 下 班 時 間)	soeng5|haa6|baan1|si4|gaan3
 (上 下 班 时 间)	soeng5|haa6|baan1|si4|gaan3
-(上 ㊦ 班 时 间)	soeng5|haa6|baan1|si4|gaan3
-(㊤ 下 班 时 间)	soeng5|haa6|baan1|si4|gaan3
 (上 升 趨 勢)	soeng5|sing1|ceoi1|sai3
-(㊤ 升 趨 勢)	soeng5|sing1|ceoi1|sai3
 (上 升 趋 势)	soeng5|sing1|ceoi1|sai3
-(㊤ 升 趋 势)	soeng5|sing1|ceoi1|sai3
 (上 半 部 分)	soeng6|bun3|bou6|fan1
-(㊤ 半 部 分)	soeng6|bun3|bou6|fan1
 (上 吐 下 瀉)	soeng6|tou3|haa6|se3
-(上 吐 ㊦ 瀉)	soeng6|tou3|haa6|se3
-(㊤ 吐 下 瀉)	soeng6|tou3|haa6|se3
 (上 吐 下 泻)	soeng6|tou3|haa6|se3
-(上 吐 ㊦ 泻)	soeng6|tou3|haa6|se3
-(㊤ 吐 下 泻)	soeng6|tou3|haa6|se3
 (上 沃 爾 特)	soeng6|juk1|ji5|dak6
-(㊤ 沃 爾 特)	soeng6|juk1|ji5|dak6
-(上 沃 爾 ㊕)	soeng6|juk1|ji5|dak6
 (上 沃 尔 特)	soeng6|juk1|ji5|dak6
-(㊤ 沃 尔 特)	soeng6|juk1|ji5|dak6
-(上 沃 尔 ㊕)	soeng6|juk1|ji5|dak6
 (上 場 比 賽)	soeng6|coeng4|bei2|coi3
-(㊤ 場 比 賽)	soeng6|coeng4|bei2|coi3
 (上 场 比 赛)	soeng6|coeng4|bei2|coi3
-(㊤ 场 比 赛)	soeng6|coeng4|bei2|coi3
 (上 他 的 當)	soeng5|taa1|dik1|dong3
-(㊤ 他 的 當)	soeng5|taa1|dik1|dong3
 (上 他 的 当)	soeng5|taa1|dik1|dong3
-(㊤ 他 的 当)	soeng5|taa1|dik1|dong3
 (上 上 下 下)	soeng6|soeng6|haa6|haa6
-(上 上 ㊦ ㊦)	soeng6|soeng6|haa6|haa6
-(㊤ ㊤ 下 下)	soeng6|soeng6|haa6|haa6
 (上 天 無 路)	soeng5|tin1|mou4|lou6
-(㊤ 天 無 路)	soeng5|tin1|mou4|lou6
 (上 天 無 路)	soeng5|tin1|mou4|lou6
-(㊤ 天 無 路)	soeng5|tin1|mou4|lou6
 (上 天 无 路)	soeng5|tin1|mou4|lou6
-(㊤ 天 无 路)	soeng5|tin1|mou4|lou6
 (上 天 无 路)	soeng5|tin1|mou4|lou6
-(㊤ 天 无 路)	soeng5|tin1|mou4|lou6
 (上 中 下 遊)	soeng6|zung1|haa6|jau4
-(上 🀄 下 遊)	soeng6|zung1|haa6|jau4
-(上 中 ㊦ 遊)	soeng6|zung1|haa6|jau4
-(上 🀄 ㊦ 遊)	soeng6|zung1|haa6|jau4
-(㊤ 中 下 遊)	soeng6|zung1|haa6|jau4
-(㊤ 🀄 下 遊)	soeng6|zung1|haa6|jau4
-(上 ㊥ 下 遊)	soeng6|zung1|haa6|jau4
 (上 中 下 游)	soeng6|zung1|haa6|jau4
-(上 🀄 下 游)	soeng6|zung1|haa6|jau4
-(上 中 ㊦ 游)	soeng6|zung1|haa6|jau4
-(上 🀄 ㊦ 游)	soeng6|zung1|haa6|jau4
-(㊤ 中 下 游)	soeng6|zung1|haa6|jau4
-(㊤ 🀄 下 游)	soeng6|zung1|haa6|jau4
-(上 ㊥ 下 游)	soeng6|zung1|haa6|jau4
 (上 個 世 紀)	soeng6|go3|sai5|gei5
-(㊤ 個 世 紀)	soeng6|go3|sai5|gei5
 (上 个 世 纪)	soeng6|go3|sai5|gei5
-(㊤ 个 世 纪)	soeng6|go3|sai5|gei5
 (上 她 的 當)	soeng5|taa1|dik1|dong3
-(㊤ 她 的 當)	soeng5|taa1|dik1|dong3
 (上 她 的 当)	soeng5|taa1|dik1|dong3
-(㊤ 她 的 当)	soeng5|taa1|dik1|dong3
 (上 片 時 間)	soeng6|pin3|si4|gaan1
-(㊤ 片 時 間)	soeng6|pin3|si4|gaan1
 (上 片 时 间)	soeng6|pin3|si4|gaan1
-(㊤ 片 时 间)	soeng6|pin3|si4|gaan1
 (上 情 下 達)	soeng6|cing4|haa6|daat6
-(上 情 ㊦ 達)	soeng6|cing4|haa6|daat6
-(㊤ 情 下 達)	soeng6|cing4|haa6|daat6
 (上 情 下 达)	soeng6|cing4|haa6|daat6
-(上 情 ㊦ 达)	soeng6|cing4|haa6|daat6
-(㊤ 情 下 达)	soeng6|cing4|haa6|daat6
 (上 體 育 課)	soeng5|tai5|juk6|fo3
-(㊤ 體 育 課)	soeng5|tai5|juk6|fo3
 (上 体 育 课)	soeng5|tai5|juk6|fo3
-(㊤ 体 育 课)	soeng5|tai5|juk6|fo3
 (上 一 個)	soeng6|jat1|go3
-(㊤ 一 個)	soeng6|jat1|go3
-(上 ㊀ 個)	soeng6|jat1|go3
 (上 一 个)	soeng6|jat1|go3
-(㊤ 一 个)	soeng6|jat1|go3
-(上 ㊀ 个)	soeng6|jat1|go3
 (上 下 班)	soeng5|haa6|baan1
-(上 ㊦ 班)	soeng5|haa6|baan1
-(㊤ 下 班)	soeng5|haa6|baan1
 (上 星 期)	soeng6|sing1|kei4
-(㊤ 星 期)	soeng6|sing1|kei4
 (上 海 話)	soeng6|hoi2|waa2
-(㊤ 海 話)	soeng6|hoi2|waa2
 (上 海 話)	soeng6|hoi2|waa2
-(㊤ 海 話)	soeng6|hoi2|waa2
 (上 海 话)	soeng6|hoi2|waa2
-(㊤ 海 话)	soeng6|hoi2|waa2
 (上 海 话)	soeng6|hoi2|waa2
-(㊤ 海 话)	soeng6|hoi2|waa2
 (上 等 兵)	soeng6|dang2|bing1
-(㊤ 等 兵)	soeng6|dang2|bing1
 (上 議 院)	soeng6|ji5|jyun2
-(㊤ 議 院)	soeng6|ji5|jyun2
 (上 议 院)	soeng6|ji5|jyun2
-(㊤ 议 院)	soeng6|ji5|jyun2
 (上 軌 道)	soeng6|gwai2|dou3
-(㊤ 軌 道)	soeng6|gwai2|dou3
 (上 轨 道)	soeng6|gwai2|dou3
-(㊤ 轨 道)	soeng6|gwai2|dou3
 (上 輩 子)	soeng6|bui3|zi2
-(㊤ 輩 子)	soeng6|bui3|zi2
 (上 辈 子)	soeng6|bui3|zi2
-(㊤ 辈 子)	soeng6|bui3|zi2
 (上 進 心)	soeng5|zeon3|sam1
-(㊤ 進 心)	soeng5|zeon3|sam1
 (上 进 心)	soeng5|zeon3|sam1
-(㊤ 进 心)	soeng5|zeon3|sam1
 (上 意 識)	soeng6|ji3|sik1
-(㊤ 意 識)	soeng6|ji3|sik1
 (上 意 識)	soeng6|ji3|sik1
-(㊤ 意 識)	soeng6|ji3|sik1
 (上 意 识)	soeng6|ji3|sik1
-(㊤ 意 识)	soeng6|ji3|sik1
 (上 大 學)	soeng6|daai6|hok6
-(㊤ 大 學)	soeng6|daai6|hok6
 (上 大 学)	soeng6|daai6|hok6
-(上 大 ㊫)	soeng6|daai6|hok6
-(㊤ 大 学)	soeng6|daai6|hok6
 (上 等 貨)	soeng6|dang2|fo3
-(㊤ 等 貨)	soeng6|dang2|fo3
 (上 等 货)	soeng6|dang2|fo3
-(㊤ 等 货)	soeng6|dang2|fo3
 (上 帝 教)	soeng6|dai3|gaau1
-(㊤ 帝 教)	soeng6|dai3|gaau1
 (上 水 船)	soeng5|seoi2|syun4
-(㊤ 水 船)	soeng5|seoi2|syun4
-(上 ㊌ 船)	soeng5|seoi2|syun4
 (上 一 代)	soeng6|jat1|doi6
-(㊤ 一 代)	soeng6|jat1|doi6
-(上 ㊀ 代)	soeng6|jat1|doi6
 (上 書 房)	soeng6|syu1|fong2
-(㊤ 書 房)	soeng6|syu1|fong2
 (上 书 房)	soeng6|syu1|fong2
-(㊤ 书 房)	soeng6|syu1|fong2
 (上 坡 道)	soeng6|bo1|dou3
-(㊤ 坡 道)	soeng6|bo1|dou3
 (上 中 農)	soeng6|zung1|nung4
-(上 🀄 農)	soeng6|zung1|nung4
-(㊤ 中 農)	soeng6|zung1|nung4
-(㊤ 🀄 農)	soeng6|zung1|nung4
-(上 ㊥ 農)	soeng6|zung1|nung4
 (上 中 农)	soeng6|zung1|nung4
-(上 🀄 农)	soeng6|zung1|nung4
-(㊤ 中 农)	soeng6|zung1|nung4
-(㊤ 🀄 农)	soeng6|zung1|nung4
-(上 ㊥ 农)	soeng6|zung1|nung4
 (上 中 旬)	soeng6|zung7|ceon4
-(上 🀄 旬)	soeng6|zung7|ceon4
-(㊤ 中 旬)	soeng6|zung7|ceon4
-(㊤ 🀄 旬)	soeng6|zung7|ceon4
-(上 ㊥ 旬)	soeng6|zung7|ceon4
 (上 眼 皮)	soeng6|ngaan5|pei4
-(㊤ 眼 皮)	soeng6|ngaan5|pei4
 (上 狗 式)	soeng6|gau2|sik1
-(㊤ 狗 式)	soeng6|gau2|sik1
 (上 下)	soeng6|haa6
-(上 ㊦)	soeng6|haa6
-(㊤ 下)	soeng6|haa6
 (上 交)	soeng6|gaau1
-(㊤ 交)	soeng6|gaau1
 (上 代)	soeng6|doi6
-(㊤ 代)	soeng6|doi6
 (上 任)	soeng6|jam6
-(㊤ 任)	soeng6|jam6
 (上 個)	soeng6|go3
-(㊤ 個)	soeng6|go3
 (上 个)	soeng6|go3
-(㊤ 个)	soeng6|go3
 (上 午)	soeng6|ng5
-(㊤ 午)	soeng6|ng5
 (上 半)	soeng6|bun3
-(㊤ 半)	soeng6|bun3
 (上 古)	soeng6|gu2
-(㊤ 古)	soeng6|gu2
 (上 司)	soeng6|si1
-(㊤ 司)	soeng6|si1
 (上 周)	soeng6|zau1
-(㊤ 周)	soeng6|zau1
 (上 回)	soeng6|wui4
-(㊤ 回)	soeng6|wui4
 (上 坡)	soeng6|bo1
-(㊤ 坡)	soeng6|bo1
 (上 報)	soeng6|bou3
-(㊤ 報)	soeng6|bou3
 (上 报)	soeng6|bou3
-(㊤ 报)	soeng6|bou3
 (上 夜)	soeng6|je6
-(㊤ 夜)	soeng6|je6
-(上 ㊰)	soeng6|je6
 (上 天)	soeng6|tin1
-(㊤ 天)	soeng6|tin1
 (上 家)	soeng6|gaa1
-(㊤ 家)	soeng6|gaa1
 (上 將)	soeng6|zoeng3
-(㊤ 將)	soeng6|zoeng3
 (上 将)	soeng6|zoeng3
-(㊤ 将)	soeng6|zoeng3
 (上 尉)	soeng6|wai3
-(㊤ 尉)	soeng6|wai3
 (上 層)	soeng6|cang4
-(㊤ 層)	soeng6|cang4
 (上 層)	soeng6|cang4
-(㊤ 層)	soeng6|cang4
 (上 层)	soeng6|cang4
-(㊤ 层)	soeng6|cang4
 (上 帝)	soeng6|dai3
-(㊤ 帝)	soeng6|dai3
 (上 弦)	soeng6|jin4
-(㊤ 弦)	soeng6|jin4
 (上 思)	soeng6|si1
-(㊤ 思)	soeng6|si1
 (上 房)	soeng6|fong2
-(㊤ 房)	soeng6|fong2
 (上 揚)	soeng6|joeng4
-(㊤ 揚)	soeng6|joeng4
 (上 扬)	soeng6|joeng4
-(㊤ 扬)	soeng6|joeng4
 (上 旬)	soeng6|ceon4
-(㊤ 旬)	soeng6|ceon4
 (上 昇)	soeng6|sing1
-(㊤ 昇)	soeng6|sing1
 (上 升)	soeng6|sing1
-(㊤ 升)	soeng6|sing1
 (上 書)	soeng6|syu1
-(㊤ 書)	soeng6|syu1
 (上 书)	soeng6|syu1
-(㊤ 书)	soeng6|syu1
 (上 杭)	soeng6|hong4
-(㊤ 杭)	soeng6|hong4
 (上 林)	soeng6|lam4
-(㊤ 林)	soeng6|lam4
 (上 林)	soeng6|lam4
-(㊤ 林)	soeng6|lam4
 (上 校)	soeng6|gaau3
-(㊤ 校)	soeng6|gaau3
 (上 次)	soeng6|ci3
-(㊤ 次)	soeng6|ci3
 (上 款)	soeng6|fun2
-(㊤ 款)	soeng6|fun2
 (上 水)	soeng6|seoi2
-(㊤ 水)	soeng6|seoi2
-(上 ㊌)	soeng6|seoi2
 (上 流)	soeng6|lau4
-(㊤ 流)	soeng6|lau4
 (上 流)	soeng6|lau4
-(㊤ 流)	soeng6|lau4
 (上 流)	soeng6|lau4
-(㊤ 流)	soeng6|lau4
 (上 海)	soeng6|hoi2
-(㊤ 海)	soeng6|hoi2
 (上 海)	soeng6|hoi2
-(㊤ 海)	soeng6|hoi2
 (上 游)	soeng6|jau4
-(㊤ 游)	soeng6|jau4
 (上 漲)	soeng6|zoeng3
-(㊤ 漲)	soeng6|zoeng3
 (上 涨)	soeng6|zoeng3
-(㊤ 涨)	soeng6|zoeng3
 (上 當)	soeng5|dong3
-(㊤ 當)	soeng5|dong3
 (上 当)	soeng5|dong3
-(㊤ 当)	soeng5|dong3
 (上 疏)	soeng6|so1
-(㊤ 疏)	soeng6|so1
 (上 皮)	soeng6|pei4
-(㊤ 皮)	soeng6|pei4
 (上 空)	soeng6|hung1
-(㊤ 空)	soeng6|hung1
 (上 等)	soeng6|deng2
-(㊤ 等)	soeng6|deng2
 (上 級)	soeng6|kap1
-(㊤ 級)	soeng6|kap1
 (上 级)	soeng6|kap1
-(㊤ 级)	soeng6|kap1
 (上 聲)	soeng6|sing1
-(㊤ 聲)	soeng6|sing1
 (上 声)	soeng6|sing1
-(㊤ 声)	soeng6|sing1
 (上 肢)	soeng6|zi1
-(㊤ 肢)	soeng6|zi1
 (上 膛)	soeng6|tong4
-(㊤ 膛)	soeng6|tong4
 (上 蒼)	soeng6|cong1
-(㊤ 蒼)	soeng6|cong1
 (上 苍)	soeng6|cong1
-(㊤ 苍)	soeng6|cong1
 (上 行)	soeng6|hang4
-(㊤ 行)	soeng6|hang4
 (上 行)	soeng6|hang4
-(㊤ 行)	soeng6|hang4
 (上 衣)	soeng6|ji1
-(㊤ 衣)	soeng6|ji1
 (上 裝)	soeng6|zong1
-(㊤ 裝)	soeng6|zong1
 (上 装)	soeng6|zong1
-(㊤ 装)	soeng6|zong1
 (上 訪)	soeng6|fong2
-(㊤ 訪)	soeng6|fong2
 (上 访)	soeng6|fong2
-(㊤ 访)	soeng6|fong2
 (上 訴)	soeng6|sou3
-(㊤ 訴)	soeng6|sou3
 (上 诉)	soeng6|sou3
-(㊤ 诉)	soeng6|sou3
 (上 諭)	soeng6|jyu6
-(㊤ 諭)	soeng6|jyu6
 (上 諭)	soeng6|jyu6
-(㊤ 諭)	soeng6|jyu6
 (上 谕)	soeng6|jyu6
-(㊤ 谕)	soeng6|jyu6
 (上 載)	soeng6|zoi3
-(㊤ 載)	soeng6|zoi3
 (上 载)	soeng6|zoi3
-(㊤ 载)	soeng6|zoi3
 (上 農)	soeng6|nung4
-(㊤ 農)	soeng6|nung4
 (上 农)	soeng6|nung4
-(㊤ 农)	soeng6|nung4
 (上 述)	soeng6|seot6
-(㊤ 述)	soeng6|seot6
 (上 進)	soeng6|zeon3
-(㊤ 進)	soeng6|zeon3
 (上 进)	soeng6|zeon3
-(㊤ 进)	soeng6|zeon3
 (上 邊)	soeng6|bin1
-(㊤ 邊)	soeng6|bin1
 (上 边)	soeng6|bin1
-(㊤ 边)	soeng6|bin1
 (上 部)	soeng6|bou6
-(㊤ 部)	soeng6|bou6
 (上 限)	soeng6|haan6
-(㊤ 限)	soeng6|haan6
 (上 面)	soeng6|min6
-(㊤ 面)	soeng6|min6
 (上 頁)	soeng6|jip6
-(㊤ 頁)	soeng6|jip6
 (上 页)	soeng6|jip6
-(㊤ 页)	soeng6|jip6
 (上 頜)	soeng6|hap6
-(㊤ 頜)	soeng6|hap6
 (上 颌)	soeng6|hap6
-(㊤ 颌)	soeng6|hap6
 (上 風)	soeng6|fung1
-(㊤ 風)	soeng6|fung1
 (上 风)	soeng6|fung1
-(㊤ 风)	soeng6|fung1
 (上 冊)	soeng6|caak3
-(㊤ 冊)	soeng6|caak3
 (上 册)	soeng6|caak3
-(㊤ 册)	soeng6|caak3
 (上 言)	soeng6|jin4
-(㊤ 言)	soeng6|jin4
 (上 京)	soeng6|ging1
-(㊤ 京)	soeng6|ging1
 (上 略)	soeng6|loek6
-(㊤ 略)	soeng6|loek6
 (上 略)	soeng6|loek6
-(㊤ 略)	soeng6|loek6
 (上 達)	soeng6|daat6
-(㊤ 達)	soeng6|daat6
 (上 达)	soeng6|daat6
-(㊤ 达)	soeng6|daat6
 (上 緣)	soeng6|jyun4
-(㊤ 緣)	soeng6|jyun4
 (上 缘)	soeng6|jyun4
-(㊤ 缘)	soeng6|jyun4
 (上 駟)	soeng6|si3
-(㊤ 駟)	soeng6|si3
 (上 驷)	soeng6|si3
-(㊤ 驷)	soeng6|si3
 (上 屆)	soeng6|gaai3
-(㊤ 屆)	soeng6|gaai3
 (上 届)	soeng6|gaai3
-(㊤ 届)	soeng6|gaai3
 (上 知)	soeng6|zi1
-(㊤ 知)	soeng6|zi1
 (上 檔)	soeng5|dong2
-(㊤ 檔)	soeng5|dong2
 (上 档)	soeng5|dong2
-(㊤ 档)	soeng5|dong2
 (上 黨)	soeng6|dong2
-(㊤ 黨)	soeng6|dong2
 (上 党)	soeng6|dong2
-(㊤ 党)	soeng6|dong2
 (上 過)	soeng6|gwo3
-(㊤ 過)	soeng6|gwo3
 (上 过)	soeng6|gwo3
-(㊤ 过)	soeng6|gwo3
 (上 舖)	soeng6|pou3
-(㊤ 舖)	soeng6|pou3
 (上 朔)	soeng6|sok3
-(㊤ 朔)	soeng6|sok3
 (上 漿)	soeng6|zoeng1
-(㊤ 漿)	soeng6|zoeng1
 (上 浆)	soeng6|zoeng1
-(㊤ 浆)	soeng6|zoeng1
 (上 之)	soeng6|zi1
-(㊤ 之)	soeng6|zi1
 (上 官)	soeng6|gun1
-(㊤ 官)	soeng6|gun1
 (上 聯)	soeng6|lyun4
-(㊤ 聯)	soeng6|lyun4
 (上 聯)	soeng6|lyun4
-(㊤ 聯)	soeng6|lyun4
 (上 联)	soeng6|lyun4
-(㊤ 联)	soeng6|lyun4
 (上 鋪)	soeng6|pou1
-(㊤ 鋪)	soeng6|pou1
 (上 铺)	soeng6|pou1
-(㊤ 铺)	soeng6|pou1
 (上 臂)	soeng6|bei3
-(㊤ 臂)	soeng6|bei3
 (上 顎)	soeng6|ngok6
-(㊤ 顎)	soeng6|ngok6
 (上 颚)	soeng6|ngok6
-(㊤ 颚)	soeng6|ngok6
 (上 起)	soeng6|hei2
-(㊤ 起)	soeng6|hei2
 (上 葉)	soeng6|jip6
-(㊤ 葉)	soeng6|jip6
 (上 葉)	soeng6|jip6
-(㊤ 葉)	soeng6|jip6
 (上 叶)	soeng6|jip6
-(㊤ 叶)	soeng6|jip6
 (上 有)	soeng6|jau5
-(㊤ 有)	soeng6|jau5
-(上 ㊒)	soeng6|jau5
 (上 站)	soeng6|zaam6
-(㊤ 站)	soeng6|zaam6
 (上 士)	soeng6|si6
-(㊤ 士)	soeng6|si6
 (上 端)	soeng6|dyun1
-(㊤ 端)	soeng6|dyun1
 (上 座)	soeng6|zo6
-(㊤ 座)	soeng6|zo6
 (上 湯)	soeng6|tong1
-(㊤ 湯)	soeng6|tong1
 (上 汤)	soeng6|tong1
-(㊤ 汤)	soeng6|tong1
 (上 著)	soeng6|zyu3
-(㊤ 著)	soeng6|zyu3
 (上 著)	soeng6|zyu3
-(㊤ 著)	soeng6|zyu3
 (上 着)	soeng6|zyu3
-(㊤ 着)	soeng6|zyu3
 (上 着)	soeng6|zyu3
-(㊤ 着)	soeng6|zyu3
 (上 坐)	soeng6|zo6
-(㊤ 坐)	soeng6|zo6
 (上 潮)	soeng6|ciu4
-(㊤ 潮)	soeng6|ciu4
 (上 桌)	soeng6|coek3
-(㊤ 桌)	soeng6|coek3
 (上 週)	soeng6|zau1
-(㊤ 週)	soeng6|zau1
 (上 明)	soeng6|ming4
-(㊤ 明)	soeng6|ming4
 (上 賓)	soeng6|ban1
-(㊤ 賓)	soeng6|ban1
 (上 賓)	soeng6|ban1
-(㊤ 賓)	soeng6|ban1
 (上 宾)	soeng6|ban1
-(㊤ 宾)	soeng6|ban1
 (上 釉)	soeng6|jau6
-(㊤ 釉)	soeng6|jau6
 (上 乘)	soeng6|sing6
-(㊤ 乘)	soeng6|sing6
 (上 架)	soeng5|gaa2
-(㊤ 架)	soeng5|gaa2
 (上 肥)	soeng6|fei4
-(㊤ 肥)	soeng6|fei4
 (上 石)	soeng6|sek6
-(㊤ 石)	soeng6|sek6
 (上 到)	soeng6|dou3
-(㊤ 到)	soeng6|dou3
 (上 排)	soeng6|paai4
-(㊤ 排)	soeng6|paai4
 (上 計)	soeng6|gai3
-(㊤ 計)	soeng6|gai3
 (上 计)	soeng6|gai3
-(㊤ 计)	soeng6|gai3
 (上 舉)	soeng6|geoi2
-(㊤ 舉)	soeng6|geoi2
 (上 举)	soeng6|geoi2
-(㊤ 举)	soeng6|geoi2
 (上 策)	soeng6|caak3
-(㊤ 策)	soeng6|caak3
 (上 刑)	soeng6|jing4
-(㊤ 刑)	soeng6|jing4
 (上 算)	soeng6|syun3
-(㊤ 算)	soeng6|syun3
 (上 光)	soeng6|gwong1
-(㊤ 光)	soeng6|gwong1
 (上 好)	soeng6|hou2
-(㊤ 好)	soeng6|hou2
 (上 溯)	soeng6|sou3
-(㊤ 溯)	soeng6|sou3
 (上 圈)	soeng6|hyun1
-(㊤ 圈)	soeng6|hyun1
 (上 段)	soeng6|dyun6
-(㊤ 段)	soeng6|dyun6
 (上 的)	soeng6|dik1
-(㊤ 的)	soeng6|dik1
 (上 盤)	soeng6|pun4
-(㊤ 盤)	soeng6|pun4
 (上 盘)	soeng6|pun4
-(㊤ 盘)	soeng6|pun4
 (上 簽)	soeng6|cim1
-(㊤ 簽)	soeng6|cim1
 (上 签)	soeng6|cim1
-(㊤ 签)	soeng6|cim1
 (上 人)	soeng6|jan4
-(㊤ 人)	soeng6|jan4
 (上 移)	soeng6|ji4
-(㊤ 移)	soeng6|ji4
 (上 智)	soeng6|zi3
-(㊤ 智)	soeng6|zi3
 (上 籤)	soeng6|cim1
-(㊤ 籤)	soeng6|cim1
 (上 首)	soeng6|sau2
-(㊤ 首)	soeng6|sau2
 (上 道)	soeng6|dou3
-(㊤ 道)	soeng6|dou3
 (上 品)	soeng6|ban2
-(㊤ 品)	soeng6|ban2
 (上 客)	soeng6|haak3
-(㊤ 客)	soeng6|haak3
 (上 梁)	soeng6|loeng4
-(㊤ 梁)	soeng6|loeng4
 (上 梁)	soeng6|loeng4
-(㊤ 梁)	soeng6|loeng4
 (上 至)	soeng6|zi3
-(㊤ 至)	soeng6|zi3
 (上 上)	soeng6|soeng6
-(㊤ ㊤)	soeng6|soeng6
 (上 章)	soeng6|zoeng1
-(㊤ 章)	soeng6|zoeng1
 (上 旋)	soeng6|syun4
-(㊤ 旋)	soeng6|syun4
 (上 址)	soeng6|zi2
-(㊤ 址)	soeng6|zi2
 (上 告)	soeng6|gou3
-(㊤ 告)	soeng6|gou3
 (上 供)	soeng6|gung1
-(㊤ 供)	soeng6|gung1
 (上 清)	soeng6|cing1
-(㊤ 清)	soeng6|cing1
 (上 邦)	soeng6|bong1
-(㊤ 邦)	soeng6|bong1
 (上 集)	soeng6|zaap6
-(㊤ 集)	soeng6|zaap6
 (上 日)	soeng6|jat6
-(㊤ 日)	soeng6|jat6
-(上 ㊐)	soeng6|jat6
 (上 方)	soeng6|fong1
-(㊤ 方)	soeng6|fong1
 (上 體)	soeng6|tai2
-(㊤ 體)	soeng6|tai2
 (上 体)	soeng6|tai2
-(㊤ 体)	soeng6|tai2
 (上 年)	soeng6|nin4
-(㊤ 年)	soeng6|nin4
 (上 年)	soeng6|nin4
-(㊤ 年)	soeng6|nin4
 (上 樑)	soeng6|loeng4
-(㊤ 樑)	soeng6|loeng4
 (上 列)	soeng6|lit6
-(㊤ 列)	soeng6|lit6
 (上 列)	soeng6|lit6
-(㊤ 列)	soeng6|lit6
 (上 屈)	soeng6|wat1
-(㊤ 屈)	soeng6|wat1
 (上 油)	soeng6|jau4
-(㊤ 油)	soeng6|jau4
 (上 主)	soeng6|zyu2
-(㊤ 主)	soeng6|zyu2
 (上 奏)	soeng6|zau3
-(㊤ 奏)	soeng6|zau3
 (上 接)	soeng6|zip3
-(㊤ 接)	soeng6|zip3
 (上 兵)	soeng6|bing1
-(㊤ 兵)	soeng6|bing1
 (上 片)	soeng6|pin3
-(㊤ 片)	soeng6|pin3
 (上 相)	soeng6|soeng3
-(㊤ 相)	soeng6|soeng3
 (上 元)	soeng6|jyun4
-(㊤ 元)	soeng6|jyun4
 (上 世)	soeng6|sai3
-(㊤ 世)	soeng6|sai3
 (上 金)	soeng6|gam1
-(㊤ 金)	soeng6|gam1
-(上 ㊎)	soeng6|gam1
 (上 金)	soeng6|gam1
-(㊤ 金)	soeng6|gam1
 下	haa6
 ㊦	haa6
 (下 不 為 例)	haa5|bat1|wai4|lai6
-(㊦ 不 為 例)	haa5|bat1|wai4|lai6
 (下 不 為 例)	haa5|bat1|wai4|lai6
-(㊦ 不 為 例)	haa5|bat1|wai4|lai6
 (下 不 為 例)	haa5|bat1|wai4|lai6
-(㊦ 不 為 例)	haa5|bat1|wai4|lai6
 (下 不 为 例)	haa5|bat1|wai4|lai6
-(㊦ 不 为 例)	haa5|bat1|wai4|lai6
 (下 不 为 例)	haa5|bat1|wai4|lai6
-(㊦ 不 为 例)	haa5|bat1|wai4|lai6
 (下 不 为 例)	haa5|bat1|wai4|lai6
-(㊦ 不 为 例)	haa5|bat1|wai4|lai6
 (下 巴 輕 輕)	haa6|paa4|heng1|heng1
-(㊦ 巴 輕 輕)	haa6|paa4|heng1|heng1
 (下 巴 轻 轻)	haa6|paa4|heng1|heng1
-(㊦ 巴 轻 轻)	haa6|paa4|heng1|heng1
 (下 一 代)	haa5|jat1|doi6
-(㊦ 一 代)	haa5|jat1|doi6
-(下 ㊀ 代)	haa5|jat1|doi6
 (下 巴 頰)	haa5|baa1|haap3
-(㊦ 巴 頰)	haa5|baa1|haap3
 (下 巴 颊)	haa5|baa1|haap3
-(㊦ 巴 颊)	haa5|baa1|haap3
 (下 顎 骨)	haa6|ngok6|gwat1
-(㊦ 顎 骨)	haa6|ngok6|gwat1
 (下 颚 骨)	haa6|ngok6|gwat1
-(㊦ 颚 骨)	haa6|ngok6|gwat1
 (下 巴 顆)	haa5|baa1|fo2
-(㊦ 巴 顆)	haa5|baa1|fo2
 (下 巴 颗)	haa5|baa1|fo2
-(㊦ 巴 颗)	haa5|baa1|fo2
 (下 著 雪)	haa6|zoek3|syut3
-(㊦ 著 雪)	haa6|zoek3|syut3
 (下 著 雪)	haa6|zoek3|syut3
-(㊦ 著 雪)	haa6|zoek3|syut3
 (下 着 雪)	haa6|zoek3|syut3
-(㊦ 着 雪)	haa6|zoek3|syut3
 (下 着 雪)	haa6|zoek3|syut3
-(㊦ 着 雪)	haa6|zoek3|syut3
 (下 廚 房)	haa6|cyu4|fong2
-(㊦ 廚 房)	haa6|cyu4|fong2
 (下 厨 房)	haa6|cyu4|fong2
-(㊦ 厨 房)	haa6|cyu4|fong2
 (下 不 去)	haa5|bat1|heoi3
-(㊦ 不 去)	haa5|bat1|heoi3
 (下 不 去)	haa5|bat1|heoi3
-(㊦ 不 去)	haa5|bat1|heoi3
 (下 斷 語)	haa6|dyun6|jyu5
-(㊦ 斷 語)	haa6|dyun6|jyu5
 (下 断 语)	haa6|dyun6|jyu5
-(㊦ 断 语)	haa6|dyun6|jyu5
 (下 巴)	haa6|paa4
-(㊦ 巴)	haa6|paa4
 (下 詔)	haa6|ziu6
-(㊦ 詔)	haa6|ziu6
 (下 诏)	haa6|ziu6
-(㊦ 诏)	haa6|ziu6
 (下 調)	haa6|tiu4
-(㊦ 調)	haa6|tiu4
 (下 調)	haa6|tiu4
-(㊦ 調)	haa6|tiu4
 (下 调)	haa6|tiu4
-(㊦ 调)	haa6|tiu4
 (下 頜)	haa6|hap6
-(㊦ 頜)	haa6|hap6
 (下 颌)	haa6|hap6
-(㊦ 颌)	haa6|hap6
 (下 顎)	haa5|ngok6
-(㊦ 顎)	haa5|ngok6
 (下 颚)	haa5|ngok6
-(㊦ 颚)	haa5|ngok6
 (下 底)	haa6|dai1
-(㊦ 底)	haa6|dai1
 (下 下)	haa5|haa5
-(㊦ ㊦)	haa5|haa5
 (下 咽)	haa6|jin1
-(㊦ 咽)	haa6|jin1
 (下 咽)	haa6|jin1
-(㊦ 咽)	haa6|jin1
 (下 相)	haa6|soeng3
-(㊦ 相)	haa6|soeng3
 (下 種)	haa6|zung3
-(㊦ 種)	haa6|zung3
 (下 种)	haa6|zung3
-(㊦ 种)	haa6|zung3
 (下 著)	haa6|zoek6
-(㊦ 著)	haa6|zoek6
 (下 著)	haa6|zoek6
-(㊦ 著)	haa6|zoek6
 (下 着)	haa6|zoek6
-(㊦ 着)	haa6|zoek6
 (下 着)	haa6|zoek6
-(㊦ 着)	haa6|zoek6
 (下 過)	haa6|gwo1
-(㊦ 過)	haa6|gwo1
 (下 过)	haa6|gwo1
-(㊦ 过)	haa6|gwo1
 (下 朝)	haa6|ziu1
-(㊦ 朝)	haa6|ziu1
 (下 房)	haa6|fong2
-(㊦ 房)	haa6|fong2
 (下 箸)	haa6|zyu6
-(㊦ 箸)	haa6|zyu6
 (下 嚥)	haa6|jin3
-(㊦ 嚥)	haa6|jin3
 (下 元)	haa5|jyun4
-(㊦ 元)	haa5|jyun4
 (下 了)	haa5|liu5
-(㊦ 了)	haa5|liu5
 (下 了)	haa5|liu5
-(㊦ 了)	haa5|liu5
 (下 子)	haa5|zi2
-(㊦ 子)	haa5|zi2
 丌	gei1
 不	bat1
 不	bat1
@@ -7944,11 +6775,7 @@ _9      gau2||
 (不 知 为 不 知)	bat1|zi1|wai4|bat1|zi3
 (不 知 为 不 知)	bat1|zi1|wai4|bat1|zi3
 (不 三 不 四)	bat1|saam1|bat1|sei3
-(不 ㊂ 不 四)	bat1|saam1|bat1|sei3
-(不 三 不 ㊃)	bat1|saam1|bat1|sei3
 (不 三 不 四)	bat1|saam1|bat1|sei3
-(不 ㊂ 不 四)	bat1|saam1|bat1|sei3
-(不 三 不 ㊃)	bat1|saam1|bat1|sei3
 (不 干 不 净)	bat1|gon1|bat1|zing6
 (不 干 不 净)	bat1|gon1|bat1|zing6
 (不 假 思 索)	bat1|gaa2|si1|sok3
@@ -8015,19 +6842,11 @@ _9      gau2||
 (不 远 千 里)	bat1|jyun5|cin1|lei5
 (不 远 千 里)	bat1|jyun5|cin1|lei5
 (不 孝 有 三)	bat1|haau3|jau5|saam1
-(不 孝 有 ㊂)	bat1|haau3|jau5|saam1
-(不 孝 ㊒ 三)	bat1|haau3|jau5|saam1
 (不 孝 有 三)	bat1|haau3|jau5|saam1
-(不 孝 有 ㊂)	bat1|haau3|jau5|saam1
-(不 孝 ㊒ 三)	bat1|haau3|jau5|saam1
 (不 長 一 智)	bat1|zoeng2|jat1|zi3
-(不 長 ㊀ 智)	bat1|zoeng2|jat1|zi3
 (不 長 一 智)	bat1|zoeng2|jat1|zi3
-(不 長 ㊀ 智)	bat1|zoeng2|jat1|zi3
 (不 长 一 智)	bat1|zoeng2|jat1|zi3
-(不 长 ㊀ 智)	bat1|zoeng2|jat1|zi3
 (不 长 一 智)	bat1|zoeng2|jat1|zi3
-(不 长 ㊀ 智)	bat1|zoeng2|jat1|zi3
 (不 講 道 理)	bat1|gong2|dou3|lei5
 (不 講 道 理)	bat1|gong2|dou3|lei5
 (不 講 道 理)	bat1|gong2|dou3|lei5
@@ -8037,11 +6856,7 @@ _9      gau2||
 (不 安 本 分)	bat1|on1|bun2|fan6
 (不 安 本 分)	bat1|on1|bun2|fan6
 (不 上 不 下)	bat1|soeng6|bat1|haa6
-(不 上 不 ㊦)	bat1|soeng6|bat1|haa6
-(不 ㊤ 不 下)	bat1|soeng6|bat1|haa6
 (不 上 不 下)	bat1|soeng6|bat1|haa6
-(不 上 不 ㊦)	bat1|soeng6|bat1|haa6
-(不 ㊤ 不 下)	bat1|soeng6|bat1|haa6
 (不 安 於 位)	bat1|on1|jyu1|wai6
 (不 安 於 位)	bat1|on1|jyu1|wai6
 (不 安 于 位)	bat1|on1|jyu1|wai6
@@ -8093,13 +6908,9 @@ _9      gau2||
 (不 说 出)	bat1|seoi3|ceot1
 (不 说 出)	bat1|seoi3|ceot1
 (不 會 有)	bat1|wui2|jau5
-(不 會 ㊒)	bat1|wui2|jau5
 (不 會 有)	bat1|wui2|jau5
-(不 會 ㊒)	bat1|wui2|jau5
 (不 会 有)	bat1|wui2|jau5
-(不 会 ㊒)	bat1|wui2|jau5
 (不 会 有)	bat1|wui2|jau5
-(不 会 ㊒)	bat1|wui2|jau5
 (不 會 不)	bat1|wui2|bat1
 (不 會 不)	bat1|wui2|bat1
 (不 会 不)	bat1|wui2|bat1
@@ -8155,9 +6966,7 @@ _9      gau2||
 丕	pei1
 世	sai3
 (世 界 上)	sai3|gaai3|soeng6
-(世 界 ㊤)	sai3|gaai3|soeng6
 (世 上)	sai3|soeng6
-(世 ㊤)	sai3|soeng6
 (世 伯)	sai3|baa3
 (世 銀)	sai3|ngan2
 (世 银)	sai3|ngan2
@@ -8177,54 +6986,29 @@ _9      gau2||
 东	dung1
 🀀	dung1
 (东 逃 西 窜)	dung1|tou4|sai1|cyun2
-(东 逃 🀂 窜)	dung1|tou4|sai1|cyun2
-(🀀 逃 西 窜)	dung1|tou4|sai1|cyun2
 (东 邻 西 舍)	dung1|leon4|sai1|se5
-(东 邻 🀂 舍)	dung1|leon4|sai1|se5
-(🀀 邻 西 舍)	dung1|leon4|sai1|se5
 (东 仓 里)	dung1|cong1|leoi5
-(🀀 仓 里)	dung1|cong1|leoi5
 (东 仓 里)	dung1|cong1|leoi5
-(🀀 仓 里)	dung1|cong1|leoi5
 (东 三 省)	dung1|saam1|saang2
-(🀀 三 省)	dung1|saam1|saang2
-(东 ㊂ 省)	dung1|saam1|saang2
-(🀀 ㊂ 省)	dung1|saam1|saang2
 (东 三 省)	dung1|saam1|saang2
-(🀀 三 省)	dung1|saam1|saang2
-(东 ㊂ 省)	dung1|saam1|saang2
-(🀀 ㊂ 省)	dung1|saam1|saang2
 (东 莞)	dung1|gun2
-(🀀 莞)	dung1|gun2
 (东 涌)	dung1|cung1
-(🀀 涌)	dung1|cung1
 丝	si1
 丞	sing4
 (丞 相)	sing4|soeng3
 丟	diu1
 (丟 三 落 四)	diu1|saam1|lok6|sei3
-(丟 ㊂ 落 四)	diu1|saam1|lok6|sei3
-(丟 三 落 ㊃)	diu1|saam1|lok6|sei3
 (丟 三 落 四)	diu1|saam1|lok6|sei3
-(丟 ㊂ 落 四)	diu1|saam1|lok6|sei3
-(丟 三 落 ㊃)	diu1|saam1|lok6|sei3
 (丟 上)	diu1|soeng6
-(丟 ㊤)	diu1|soeng6
 両	loeng5
 丢	diu1
 (丢 三 落 四)	diu1|saam1|lok6|sei3
-(丢 ㊂ 落 四)	diu1|saam1|lok6|sei3
-(丢 三 落 ㊃)	diu1|saam1|lok6|sei3
 (丢 三 落 四)	diu1|saam1|lok6|sei3
-(丢 ㊂ 落 四)	diu1|saam1|lok6|sei3
-(丢 三 落 ㊃)	diu1|saam1|lok6|sei3
 (丢 上)	diu1|soeng6
-(丢 ㊤)	diu1|soeng6
 丣	jau5
 两	loeng5
 (两 虎 相 斗)	loeng5|fu2|soeng1|dau3
 (两 次 三 番)	loeng5|ci3|saam1|faan1
-(两 次 ㊂ 番)	loeng5|ci3|saam1|faan1
 (两 块 钱)	loeng5|faai3|cin4
 (两 筒)	loeng5|tung4
 (两 行)	loeng5|hong4
@@ -8268,304 +7052,88 @@ _9      gau2||
 ㊥	zung1
 🈭	zung1
 (中 華 學 生 愛 國 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(🀄 華 學 生 愛 國 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(㊥ 華 學 生 愛 國 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
 (中 華 學 生 愛 國 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(🀄 華 學 生 愛 國 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(㊥ 華 學 生 愛 國 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
 (中 华 学 生 爱 国 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(🀄 华 学 生 爱 国 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(中 华 ㊫ 生 爱 国 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(🀄 华 ㊫ 生 爱 国 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
-(㊥ 华 学 生 爱 国 民 主 同 盟)	zung1|waa4|hok6|saang7|ngoi3|gwok3|man4|zyu2|tung4|mang4
 (中 小 企 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 企 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(中 小 ㊭ 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 ㊭ 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(㊥ 小 企 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
 (中 小 企 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 企 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(中 小 ㊭ 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 ㊭ 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(㊥ 小 企 業 銀 行)	zung1|siu2|kei2|jip6|ngan2|hong4
 (中 小 企 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 企 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(中 小 ㊭ 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 ㊭ 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(㊥ 小 企 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
 (中 小 企 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 企 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(中 小 ㊭ 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(🀄 小 ㊭ 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
-(㊥ 小 企 业 银 行)	zung1|siu2|kei2|jip6|ngan2|hong4
 (中 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(🀄 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(㊥ 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
 (中 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(🀄 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(㊥ 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
 (中 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(🀄 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(㊥ 央 處 理 器)	zung1|joeng1|cyu3|lei5|hei3
 (中 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(🀄 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(㊥ 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
 (中 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(🀄 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(㊥ 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
 (中 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(🀄 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
-(㊥ 央 处 理 器)	zung1|joeng1|cyu3|lei5|hei3
 (中 小 企 業)	zung1|siu2|kei2|jip6
-(🀄 小 企 業)	zung1|siu2|kei2|jip6
-(中 小 ㊭ 業)	zung1|siu2|kei2|jip6
-(🀄 小 ㊭ 業)	zung1|siu2|kei2|jip6
-(㊥ 小 企 業)	zung1|siu2|kei2|jip6
 (中 小 企 业)	zung1|siu2|kei2|jip6
-(🀄 小 企 业)	zung1|siu2|kei2|jip6
-(中 小 ㊭ 业)	zung1|siu2|kei2|jip6
-(🀄 小 ㊭ 业)	zung1|siu2|kei2|jip6
-(㊥ 小 企 业)	zung1|siu2|kei2|jip6
 (中 下 階 層)	zung3|haa6|gaai1|cang4
-(🀄 下 階 層)	zung3|haa6|gaai1|cang4
-(中 ㊦ 階 層)	zung3|haa6|gaai1|cang4
-(🀄 ㊦ 階 層)	zung3|haa6|gaai1|cang4
-(㊥ 下 階 層)	zung3|haa6|gaai1|cang4
 (中 下 階 層)	zung3|haa6|gaai1|cang4
-(🀄 下 階 層)	zung3|haa6|gaai1|cang4
-(中 ㊦ 階 層)	zung3|haa6|gaai1|cang4
-(🀄 ㊦ 階 層)	zung3|haa6|gaai1|cang4
-(㊥ 下 階 層)	zung3|haa6|gaai1|cang4
 (中 下 阶 层)	zung3|haa6|gaai1|cang4
-(🀄 下 阶 层)	zung3|haa6|gaai1|cang4
-(中 ㊦ 阶 层)	zung3|haa6|gaai1|cang4
-(🀄 ㊦ 阶 层)	zung3|haa6|gaai1|cang4
-(㊥ 下 阶 层)	zung3|haa6|gaai1|cang4
 (中 小 學 生)	zung1|siu2|hok6|saang1
-(🀄 小 學 生)	zung1|siu2|hok6|saang1
-(㊥ 小 學 生)	zung1|siu2|hok6|saang1
 (中 小 学 生)	zung1|siu2|hok6|saang1
-(🀄 小 学 生)	zung1|siu2|hok6|saang1
-(中 小 ㊫ 生)	zung1|siu2|hok6|saang1
-(🀄 小 ㊫ 生)	zung1|siu2|hok6|saang1
-(㊥ 小 学 生)	zung1|siu2|hok6|saang1
 (中 下 階 級)	zung3|haa6|gaai1|kap1
-(🀄 下 階 級)	zung3|haa6|gaai1|kap1
-(中 ㊦ 階 級)	zung3|haa6|gaai1|kap1
-(🀄 ㊦ 階 級)	zung3|haa6|gaai1|kap1
-(㊥ 下 階 級)	zung3|haa6|gaai1|kap1
 (中 下 阶 级)	zung3|haa6|gaai1|kap1
-(🀄 下 阶 级)	zung3|haa6|gaai1|kap1
-(中 ㊦ 阶 级)	zung3|haa6|gaai1|kap1
-(🀄 ㊦ 阶 级)	zung3|haa6|gaai1|kap1
-(㊥ 下 阶 级)	zung3|haa6|gaai1|kap1
 (中 下 程 度)	zung3|haa6|cing4|dou6
-(🀄 下 程 度)	zung3|haa6|cing4|dou6
-(中 ㊦ 程 度)	zung3|haa6|cing4|dou6
-(🀄 ㊦ 程 度)	zung3|haa6|cing4|dou6
-(㊥ 下 程 度)	zung3|haa6|cing4|dou6
 (中 下 程 度)	zung3|haa6|cing4|dou6
-(🀄 下 程 度)	zung3|haa6|cing4|dou6
-(中 ㊦ 程 度)	zung3|haa6|cing4|dou6
-(🀄 ㊦ 程 度)	zung3|haa6|cing4|dou6
-(㊥ 下 程 度)	zung3|haa6|cing4|dou6
 (中 圈 套)	zung3|hyun1|tou3
-(🀄 圈 套)	zung3|hyun1|tou3
-(㊥ 圈 套)	zung3|hyun1|tou3
 (中 子 彈)	zung1|zi2|daan6
-(🀄 子 彈)	zung1|zi2|daan6
-(㊥ 子 彈)	zung1|zi2|daan6
 (中 子 弹)	zung1|zi2|daan6
-(🀄 子 弹)	zung1|zi2|daan6
-(㊥ 子 弹)	zung1|zi2|daan6
 (中 子 星)	zung1|zi2|sing1
-(🀄 子 星)	zung1|zi2|sing1
-(㊥ 子 星)	zung1|zi2|sing1
 (中 學 生)	zung1|hok6|saang7
-(🀄 學 生)	zung1|hok6|saang7
-(㊥ 學 生)	zung1|hok6|saang7
 (中 学 生)	zung1|hok6|saang7
-(🀄 学 生)	zung1|hok6|saang7
-(中 ㊫ 生)	zung1|hok6|saang7
-(🀄 ㊫ 生)	zung1|hok6|saang7
-(㊥ 学 生)	zung1|hok6|saang7
 (中 轉 站)	zung1|zyun3|zaam6
-(🀄 轉 站)	zung1|zyun3|zaam6
-(㊥ 轉 站)	zung1|zyun3|zaam6
 (中 转 站)	zung1|zyun3|zaam6
-(🀄 转 站)	zung1|zyun3|zaam6
-(㊥ 转 站)	zung1|zyun3|zaam6
 (中 了 毒)	zung3|liu5|duk6
-(🀄 了 毒)	zung3|liu5|duk6
-(㊥ 了 毒)	zung3|liu5|duk6
 (中 了 毒)	zung3|liu5|duk6
-(🀄 了 毒)	zung3|liu5|duk6
-(㊥ 了 毒)	zung3|liu5|duk6
 (中 下 遊)	zung3|haa6|jau4
-(🀄 下 遊)	zung3|haa6|jau4
-(中 ㊦ 遊)	zung3|haa6|jau4
-(🀄 ㊦ 遊)	zung3|haa6|jau4
-(㊥ 下 遊)	zung3|haa6|jau4
 (中 下 游)	zung3|haa6|jau4
-(🀄 下 游)	zung3|haa6|jau4
-(中 ㊦ 游)	zung3|haa6|jau4
-(🀄 ㊦ 游)	zung3|haa6|jau4
-(㊥ 下 游)	zung3|haa6|jau4
 (中 馬 票)	zung3|maa5|biu1
-(🀄 馬 票)	zung3|maa5|biu1
-(㊥ 馬 票)	zung3|maa5|biu1
 (中 马 票)	zung3|maa5|biu1
-(🀄 马 票)	zung3|maa5|biu1
-(㊥ 马 票)	zung3|maa5|biu1
 (中 下 層)	zung3|haa6|cang4
-(🀄 下 層)	zung3|haa6|cang4
-(中 ㊦ 層)	zung3|haa6|cang4
-(🀄 ㊦ 層)	zung3|haa6|cang4
-(㊥ 下 層)	zung3|haa6|cang4
 (中 下 層)	zung3|haa6|cang4
-(🀄 下 層)	zung3|haa6|cang4
-(中 ㊦ 層)	zung3|haa6|cang4
-(🀄 ㊦ 層)	zung3|haa6|cang4
-(㊥ 下 層)	zung3|haa6|cang4
 (中 下 层)	zung3|haa6|cang4
-(🀄 下 层)	zung3|haa6|cang4
-(中 ㊦ 层)	zung3|haa6|cang4
-(🀄 ㊦ 层)	zung3|haa6|cang4
-(㊥ 下 层)	zung3|haa6|cang4
 (中 了 標)	zung3|liu5|biu1
-(🀄 了 標)	zung3|liu5|biu1
-(㊥ 了 標)	zung3|liu5|biu1
 (中 了 標)	zung3|liu5|biu1
-(🀄 了 標)	zung3|liu5|biu1
-(㊥ 了 標)	zung3|liu5|biu1
 (中 了 标)	zung3|liu5|biu1
-(🀄 了 标)	zung3|liu5|biu1
-(㊥ 了 标)	zung3|liu5|biu1
 (中 了 标)	zung3|liu5|biu1
-(🀄 了 标)	zung3|liu5|biu1
-(㊥ 了 标)	zung3|liu5|biu1
 (中 子 流)	zung1|zi2|lau4
-(🀄 子 流)	zung1|zi2|lau4
-(㊥ 子 流)	zung1|zi2|lau4
 (中 子 流)	zung1|zi2|lau4
-(🀄 子 流)	zung1|zi2|lau4
-(㊥ 子 流)	zung1|zi2|lau4
 (中 子 流)	zung1|zi2|lau4
-(🀄 子 流)	zung1|zi2|lau4
-(㊥ 子 流)	zung1|zi2|lau4
 (中 上 級)	zung3|soeng6|kap1
-(🀄 上 級)	zung3|soeng6|kap1
-(中 ㊤ 級)	zung3|soeng6|kap1
-(🀄 ㊤ 級)	zung3|soeng6|kap1
-(㊥ 上 級)	zung3|soeng6|kap1
 (中 上 级)	zung3|soeng6|kap1
-(🀄 上 级)	zung3|soeng6|kap1
-(中 ㊤ 级)	zung3|soeng6|kap1
-(🀄 ㊤ 级)	zung3|soeng6|kap1
-(㊥ 上 级)	zung3|soeng6|kap1
 (中 了 暑)	zung3|liu5|syu2
-(🀄 了 暑)	zung3|liu5|syu2
-(㊥ 了 暑)	zung3|liu5|syu2
 (中 了 暑)	zung3|liu5|syu2
-(🀄 了 暑)	zung3|liu5|syu2
-(㊥ 了 暑)	zung3|liu5|syu2
 (中 了 暑)	zung3|liu5|syu2
-(🀄 了 暑)	zung3|liu5|syu2
-(㊥ 了 暑)	zung3|liu5|syu2
 (中 下 等)	zung3|haa6|dang2
-(🀄 下 等)	zung3|haa6|dang2
-(中 ㊦ 等)	zung3|haa6|dang2
-(🀄 ㊦ 等)	zung3|haa6|dang2
-(㊥ 下 等)	zung3|haa6|dang2
 (中 傷)	zung3|soeng1
-(🀄 傷)	zung3|soeng1
-(㊥ 傷)	zung3|soeng1
 (中 伤)	zung3|soeng1
-(🀄 伤)	zung3|soeng1
-(㊥ 伤)	zung3|soeng1
 (中 子)	zung7|zi2
-(🀄 子)	zung7|zi2
-(㊥ 子)	zung7|zi2
 (中 彈)	zung3|daan6
-(🀄 彈)	zung3|daan6
-(㊥ 彈)	zung3|daan6
 (中 弹)	zung3|daan6
-(🀄 弹)	zung3|daan6
-(㊥ 弹)	zung3|daan6
 (中 彩)	zung3|coi2
-(🀄 彩)	zung3|coi2
-(㊥ 彩)	zung3|coi2
 (中 彩)	zung3|coi2
-(🀄 彩)	zung3|coi2
-(㊥ 彩)	zung3|coi2
 (中 暑)	zung3|syu2
-(🀄 暑)	zung3|syu2
-(㊥ 暑)	zung3|syu2
 (中 暑)	zung3|syu2
-(🀄 暑)	zung3|syu2
-(㊥ 暑)	zung3|syu2
 (中 校)	zung1|gaau3
-(🀄 校)	zung1|gaau3
-(㊥ 校)	zung1|gaau3
 (中 槍)	zung3|coeng1
-(🀄 槍)	zung3|coeng1
-(㊥ 槍)	zung3|coeng1
 (中 枪)	zung3|coeng1
-(🀄 枪)	zung3|coeng1
-(㊥ 枪)	zung3|coeng1
 (中 標)	zung3|biu1
-(🀄 標)	zung3|biu1
-(㊥ 標)	zung3|biu1
 (中 标)	zung3|biu1
-(🀄 标)	zung3|biu1
-(㊥ 标)	zung3|biu1
 (中 毒)	zung3|duk6
-(🀄 毒)	zung3|duk6
-(㊥ 毒)	zung3|duk6
 (中 獎)	zung3|zoeng2
-(🀄 獎)	zung3|zoeng2
-(㊥ 獎)	zung3|zoeng2
 (中 奖)	zung3|zoeng2
-(🀄 奖)	zung3|zoeng2
-(㊥ 奖)	zung3|zoeng2
 (中 聽)	zung1|teng1
-(🀄 聽)	zung1|teng1
-(㊥ 聽)	zung1|teng1
 (中 听)	zung1|teng1
-(🀄 听)	zung1|teng1
-(㊥ 听)	zung1|teng1
 (中 邪)	zung3|ce4
-(🀄 邪)	zung3|ce4
-(㊥ 邪)	zung3|ce4
 (中 風)	zung3|fung1
-(🀄 風)	zung3|fung1
-(㊥ 風)	zung3|fung1
 (中 风)	zung3|fung1
-(🀄 风)	zung3|fung1
-(㊥ 风)	zung3|fung1
 (中 上)	zung1|soeng6
-(🀄 上)	zung1|soeng6
-(中 ㊤)	zung1|soeng6
-(🀄 ㊤)	zung1|soeng6
-(㊥ 上)	zung1|soeng6
 (中 箭)	zung3|zin3
-(🀄 箭)	zung3|zin3
-(㊥ 箭)	zung3|zin3
 (中 靶)	zung3|baa2
-(🀄 靶)	zung3|baa2
-(㊥ 靶)	zung3|baa2
 (中 鏢)	zung3|biu1
-(🀄 鏢)	zung3|biu1
-(㊥ 鏢)	zung3|biu1
 (中 镖)	zung3|biu1
-(🀄 镖)	zung3|biu1
-(㊥ 镖)	zung3|biu1
 (中 使)	zung1|si3
-(🀄 使)	zung1|si3
-(㊥ 使)	zung1|si3
 (中 派)	zung1|paai1
-(🀄 派)	zung1|paai1
-(㊥ 派)	zung1|paai1
 丯	gaai3
 丰	fung1
 (丰 溪 里)	fung1|kai1|leoi5
@@ -8638,14 +7206,10 @@ _9      gau2||
 乇	tok3
 么	mo1
 (么 九)	jiu1|gau2
-(么 ㊈)	jiu1|gau2
 义	ji6
 之	zi1
 (之 上)	zi1|soeng6
-(之 ㊤)	zi1|soeng6
 (之 中)	zi7|zung7
-(之 🀄)	zi7|zung7
-(之 ㊥)	zi7|zung7
 乌	wu1
 (乌 苏 里 斯 克)	wu1|sou1|leoi5|si1|hak1
 (乌 苏 里 斯 克)	wu1|sou1|leoi5|si1|hak1
@@ -8705,30 +7269,15 @@ _9      gau2||
 九	gau2
 ㊈	gau2
 (九 品 中 正)	gau2|ban2|zung3|zing1
-(九 品 🀄 正)	gau2|ban2|zung3|zing1
-(九 品 中 ㊣)	gau2|ban2|zung3|zing1
-(九 品 🀄 ㊣)	gau2|ban2|zung3|zing1
-(九 品 ㊥ 正)	gau2|ban2|zung3|zing1
-(㊈ 品 中 正)	gau2|ban2|zung3|zing1
-(㊈ 品 🀄 正)	gau2|ban2|zung3|zing1
 (九 廿 幾)	gau2|aa6|gei2
-(㊈ 廿 幾)	gau2|aa6|gei2
 (九 廿 几)	gau2|aa6|gei2
-(㊈ 廿 几)	gau2|aa6|gei2
 (九 塊 錢)	gau2|faai3|cin4
-(㊈ 塊 錢)	gau2|faai3|cin4
 (九 块 钱)	gau2|faai3|cin4
-(㊈ 块 钱)	gau2|faai3|cin4
 (九 里)	gau2|leoi5
-(㊈ 里)	gau2|leoi5
 (九 里)	gau2|leoi5
-(㊈ 里)	gau2|leoi5
 (九 行)	gou2|hong4
-(㊈ 行)	gou2|hong4
 (九 行)	gou2|hong4
-(㊈ 行)	gou2|hong4
 (九 打)	gau2|daa1
-(㊈ 打)	gau2|daa1
 乞	hat1
 (乞 降)	hat1|hong4
 (乞 降)	hat1|hong4
@@ -8741,11 +7290,9 @@ _9      gau2||
 乣	gau2
 书	syu1
 (书 本 上)	syu1|bun2|soeng6
-(书 本 ㊤)	syu1|bun2|soeng6
 (书 札)	syu1|zaat3
 (书 房)	syu1|fong2
 (书 上)	syu7|soeng6
-(书 ㊤)	syu7|soeng6
 乨	ci2
 乩	gei1
 乪	kek6
@@ -8758,7 +7305,6 @@ _9      gau2||
 (乱 画)	lyun6|waak6
 乳	jyu5
 (乳 名)	jyu5|meng2
-(乳 ㊔)	jyu5|meng2
 (乳 暈)	jyu5|wan6
 (乳 暈)	jyu5|wan6
 (乳 晕)	jyu5|wan6
@@ -8803,9 +7349,7 @@ _9      gau2||
 (争 斗)	zang1|dau3
 事	si6
 (事 實 上)	si6|sat6|soeng6
-(事 實 ㊤)	si6|sat6|soeng6
 (事 实 上)	si6|sat6|soeng6
-(事 实 ㊤)	si6|sat6|soeng6
 (事 務 長)	si6|mou6|zoeng2
 (事 务 长)	si6|mou6|zoeng2
 二	ji6
@@ -8813,86 +7357,44 @@ _9      gau2||
 🈔	ji6
 🉂	ji6
 (二 分 音 符)	ji6|fan1|jam1|fu4
-(㊁ 分 音 符)	ji6|fan1|jam1|fu4
 (二 號 分 機)	ji6|hou4|fan1|gei1
-(㊁ 號 分 機)	ji6|hou4|fan1|gei1
 (二 号 分 机)	ji6|hou4|fan1|gei1
-(㊁ 号 分 机)	ji6|hou4|fan1|gei1
 (二 路 縱 隊)	ji6|lou6|zung1|deoi6
-(㊁ 路 縱 隊)	ji6|lou6|zung1|deoi6
 (二 路 縱 隊)	ji6|lou6|zung1|deoi6
-(㊁ 路 縱 隊)	ji6|lou6|zung1|deoi6
 (二 路 纵 队)	ji6|lou6|zung1|deoi6
-(㊁ 路 纵 队)	ji6|lou6|zung1|deoi6
 (二 路 纵 队)	ji6|lou6|zung1|deoi6
-(㊁ 路 纵 队)	ji6|lou6|zung1|deoi6
 (二 虎 相 斗)	ji6|fu2|soeng1|dau3
-(㊁ 虎 相 斗)	ji6|fu2|soeng1|dau3
 (二 帝 三 王)	ji6|dai3|saam1|wong4
-(二 帝 ㊂ 王)	ji6|dai3|saam1|wong4
-(㊁ 帝 三 王)	ji6|dai3|saam1|wong4
 (二 里 頭)	ji6|leoi5|tau4
-(㊁ 里 頭)	ji6|leoi5|tau4
 (二 里 頭)	ji6|leoi5|tau4
-(㊁ 里 頭)	ji6|leoi5|tau4
 (二 舅 媽)	ji6|kau3|maa1
-(㊁ 舅 媽)	ji6|kau3|maa1
 (二 舅 妈)	ji6|kau3|maa1
-(㊁ 舅 妈)	ji6|kau3|maa1
 (二 分 法)	ji6|fan1|faat3
-(㊁ 分 法)	ji6|fan1|faat3
 (二 塊 錢)	ji6|faai3|cin4
-(㊁ 塊 錢)	ji6|faai3|cin4
 (二 块 钱)	ji6|faai3|cin4
-(㊁ 块 钱)	ji6|faai3|cin4
 (二 分 鐘)	ji6|fan1|zung1
-(㊁ 分 鐘)	ji6|fan1|zung1
 (二 分 钟)	ji6|fan1|zung1
-(㊁ 分 钟)	ji6|fan1|zung1
 (二 分)	ji6|fan6
-(㊁ 分)	ji6|fan6
 (二 更)	ji6|gaang1
-(㊁ 更)	ji6|gaang1
 (二 更)	ji6|gaang1
-(㊁ 更)	ji6|gaang1
 (二 聲)	ji6|seng1
-(㊁ 聲)	ji6|seng1
 (二 声)	ji6|seng1
-(㊁ 声)	ji6|seng1
 (二 胡)	ji6|wu2
-(㊁ 胡)	ji6|wu2
 (二 話)	ji6|waa2
-(㊁ 話)	ji6|waa2
 (二 话)	ji6|waa2
-(㊁ 话)	ji6|waa2
 (二 錢)	ji6|cin4
-(㊁ 錢)	ji6|cin4
 (二 钱)	ji6|cin4
-(㊁ 钱)	ji6|cin4
 (二 三)	ji6|saam1
-(二 ㊂)	ji6|saam1
-(㊁ 三)	ji6|saam1
 (二 頂)	ji6|deng2
-(㊁ 頂)	ji6|deng2
 (二 顶)	ji6|deng2
-(㊁ 顶)	ji6|deng2
 (二 兩)	ji6|loeng2
-(㊁ 兩)	ji6|loeng2
 (二 兩)	ji6|loeng2
-(㊁ 兩)	ji6|loeng2
 (二 两)	ji6|loeng2
-(㊁ 两)	ji6|loeng2
 (二 伯)	ji6|baa3
-(㊁ 伯)	ji6|baa3
 (二 行)	ji6|hong4
-(㊁ 行)	ji6|hong4
 (二 行)	ji6|hong4
-(㊁ 行)	ji6|hong4
 (二 筒)	ji6|tung4
-(㊁ 筒)	ji6|tung4
 (二 下)	ji6|haa5
-(二 ㊦)	ji6|haa5
-(㊁ 下)	ji6|haa5
 亍	cuk1
 于	jyu1
 亏	kwai1
@@ -8906,63 +7408,33 @@ _9      gau2||
 五	ng5
 ㊄	ng5
 (五 雷 轟 頂)	ng5|leoi4|gwang1|deng2
-(㊄ 雷 轟 頂)	ng5|leoi4|gwang1|deng2
 (五 雷 轟 頂)	ng5|leoi4|gwang1|deng2
-(㊄ 雷 轟 頂)	ng5|leoi4|gwang1|deng2
 (五 雷 轰 顶)	ng5|leoi4|gwang1|deng2
-(㊄ 雷 轰 顶)	ng5|leoi4|gwang1|deng2
 (五 雷 轰 顶)	ng5|leoi4|gwang1|deng2
-(㊄ 雷 轰 顶)	ng5|leoi4|gwang1|deng2
 (五 塊 錢)	ng5|faai3|cin4
-(㊄ 塊 錢)	ng5|faai3|cin4
 (五 块 钱)	ng5|faai3|cin4
-(㊄ 块 钱)	ng5|faai3|cin4
 (五 七 只)	ng5|cat7|zek3
-(五 ㊆ 只)	ng5|cat7|zek3
-(㊄ 七 只)	ng5|cat7|zek3
 (五 毛 錢)	ng5|mou4|cin4
-(㊄ 毛 錢)	ng5|mou4|cin4
 (五 毛 钱)	ng5|mou4|cin4
-(㊄ 毛 钱)	ng5|mou4|cin4
 (五 嶺)	ng5|ling5
-(㊄ 嶺)	ng5|ling5
 (五 嶺)	ng5|ling5
-(㊄ 嶺)	ng5|ling5
 (五 岭)	ng5|ling5
-(㊄ 岭)	ng5|ling5
 (五 更)	ng5|gaang1
-(㊄ 更)	ng5|gaang1
 (五 更)	ng5|gaang1
-(㊄ 更)	ng5|gaang1
 (五 聲)	ng5|seng1
-(㊄ 聲)	ng5|seng1
 (五 声)	ng5|seng1
-(㊄ 声)	ng5|seng1
 (五 下)	ng5|haa5
-(五 ㊦)	ng5|haa5
-(㊄ 下)	ng5|haa5
 (五 頂)	ng5|deng2
-(㊄ 頂)	ng5|deng2
 (五 顶)	ng5|deng2
-(㊄ 顶)	ng5|deng2
 (五 棟)	ng5|dung3
-(㊄ 棟)	ng5|dung3
 (五 栋)	ng5|dung3
-(㊄ 栋)	ng5|dung3
 (五 錢)	ng5|cin4
-(㊄ 錢)	ng5|cin4
 (五 钱)	ng5|cin4
-(㊄ 钱)	ng5|cin4
 (五 只)	ng5|zek3
-(㊄ 只)	ng5|zek3
 (五 打)	ng5|daa1
-(㊄ 打)	ng5|daa1
 (五 匙)	ng5|ci4
-(㊄ 匙)	ng5|ci4
 (五 幢)	ng5|zong6
-(㊄ 幢)	ng5|zong6
 (五 筒)	ng5|tung4
-(㊄ 筒)	ng5|tung4
 井	zeng2
 (井 架)	zeng2|gaa2
 亘	gang2
@@ -9000,7 +7472,6 @@ _9      gau2||
 (交 相)	gaau1|soeng3
 (交 差)	gaau1|caai1
 (交 上)	gaau1|soeng6
-(交 ㊤)	gaau1|soeng6
 (交 更)	gaau1|gaang7
 (交 更)	gaau1|gaang7
 亥	hoi6
@@ -9030,21 +7501,13 @@ _9      gau2||
 亹	mei5
 人	jan4
 (人 在 屋 簷 下 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 簷 ㊦ 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 在 屋 簷 下 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 簷 ㊦ 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 在 屋 簷 下 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 簷 ㊦ 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 在 屋 簷 下 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 簷 ㊦ 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 在 屋 檐 下 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 檐 ㊦ 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 在 屋 檐 下 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 檐 ㊦ 不 得 不 低 頭)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 在 屋 檐 下 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 檐 ㊦ 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 在 屋 檐 下 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
-(人 在 屋 檐 ㊦ 不 得 不 低 头)	jan4|zoi6|nguk1|sim4|haa5|bat1|dak1|bat1|dai1|tau4
 (人 生 路 不 熟)	jan4|sang1|lou6|bat1|suk6
 (人 生 路 不 熟)	jan4|sang1|lou6|bat1|suk6
 (人 生 路 不 熟)	jan4|sang1|lou6|bat1|suk6
@@ -9079,7 +7542,6 @@ _9      gau2||
 (人 語 馬 嘶)	jan4|jyu5|maa5|si1
 (人 语 马 嘶)	jan4|jyu5|maa5|si1
 (人 為 財 死)	jan4|wai6|coi4|sei2
-(人 為 ㊖ 死)	jan4|wai6|coi4|sei2
 (人 为 财 死)	jan4|wai6|coi4|sei2
 (人 文 薈 萃)	jan4|man4|wui3|seoi6
 (人 文 荟 萃)	jan4|man4|wui3|seoi6
@@ -9092,9 +7554,7 @@ _9      gau2||
 (人 工 降 雨)	jan4|gung1|gong3|jyu6
 (人 字 架)	jan4|zi6|gaa2
 (人 體 上)	jan4|tai2|soeng6
-(人 體 ㊤)	jan4|tai2|soeng6
 (人 体 上)	jan4|tai2|soeng6
-(人 体 ㊤)	jan4|tai2|soeng6
 (人 命)	jan4|meng6
 (人 禍)	jan4|wo5
 (人 禍)	jan4|wo5
@@ -9161,19 +7621,14 @@ _9      gau2||
 (付 刊)	fu6|hon2
 仙	sin1
 (仙 女 座 大 星 雲)	sin1|neoi5|zo6|daai6|sing1|wan4
-(仙 ㊛ 座 大 星 雲)	sin1|neoi5|zo6|daai6|sing1|wan4
 (仙 女 座 大 星 雲)	sin1|neoi5|zo6|daai6|sing1|wan4
 (仙 女 座 大 星 云)	sin1|neoi5|zo6|daai6|sing1|wan4
-(仙 ㊛ 座 大 星 云)	sin1|neoi5|zo6|daai6|sing1|wan4
 (仙 女 座 大 星 云)	sin1|neoi5|zo6|daai6|sing1|wan4
 (仙 女 座 星 系)	sin1|neoi5|zo6|sing1|hai6
-(仙 ㊛ 座 星 系)	sin1|neoi5|zo6|sing1|hai6
 (仙 女 座 星 系)	sin1|neoi5|zo6|sing1|hai6
 (仙 女 座)	sin1|neoi5|zo6
-(仙 ㊛ 座)	sin1|neoi5|zo6
 (仙 女 座)	sin1|neoi5|zo6
 (仙 女)	sin1|neoi2
-(仙 ㊛)	sin1|neoi2
 (仙 女)	sin1|neoi2
 仝	tung4
 仞	jan6
@@ -9192,9 +7647,7 @@ _9      gau2||
 令	ling6
 以	ji5
 (以 無 厚 入 有 間)	ji5|mou4|hau5|jap6|jau5|gaan3
-(以 無 厚 入 ㊒ 間)	ji5|mou4|hau5|jap6|jau5|gaan3
 (以 无 厚 入 有 间)	ji5|mou4|hau5|jap6|jau5|gaan3
-(以 无 厚 入 ㊒ 间)	ji5|mou4|hau5|jap6|jau5|gaan3
 (以 鄰 為 壑)	ji5|leon4|wai6|kok3
 (以 邻 为 壑)	ji5|leon4|wai6|kok3
 (以 貨 易 貨)	ji5|fo3|jik6|fo3
@@ -9214,7 +7667,6 @@ _9      gau2||
 (以 假 謬 真)	ji5|gaa2|mau6|zan1
 (以 假 谬 真)	ji5|gaa2|mau6|zan1
 (以 上)	ji5|soeng6
-(以 ㊤)	ji5|soeng6
 仨	saam1
 仪	ji4
 (仪 表 盘)	ji4|biu2|pun4
@@ -9236,7 +7688,6 @@ _9      gau2||
 (任 务 重)	jam6|mou6|cung5
 份	fan6
 (份 上)	fan6|soeng6
-(份 ㊤)	fan6|soeng6
 仿	fong2
 (仿 佛)	fong2|fat1
 伀	zung1
@@ -9259,11 +7710,8 @@ _9      gau2||
 休	jau1
 ㊡	jau1
 (休 會)	jau1|wui6
-(㊡ 會)	jau1|wui6
 (休 会)	jau1|wui6
-(㊡ 会)	jau1|wui6
 (休 刊)	jau1|hon2
-(㊡ 刊)	jau1|hon2
 伒	gan3
 伕	fu1
 众	zung3
@@ -9282,7 +7730,6 @@ _9      gau2||
 (会 战)	wui6|zin3
 (会 盟)	wui6|mang4
 (会 社)	wui6|se5
-(会 ㊓)	wui6|se5
 (会 社)	wui6|se5
 (会 考)	wui6|haau2
 (会 计)	wui6|gai3
@@ -9349,7 +7796,6 @@ _9      gau2||
 伷	zau6
 伸	san1
 (伸 下)	san1|haa5
-(伸 ㊦)	san1|haa5
 伹	ceoi1
 伺	zi6
 (伺 候)	si6|hau6
@@ -9389,9 +7835,6 @@ _9      gau2||
 (位 尊)	wai6|zyun1
 低	dai1
 (低 三 下 四)	dai1|saam1|haa6|sei3
-(低 三 ㊦ 四)	dai1|saam1|haa6|sei3
-(低 ㊂ 下 四)	dai1|saam1|haa6|sei3
-(低 三 下 ㊃)	dai1|saam1|haa6|sei3
 (低 胸 領)	dai1|hung1|leng5
 (低 胸 領)	dai1|hung1|leng5
 (低 胸 领)	dai1|hung1|leng5
@@ -9409,7 +7852,6 @@ _9      gau2||
 (体 重)	tai2|cung5
 佔	zim3
 (佔 為 己 有)	zim3|wai4|gei2|jau5
-(佔 為 己 ㊒)	zim3|wai4|gei2|jau5
 何	ho4
 佖	bit1
 佗	taa4
@@ -9422,9 +7864,7 @@ _9      gau2||
 (佛 佗)	fat6|to4
 作	zok3
 (作 壁 上 觀)	zok3|bik1|soeng6|gun1
-(作 壁 ㊤ 觀)	zok3|bik1|soeng6|gun1
 (作 壁 上 观)	zok3|bik1|soeng6|gun1
-(作 壁 ㊤ 观)	zok3|bik1|soeng6|gun1
 (作 假)	zok3|gaa2
 佝	kau3
 佞	ning6
@@ -9588,7 +8028,6 @@ _9      gau2||
 俍	loeng4
 俎	zo2
 (俎 上 肉)	zo2|soeng6|juk6
-(俎 ㊤ 肉)	zo2|soeng6|juk6
 俏	ciu3
 俐	lei6
 俑	jung2
@@ -9596,7 +8035,6 @@ _9      gau2||
 俔	jin5
 俗	zuk6
 (俗 名)	zuk6|meng2
-(俗 ㊔)	zuk6|meng2
 (俗 話)	zuk6|waa2
 (俗 话)	zuk6|waa2
 俘	fu1
@@ -9616,7 +8054,6 @@ _9      gau2||
 (信 用 調 查)	seon3|jung6|tiu4|caa4
 (信 用 调 查)	seon3|jung6|tiu4|caa4
 (信 封 上)	seon3|fung1|soeng6
-(信 封 ㊤)	seon3|fung1|soeng6
 (信 使)	seon3|si3
 (信 差)	seon3|caai1
 (信 札)	seon3|zaat3
@@ -9671,7 +8108,6 @@ _9      gau2||
 (倒 瀉 籮 蟹)	dou2|se2|lo4|haai5
 (倒 泻 箩 蟹)	dou2|se2|lo4|haai5
 (倒 汗 水)	dou3|hon6|seoi2
-(倒 汗 ㊌)	dou3|hon6|seoi2
 (倒 帶)	dou3|daai2
 (倒 带)	dou3|daai2
 (倒 影)	dou3|jing2
@@ -9767,7 +8203,6 @@ _9      gau2||
 (假 想 敌)	gaa2|soeng2|dik6
 (假 道 學)	gaa2|dou6|hok6
 (假 道 学)	gaa2|dou6|hok6
-(假 道 ㊫)	gaa2|dou6|hok6
 (假 借)	gaa2|ze3
 (假 的)	gaa2|dik1
 (假 託)	gaa2|tok3
@@ -10017,7 +8452,6 @@ _9      gau2||
 (先 会)	sin1|wui6
 (先 刊)	sin1|hon2
 (先 上)	sin1|soeng6
-(先 ㊤)	sin1|soeng6
 光	gwong1
 (光 瞠 瞠)	gwong1|caang4|caang4
 (光 溜)	gwong1|liu1
@@ -10027,7 +8461,6 @@ _9      gau2||
 (光 暈)	gwong1|wan6
 (光 晕)	gwong1|wan6
 (光 上)	gwong1|soeng6
-(光 ㊤)	gwong1|soeng6
 克	hak1
 (克 裡 姆 林 宮)	hak1|lei5|mou5|lam4|gung1
 (克 裡 姆 林 宮)	hak1|lei5|mou5|lam4|gung1
@@ -10040,7 +8473,6 @@ _9      gau2||
 (克 什 米 尔)	hak1|sap6|mai5|ji5
 (克 什 米 尔)	hak1|sap6|mai5|ji5
 (克 萊 懞 特)	hak1|loi4|mung4|dak6
-(克 萊 懞 ㊕)	hak1|loi4|mung4|dak6
 兌	deoi3
 免	min5
 免	min5
@@ -10069,7 +8501,6 @@ _9      gau2||
 入	jap6
 (入 學 考 試)	jap6|hok6|haau2|si5
 (入 学 考 试)	jap6|hok6|haau2|si5
-(入 ㊫ 考 试)	jap6|hok6|haau2|si5
 (入 場 券)	jap6|coeng4|gyun3
 (入 场 券)	jap6|coeng4|gyun3
 (入 行)	jap6|hong4
@@ -10105,9 +8536,7 @@ _9      gau2||
 兩	loeng5
 兩	loeng5
 (兩 次 三 番)	loeng5|ci3|saam1|faan1
-(兩 次 ㊂ 番)	loeng5|ci3|saam1|faan1
 (兩 次 三 番)	loeng5|ci3|saam1|faan1
-(兩 次 ㊂ 番)	loeng5|ci3|saam1|faan1
 (兩 塊 錢)	loeng5|faai3|cin4
 (兩 塊 錢)	loeng5|faai3|cin4
 (兩 筒)	loeng5|tung4
@@ -10123,44 +8552,26 @@ _9      gau2||
 八	baat3
 ㊇	baat3
 (八 里 鄉)	baat3|lei5|hoeng1
-(㊇ 里 鄉)	baat3|lei5|hoeng1
 (八 里 鄉)	baat3|lei5|hoeng1
-(㊇ 里 鄉)	baat3|lei5|hoeng1
 (八 里 乡)	baat3|lei5|hoeng1
-(㊇ 里 乡)	baat3|lei5|hoeng1
 (八 里 乡)	baat3|lei5|hoeng1
-(㊇ 里 乡)	baat3|lei5|hoeng1
 (八 斤 重)	baat3|gan1|cung5
-(㊇ 斤 重)	baat3|gan1|cung5
 (八 塊 錢)	baat3|faai3|cin4
-(㊇ 塊 錢)	baat3|faai3|cin4
 (八 块 钱)	baat3|faai3|cin4
-(㊇ 块 钱)	baat3|faai3|cin4
 (八 角 錢)	baat3|gok3|cin4
-(㊇ 角 錢)	baat3|gok3|cin4
 (八 角 钱)	baat3|gok3|cin4
-(㊇ 角 钱)	baat3|gok3|cin4
 (八 里)	baat3|leoi5
-(㊇ 里)	baat3|leoi5
 (八 里)	baat3|leoi5
-(㊇ 里)	baat3|leoi5
 (八 行)	baat3|hong4
-(㊇ 行)	baat3|hong4
 (八 行)	baat3|hong4
-(㊇ 行)	baat3|hong4
 (八 打)	baat3|daa1
-(㊇ 打)	baat3|daa1
 (八 筒)	baat3|tung4
-(㊇ 筒)	baat3|tung4
 (八 錢)	baat3|cin4
-(㊇ 錢)	baat3|cin4
 (八 钱)	baat3|cin4
-(㊇ 钱)	baat3|cin4
 公	gung1
 (公 用 電 話)	gung1|jung6|din6|waa2
 (公 用 电 话)	gung1|jung6|din6|waa2
 (公 公 正 正)	gung1|gung1|zing3|zing3
-(公 公 ㊣ ㊣)	gung1|gung1|zing3|zing3
 (公 聽 並 觀)	gung1|teng1|bing6|gun1
 (公 聽 並 觀)	gung1|teng1|bing6|gun1
 (公 听 并 观)	gung1|teng1|bing6|gun1
@@ -10193,38 +8604,25 @@ _9      gau2||
 ㊅	luk6
 六	luk6
 (六 塊 錢)	luk6|faai3|cin4
-(㊅ 塊 錢)	luk6|faai3|cin4
 (六 塊 錢)	luk6|faai3|cin4
 (六 块 钱)	luk6|faai3|cin4
-(㊅ 块 钱)	luk6|faai3|cin4
 (六 块 钱)	luk6|faai3|cin4
 (六 筒)	luk6|tung4
-(㊅ 筒)	luk6|tung4
 (六 筒)	luk6|tung4
 (六 聲)	luk6|seng1
-(㊅ 聲)	luk6|seng1
 (六 聲)	luk6|seng1
 (六 声)	luk6|seng1
-(㊅ 声)	luk6|seng1
 (六 声)	luk6|seng1
 (六 打)	luk6|daa1
-(㊅ 打)	luk6|daa1
 (六 打)	luk6|daa1
 (六 下)	luk6|haa5
-(六 ㊦)	luk6|haa5
-(㊅ 下)	luk6|haa5
 (六 下)	luk6|haa5
-(六 ㊦)	luk6|haa5
 (六 錢)	luk6|cin4
-(㊅ 錢)	luk6|cin4
 (六 錢)	luk6|cin4
 (六 钱)	luk6|cin4
-(㊅ 钱)	luk6|cin4
 (六 钱)	luk6|cin4
 (六 行)	luk6|hong4
-(㊅ 行)	luk6|hong4
 (六 行)	luk6|hong4
-(㊅ 行)	luk6|hong4
 (六 行)	luk6|hong4
 兮	hai4
 兰	laan4
@@ -10243,7 +8641,6 @@ _9      gau2||
 (共 軛)	gung6|ngaak1
 (共 轭)	gung6|ngaak1
 (共 上)	gung6|soeng6
-(共 ㊤)	gung6|soeng6
 (共 相)	gung6|soeng3
 (共 降)	gung6|hong4
 (共 降)	gung6|hong4
@@ -10324,13 +8721,11 @@ _9      gau2||
 (再 生 產)	zoi3|saang7|caan2
 (再 生 产)	zoi3|saang7|caan2
 (再 三)	zoi3|saam1
-(再 ㊂)	zoi3|saam1
 (再 會)	zoi3|wui6
 (再 会)	zoi3|wui6
 (再 種)	zoi3|zung3
 (再 种)	zoi3|zung3
 (再 上)	zoi6|soeng5
-(再 ㊤)	zoi6|soeng5
 冏	gwing2
 冑	zau6
 冒	mou6
@@ -10365,7 +8760,6 @@ _9      gau2||
 (军 长)	gwan1|zoeng2
 农	nung4
 (农 业 生 产 合 作 社)	nung4|jip6|saang7|caan2|hap6|zok3|se5
-(农 业 生 产 合 作 ㊓)	nung4|jip6|saang7|caan2|hap6|zok3|se5
 (农 业 生 产 合 作 社)	nung4|jip6|saang7|caan2|hap6|zok3|se5
 (农 舍)	nung4|se3
 冞	mei4
@@ -10395,7 +8789,6 @@ _9      gau2||
 冯	fung4
 冰	bing1
 (冰 上)	bing1|soeng6
-(冰 ㊤)	bing1|soeng6
 冱	wu6
 冲	cung1
 (冲 向)	cung1|hoeng2
@@ -10411,13 +8804,9 @@ _9      gau2||
 (冷 冷 淡 淡)	laang5|laang5|daam6|daam6
 (冷 冷 淡 淡)	laang5|laang5|daam6|daam6
 (冷 笑 一 聲)	laang5|siu3|jat1|seng1
-(冷 笑 ㊀ 聲)	laang5|siu3|jat1|seng1
 (冷 笑 一 聲)	laang5|siu3|jat1|seng1
-(冷 笑 ㊀ 聲)	laang5|siu3|jat1|seng1
 (冷 笑 一 声)	laang5|siu3|jat1|seng1
-(冷 笑 ㊀ 声)	laang5|siu3|jat1|seng1
 (冷 笑 一 声)	laang5|siu3|jat1|seng1
-(冷 笑 ㊀ 声)	laang5|siu3|jat1|seng1
 (冷 醃 法)	laang5|jim1|faat3
 (冷 醃 法)	laang5|jim1|faat3
 (冷 腌 法)	laang5|jim1|faat3
@@ -10449,9 +8838,7 @@ _9      gau2||
 (净 值)	zing6|zik6
 (净 化)	zing6|faa3
 (净 土)	zing6|tou2
-(净 ㊏)	zing6|tou2
 (净 水)	zing6|seoi2
-(净 ㊌)	zing6|seoi2
 (净 尽)	zing6|zeon6
 (净 重)	zing6|cung4
 (净 返)	zing6|faan1
@@ -10526,9 +8913,7 @@ _9      gau2||
 (出 山 為 相)	ceot7|saan7|wai4|soeng3
 (出 山 为 相)	ceot7|saan7|wai4|soeng3
 (出 曬 名)	ceot1|saai3|meng2
-(出 曬 ㊔)	ceot1|saai3|meng2
 (出 晒 名)	ceot1|saai3|meng2
-(出 晒 ㊔)	ceot1|saai3|meng2
 (出 使)	ceot1|si3
 (出 差)	ceot1|caai1
 (出 聲)	ceot1|seng1
@@ -10536,8 +8921,6 @@ _9      gau2||
 (出 刊)	ceot1|hon2
 击	gik1
 (击 中)	gik1|zung3
-(击 🀄)	gik1|zung3
-(击 ㊥)	gik1|zung3
 凼	tam5
 函	haam4
 凾	haam4
@@ -10559,7 +8942,6 @@ _9      gau2||
 (分 香 卖 履)	fan1|hoeng1|maai6|leoi5
 (分 香 卖 履)	fan1|hoeng1|maai6|leoi5
 (分 之 一)	fan6|zi1|jat1
-(分 之 ㊀)	fan6|zi1|jat1
 (分 布 於)	fan7|bou3|jyu7
 (分 布 于)	fan7|bou3|jyu7
 (分 子)	fan6|zi2
@@ -10586,11 +8968,7 @@ _9      gau2||
 切	cit3
 切	cit3
 (切 中)	cit3|zung3
-(切 🀄)	cit3|zung3
-(切 ㊥)	cit3|zung3
 (切 中)	cit3|zung3
-(切 🀄)	cit3|zung3
-(切 ㊥)	cit3|zung3
 (切 斷)	cit3|dyun3
 (切 斷)	cit3|dyun3
 (切 断)	cit3|dyun3
@@ -10599,7 +8977,6 @@ _9      gau2||
 刉	gei1
 刊	hon1
 (刊 印)	hon2|jan3
-(刊 ㊞)	hon2|jan3
 (刊 登)	hon2|dang1
 (刊 載)	hon2|zoi3
 (刊 载)	hon2|zoi3
@@ -10634,7 +9011,6 @@ _9      gau2||
 (初 更)	co1|gaang1
 (初 衷)	co1|cung1
 (初 三)	co1|saam1
-(初 ㊂)	co1|saam1
 刟	diu1
 删	saan1
 判	pun3
@@ -10662,13 +9038,9 @@ _9      gau2||
 (利 默 里 克)	lei6|mak6|leoi5|hak1
 (利 默 里 克)	lei6|mak6|leoi5|hak1
 (利 上 滾 利)	lei6|soeng6|gwan2|lei6
-(利 ㊤ 滾 利)	lei6|soeng6|gwan2|lei6
 (利 上 滾 利)	lei6|soeng6|gwan2|lei6
-(利 ㊤ 滾 利)	lei6|soeng6|gwan2|lei6
 (利 上 滚 利)	lei6|soeng6|gwan2|lei6
-(利 ㊤ 滚 利)	lei6|soeng6|gwan2|lei6
 (利 上 滚 利)	lei6|soeng6|gwan2|lei6
-(利 ㊤ 滚 利)	lei6|soeng6|gwan2|lei6
 (利 比 裡 亞)	lei6|bei2|lei5|ngaa3
 (利 比 裡 亞)	lei6|bei2|lei5|ngaa3
 (利 比 裡 亞)	lei6|bei2|lei5|ngaa3
@@ -10717,11 +9089,7 @@ _9      gau2||
 刺	ci3
 刺	ci3
 (刺 中)	ci3|zung3
-(刺 🀄)	ci3|zung3
-(刺 ㊥)	ci3|zung3
 (刺 中)	ci3|zung3
-(刺 🀄)	ci3|zung3
-(刺 ㊥)	ci3|zung3
 刻	hak1
 (刻 畫)	hak1|waa6
 (刻 画)	hak1|waa6
@@ -10741,9 +9109,7 @@ _9      gau2||
 剉	co3
 削	soek3
 (削 足 適 履)	soek3|zuk1|sik1|leoi5
-(削 足 ㊜ 履)	soek3|zuk1|sik1|leoi5
 (削 足 適 履)	soek3|zuk1|sik1|leoi5
-(削 足 ㊜ 履)	soek3|zuk1|sik1|leoi5
 (削 足 适 履)	soek3|zuk1|sik1|leoi5
 (削 足 适 履)	soek3|zuk1|sik1|leoi5
 剋	hak1
@@ -10825,9 +9191,7 @@ _9      gau2||
 力	lik6
 力	lik6
 (力 爭 上 遊)	lik6|zang1|soeng6|jau4
-(力 爭 ㊤ 遊)	lik6|zang1|soeng6|jau4
 (力 爭 上 遊)	lik6|zang1|soeng6|jau4
-(力 爭 ㊤ 遊)	lik6|zang1|soeng6|jau4
 (力 薄 才 疏)	lik6|bok6|coi4|so3
 (力 薄 才 疏)	lik6|bok6|coi4|so3
 (力 錢)	lik6|zin2
@@ -10898,13 +9262,9 @@ _9      gau2||
 勇	jung5
 勇	jung5
 (勇 冠 三 軍)	jung5|gun3|saam1|gwan1
-(勇 冠 ㊂ 軍)	jung5|gun3|saam1|gwan1
 (勇 冠 三 軍)	jung5|gun3|saam1|gwan1
-(勇 冠 ㊂ 軍)	jung5|gun3|saam1|gwan1
 (勇 冠 三 军)	jung5|gun3|saam1|gwan1
-(勇 冠 ㊂ 军)	jung5|gun3|saam1|gwan1
 (勇 冠 三 军)	jung5|gun3|saam1|gwan1
-(勇 冠 ㊂ 军)	jung5|gun3|saam1|gwan1
 勉	min5
 勉	min5
 (勉 勉 強 強)	min5|min5|koeng5|koeng5
@@ -10974,7 +9334,6 @@ _9      gau2||
 (勾 當)	ngau1|dong3
 (勾 当)	ngau1|dong3
 (勾 上)	ngau1|soeng6
-(勾 ㊤)	ngau1|soeng6
 勿	mat6
 匀	wan4
 (匀 净)	wan4|zing6
@@ -11003,7 +9362,6 @@ _9      gau2||
 (化 腐 朽 为 神 奇)	faa3|fu2|nau2|wai4|san4|kei4
 (化 學 戰 斗 部)	faa3|hok6|zin3|dau3|bou6
 (化 名)	faa3|meng2
-(化 ㊔)	faa3|meng2
 (化 纤)	faa3|cim1
 北	bak1
 🀃	bak1
@@ -11046,57 +9404,29 @@ _9      gau2||
 十	sap6
 ㊉	sap6
 (十 里 洋 場)	sap6|leoi5|joeng4|coeng4
-(㊉ 里 洋 場)	sap6|leoi5|joeng4|coeng4
 (十 里 洋 場)	sap6|leoi5|joeng4|coeng4
-(㊉ 里 洋 場)	sap6|leoi5|joeng4|coeng4
 (十 里 洋 场)	sap6|leoi5|joeng4|coeng4
-(㊉ 里 洋 场)	sap6|leoi5|joeng4|coeng4
 (十 里 洋 场)	sap6|leoi5|joeng4|coeng4
-(㊉ 里 洋 场)	sap6|leoi5|joeng4|coeng4
 (十 字 架)	sap6|zi6|gaa2
-(㊉ 字 架)	sap6|zi6|gaa2
 (十 塊 錢)	sap6|faai3|cin4
-(㊉ 塊 錢)	sap6|faai3|cin4
 (十 块 钱)	sap6|faai3|cin4
-(㊉ 块 钱)	sap6|faai3|cin4
 (十 三 麽)	sap6|saam1|jiu1
-(㊉ 三 麽)	sap6|saam1|jiu1
-(十 ㊂ 麽)	sap6|saam1|jiu1
 (十 三 么)	sap6|saam1|jiu1
-(㊉ 三 么)	sap6|saam1|jiu1
-(十 ㊂ 么)	sap6|saam1|jiu1
 (十 三)	sap6|saam1
-(㊉ 三)	sap6|saam1
-(十 ㊂)	sap6|saam1
 (十 筐)	sap6|kwaang1
-(㊉ 筐)	sap6|kwaang1
 (十 下)	sap6|haa5
-(十 ㊦)	sap6|haa5
-(㊉ 下)	sap6|haa5
 (十 錢)	sap6|cin4
-(㊉ 錢)	sap6|cin4
 (十 钱)	sap6|cin4
-(㊉ 钱)	sap6|cin4
 (十 只)	sap6|zek3
-(㊉ 只)	sap6|zek3
 (十 行)	sap6|hong4
-(㊉ 行)	sap6|hong4
 (十 行)	sap6|hong4
-(㊉ 行)	sap6|hong4
 (十 頂)	sap6|deng2
-(㊉ 頂)	sap6|deng2
 (十 顶)	sap6|deng2
-(㊉ 顶)	sap6|deng2
 (十 幢)	sap6|zong6
-(㊉ 幢)	sap6|zong6
 (十 間)	sap6|gaan3
-(㊉ 間)	sap6|gaan3
 (十 间)	sap6|gaan3
-(㊉ 间)	sap6|gaan3
 (十 筒)	sap6|tung4
-(㊉ 筒)	sap6|tung4
 (十 打)	sap6|daa1
-(㊉ 打)	sap6|daa1
 卂	seon3
 千	cin1
 (千 里 達 和 多 巴 哥)	cin1|lei5|daat6|wo4|do1|baa1|go1
@@ -11128,27 +9458,20 @@ _9      gau2||
 升	sing1
 (升 學 考 試)	sing1|hok6|haau2|si5
 (升 学 考 试)	sing1|hok6|haau2|si5
-(升 ㊫ 考 试)	sing1|hok6|haau2|si5
 (升 等 考 試)	sing1|dang2|haau2|si5
 (升 等 考 试)	sing1|dang2|haau2|si5
 (升 班 考 試)	sing1|baan1|haau2|si5
 (升 班 考 试)	sing1|baan1|haau2|si5
 (升 上)	sing1|soeng6
-(升 ㊤)	sing1|soeng6
 午	ng5
 (午 覺)	ng5|gaau3
 (午 觉)	ng5|gaau3
 卉	wai2
 半	bun3
 (半 夜 三 更)	bun3|je6|saam1|gaang1
-(半 ㊰ 三 更)	bun3|je6|saam1|gaang1
-(半 夜 ㊂ 更)	bun3|je6|saam1|gaang1
 (半 夜 三 更)	bun3|je6|saam1|gaang1
-(半 ㊰ 三 更)	bun3|je6|saam1|gaang1
-(半 夜 ㊂ 更)	bun3|je6|saam1|gaang1
 (半 真 半 假)	bun3|zan1|bun3|gaa2
 (半 途 上)	bun3|tou4|soeng6
-(半 途 ㊤)	bun3|tou4|soeng6
 (半 打)	bun3|daa1
 (半 生)	bun3|saang1
 (半 載)	bun3|zoi2
@@ -11169,9 +9492,7 @@ _9      gau2||
 協	hip3
 ㊯	hip3
 (協 調)	hip3|tiu4
-(㊯ 調)	hip3|tiu4
 (協 調)	hip3|tiu4
-(㊯ 調)	hip3|tiu4
 单	daan1
 (单 亲 家 庭)	daan1|can1|gaa1|ting4
 (单 于)	sin4|jyu4
@@ -11182,17 +9503,11 @@ _9      gau2||
 南	naam4
 🀁	naam4
 (南 無 阿 彌 陀 佛)	naam4|mou4|o1|nei4|to4|fat6
-(🀁 無 阿 彌 陀 佛)	naam4|mou4|o1|nei4|to4|fat6
 (南 无 阿 弥 陀 佛)	naam4|mou4|o1|nei4|to4|fat6
-(🀁 无 阿 弥 陀 佛)	naam4|mou4|o1|nei4|to4|fat6
 (南 方 話)	naam4|fong1|waa2
-(🀁 方 話)	naam4|fong1|waa2
 (南 方 话)	naam4|fong1|waa2
-(🀁 方 话)	naam4|fong1|waa2
 (南 京 話)	naam4|ging1|waa2
-(🀁 京 話)	naam4|ging1|waa2
 (南 京 话)	naam4|ging1|waa2
-(🀁 京 话)	naam4|ging1|waa2
 単	daan1
 博	bok3
 (博 斗)	bok3|dau3
@@ -11203,10 +9518,8 @@ _9      gau2||
 卟	buk1
 占	zim3
 (占 为 己 有)	zim3|wai4|gei2|jau5
-(占 为 己 ㊒)	zim3|wai4|gei2|jau5
 (占 星 學)	zim3|sing1|hok6
 (占 星 学)	zim3|sing1|hok6
-(占 星 ㊫)	zim3|sing1|hok6
 (占 星 家)	zim3|sing1|gaa1
 (占 星 術)	zim3|sing1|seot6
 (占 星 术)	zim3|sing1|seot6
@@ -11241,13 +9554,9 @@ _9      gau2||
 印	jan3
 ㊞	jan3
 (印 地 安 話)	jan3|dei6|ngon1|waa2
-(㊞ 地 安 話)	jan3|dei6|ngon1|waa2
 (印 地 安 话)	jan3|dei6|ngon1|waa2
-(㊞ 地 安 话)	jan3|dei6|ngon1|waa2
 (印 行)	jan3|hong4
-(㊞ 行)	jan3|hong4
 (印 行)	jan3|hong4
-(㊞ 行)	jan3|hong4
 危	ngai4
 (危 難)	ngai4|naan6
 (危 難)	ngai4|naan6
@@ -11280,17 +9589,11 @@ _9      gau2||
 厂	cong2
 厄	aak1
 (厄 立 特 里 亞)	aak1|lap6|dak6|leoi5|ngaa3
-(厄 立 ㊕ 里 亞)	aak1|lap6|dak6|leoi5|ngaa3
 (厄 立 特 里 亞)	aak1|lap6|dak6|leoi5|ngaa3
-(厄 立 ㊕ 里 亞)	aak1|lap6|dak6|leoi5|ngaa3
 (厄 立 特 里 亞)	aak1|lap6|dak6|leoi5|ngaa3
-(厄 立 ㊕ 里 亞)	aak1|lap6|dak6|leoi5|ngaa3
 (厄 立 特 里 亚)	aak1|lap6|dak6|leoi5|ngaa3
-(厄 立 ㊕ 里 亚)	aak1|lap6|dak6|leoi5|ngaa3
 (厄 立 特 里 亚)	aak1|lap6|dak6|leoi5|ngaa3
-(厄 立 ㊕ 里 亚)	aak1|lap6|dak6|leoi5|ngaa3
 (厄 立 特 里 亚)	aak1|lap6|dak6|leoi5|ngaa3
-(厄 立 ㊕ 里 亚)	aak1|lap6|dak6|leoi5|ngaa3
 厅	teng1
 (厅 长)	teng1|zoeng2
 历	lik6
@@ -11317,9 +9620,7 @@ _9      gau2||
 厞	fei6
 原	jyun4
 (原 則 上)	jyun4|zak1|soeng6
-(原 則 ㊤)	jyun4|zak1|soeng6
 (原 则 上)	jyun4|zak1|soeng6
-(原 则 ㊤)	jyun4|zak1|soeng6
 厠	ci3
 厢	soeng1
 厣	jim2
@@ -11438,13 +9739,11 @@ _9      gau2||
 (叔 伯)	suk1|baa3
 取	ceoi2
 (取 法 乎 上)	ceoi2|faat3|fu4|soeng6
-(取 法 乎 ㊤)	ceoi2|faat3|fu4|soeng6
 受	sau6
 (受 之 無 愧)	sau6|zi1|mou4|kwai5
 (受 之 无 愧)	sau6|zi1|mou4|kwai5
 (受 到 重 用)	sau6|dou3|zung6|jung6
 (受 之 有 愧)	sau6|zi1|jau5|kwai5
-(受 之 ㊒ 愧)	sau6|zi1|jau5|kwai5
 (受 話 機)	sau6|waa2|gei1
 (受 话 机)	sau6|waa2|gei1
 (受 重 用)	sau6|zung6|jung6
@@ -11548,18 +9847,14 @@ _9      gau2||
 (叫 嚷)	giu3|joeng6
 (叫 醒)	giu3|seng2
 (叫 下)	giu3|haa5
-(叫 ㊦)	giu3|haa5
 (叫 上)	giu3|soeng6
-(叫 ㊤)	giu3|soeng6
 召	ziu6
 叭	baa1
 叮	ding1
 可	ho2
 🉑	ho2
 (可 可 西 里)	ho2|ho2|sai1|leoi5
-(可 可 🀂 里)	ho2|ho2|sai1|leoi5
 (可 可 西 里)	ho2|ho2|sai1|leoi5
-(可 可 🀂 里)	ho2|ho2|sai1|leoi5
 (可 緊 可 松)	ho2|gan2|ho2|sung1
 (可 紧 可 松)	ho2|gan2|ho2|sung1
 (可 惡)	ho2|wu3
@@ -11586,23 +9881,15 @@ _9      gau2||
 (史 不 绝 书)	si2|bat1|zyut6|syu1
 (史 不 绝 书)	si2|bat1|zyut6|syu1
 (史 上)	si2|soeng6
-(史 ㊤)	si2|soeng6
 右	jau6
 ㊨	jau6
 🈮	jau6
 (右 傾 機 會)	jau6|king1|gei1|wui4
-(㊨ 傾 機 會)	jau6|king1|gei1|wui4
 (右 倾 机 会)	jau6|king1|gei1|wui4
-(㊨ 倾 机 会)	jau6|king1|gei1|wui4
 (右 上)	jau6|soeng6
-(㊨ 上)	jau6|soeng6
-(右 ㊤)	jau6|soeng6
 (右 轉)	jau6|zyun3
-(㊨ 轉)	jau6|zyun3
 (右 转)	jau6|zyun3
-(㊨ 转)	jau6|zyun3
 (右 券)	jau6|gyun3
-(㊨ 券)	jau6|gyun3
 叴	kau4
 叵	po2
 叶	jip6
@@ -11627,7 +9914,6 @@ _9      gau2||
 (吃 相)	hek3|soeng3
 各	gok3
 (各 上)	gok3|soeng6
-(各 ㊤)	gok3|soeng6
 (各 剩)	gok3|sing6
 (各 使)	gok3|si3
 吅	zung6
@@ -11635,7 +9921,6 @@ _9      gau2||
 合	hap6
 🈴	hap6
 (合 上)	hap6|soeng6
-(合 ㊤)	hap6|soeng6
 (合 并)	hap6|bing3
 (合 彈)	hap6|taan4
 (合 弹)	hap6|taan4
@@ -11658,18 +9943,14 @@ _9      gau2||
 (吊 铺)	diu3|pou1
 (吊 命)	diu3|meng6
 (吊 上)	diu3|soeng6
-(吊 ㊤)	diu3|soeng6
 (吊 架)	diu3|gaa2
 吋	cyun3
 同	tung4
 (同 日 而 語)	tung4|jat6|ji4|jyu6
-(同 ㊐ 而 語)	tung4|jat6|ji4|jyu6
 (同 日 而 语)	tung4|jat6|ji4|jyu6
-(同 ㊐ 而 语)	tung4|jat6|ji4|jyu6
 (同 樣 會)	tung4|joeng6|wui6
 (同 样 会)	tung4|joeng6|wui6
 (同 上)	tung4|soeng6
-(同 ㊤)	tung4|soeng6
 (同 訂)	tung4|ding6
 (同 订)	tung4|ding6
 (同 長)	tung4|zoeng2
@@ -11679,22 +9960,14 @@ _9      gau2||
 名	ming4
 ㊔	ming4
 (名 片 盒)	ming4|pin3|hap6
-(㊔ 片 盒)	ming4|pin3|hap6
 (名 分)	ming4|fan6
-(㊔ 分)	ming4|fan6
 (名 媛)	ming4|wun4
-(㊔ 媛)	ming4|wun4
 (名 片)	ming4|pin2
-(㊔ 片)	ming4|pin2
 (名 聲)	ming4|sing1
-(㊔ 聲)	ming4|sing1
 (名 声)	ming4|sing1
-(㊔ 声)	ming4|sing1
 (名 表)	ming4|biu1
-(㊔ 表)	ming4|biu1
 后	hau6
 (后 会 有 期)	hau6|wui6|jau5|kei4
-(后 会 ㊒ 期)	hau6|wui6|jau5|kei4
 (后 生 动 物)	hau6|sang1|dung6|mat6
 (后 里)	hau6|leoi5
 (后 里)	hau6|leoi5
@@ -11713,7 +9986,6 @@ _9      gau2||
 (向 後 轉)	hoeng3|hau6|zyun3
 (向 后 转)	hoeng3|hau6|zyun3
 (向 上)	hoeng3|soeng6
-(向 ㊤)	hoeng3|soeng6
 吒	zaa1
 吓	haak3
 吔	jaa1
@@ -11724,7 +9996,6 @@ _9      gau2||
 吚	ji1
 君	gwan1
 (君 子 之 交 淡 如 水)	gwan1|zi2|zi1|gaau1|daam6|jyu4|seoi2
-(君 子 之 交 淡 如 ㊌)	gwan1|zi2|zi1|gaau1|daam6|jyu4|seoi2
 (君 子 好 逑)	gwan1|zi2|hou3|kau4
 吝	leon6
 吝	leon6
@@ -11819,9 +10090,7 @@ _9      gau2||
 (呢 喃 細 語)	nei4|naam4|sai3|jyu5
 (呢 喃 细 语)	nei4|naam4|sai3|jyu5
 (呢 幾 日)	lei1|gei2|jat6
-(呢 幾 ㊐)	lei1|gei2|jat6
 (呢 几 日)	lei1|gei2|jat6
-(呢 几 ㊐)	lei1|gei2|jat6
 (呢 個 人)	lei1|go3|jan4
 (呢 个 人)	lei1|go3|jan4
 (呢 班 人)	lei1|baan1|jan4
@@ -11849,11 +10118,7 @@ _9      gau2||
 呦	jau1
 周	zau1
 (周 三 徑 一)	zau1|saam1|ging3|jat1
-(周 ㊂ 徑 一)	zau1|saam1|ging3|jat1
-(周 三 徑 ㊀)	zau1|saam1|ging3|jat1
 (周 三 径 一)	zau1|saam1|ging3|jat1
-(周 ㊂ 径 一)	zau1|saam1|ging3|jat1
-(周 三 径 ㊀)	zau1|saam1|ging3|jat1
 (周 圍)	zau7|wai4
 (周 围)	zau7|wai4
 (周 易)	zau1|jik6
@@ -11890,8 +10155,6 @@ _9      gau2||
 (命 令 行)	ming6|ling6|hong4
 (命 令 行)	ming6|ling6|hong4
 (命 中)	ming6|zung3
-(命 🀄)	ming6|zung3
-(命 ㊥)	ming6|zung3
 (命 相)	ming6|soeng3
 (命 大)	meng6|daai6
 呾	daat3
@@ -12066,9 +10329,7 @@ _9      gau2||
 (哺 育)	bou6|juk6
 哼	hang7
 (哼 哈 二 將)	hang1|haa1|ji6|zoeng3
-(哼 哈 ㊁ 將)	hang1|haa1|ji6|zoeng3
 (哼 哈 二 将)	hang1|haa1|ji6|zoeng3
-(哼 哈 ㊁ 将)	hang1|haa1|ji6|zoeng3
 (哼 唱)	hang1|coeng3
 (哼 聲)	hang1|sing1
 (哼 声)	hang1|sing1
@@ -12102,12 +10363,9 @@ _9      gau2||
 唏	hei1
 唐	tong4
 (唐 三 藏)	tong4|saam1|zong6
-(唐 ㊂ 藏)	tong4|saam1|zong6
 (唐 伯 虎)	tong4|baa3|fu2
 (唐 三 彩)	tong4|saam1|coi2
-(唐 ㊂ 彩)	tong4|saam1|coi2
 (唐 三 彩)	tong4|saam1|coi2
-(唐 ㊂ 彩)	tong4|saam1|coi2
 唑	zo6
 唓	ce1
 唔	ng4
@@ -12554,53 +10812,27 @@ _9      gau2||
 四	sei3
 ㊃	sei3
 (四 大 须 生)	sei3|daai6|sou1|saang7
-(㊃ 大 须 生)	sei3|daai6|sou1|saang7
 (四 下 里)	sei3|haa5|leoi5
-(四 ㊦ 里)	sei3|haa5|leoi5
-(㊃ 下 里)	sei3|haa5|leoi5
 (四 下 里)	sei3|haa5|leoi5
-(四 ㊦ 里)	sei3|haa5|leoi5
-(㊃ 下 里)	sei3|haa5|leoi5
 (四 下)	sei3|haa5
-(四 ㊦)	sei3|haa5
-(㊃ 下)	sei3|haa5
 (四 更)	sei3|gaang7
-(㊃ 更)	sei3|gaang7
 (四 更)	sei3|gaang7
-(㊃ 更)	sei3|gaang7
 (四 會)	sei3|wui5
-(㊃ 會)	sei3|wui5
 (四 会)	sei3|wui5
-(㊃ 会)	sei3|wui5
 (四 濺)	sei3|zin3
-(㊃ 濺)	sei3|zin3
 (四 溅)	sei3|zin3
-(㊃ 溅)	sei3|zin3
 (四 行)	sei3|hong4
-(㊃ 行)	sei3|hong4
 (四 行)	sei3|hong4
-(㊃ 行)	sei3|hong4
 (四 檔)	sei3|dong2
-(㊃ 檔)	sei3|dong2
 (四 档)	sei3|dong2
-(㊃ 档)	sei3|dong2
 (四 錢)	sei3|cin4
-(㊃ 錢)	sei3|cin4
 (四 钱)	sei3|cin4
-(㊃ 钱)	sei3|cin4
 (四 筒)	sei3|tung4
-(㊃ 筒)	sei3|tung4
 (四 上)	sei3|soeng6
-(四 ㊤)	sei3|soeng6
-(㊃ 上)	sei3|soeng6
 (四 頂)	sei3|deng2
-(㊃ 頂)	sei3|deng2
 (四 顶)	sei3|deng2
-(㊃ 顶)	sei3|deng2
 (四 打)	sei3|daa1
-(㊃ 打)	sei3|daa1
 (四 只)	sei3|zek3
-(㊃ 只)	sei3|zek3
 囝	naam4
 (囝 囝)	zai4|zai2
 回	wui4
@@ -12688,33 +10920,19 @@ _9      gau2||
 土	tou2
 ㊏	tou2
 (土 生 土 長)	tou2|sang1|tou2|zoeng2
-(㊏ 生 ㊏ 長)	tou2|sang1|tou2|zoeng2
 (土 生 土 长)	tou2|sang1|tou2|zoeng2
-(㊏ 生 ㊏ 长)	tou2|sang1|tou2|zoeng2
 (土 地 銀 行)	tou2|dei6|ngan2|hong4
-(㊏ 地 銀 行)	tou2|dei6|ngan2|hong4
 (土 地 銀 行)	tou2|dei6|ngan2|hong4
-(㊏ 地 銀 行)	tou2|dei6|ngan2|hong4
 (土 地 银 行)	tou2|dei6|ngan2|hong4
-(㊏ 地 银 行)	tou2|dei6|ngan2|hong4
 (土 地 银 行)	tou2|dei6|ngan2|hong4
-(㊏ 地 银 行)	tou2|dei6|ngan2|hong4
 (土 壤 溫 度)	tou2|joeng5|wan1|dou6
-(㊏ 壤 溫 度)	tou2|joeng5|wan1|dou6
 (土 壤 溫 度)	tou2|joeng5|wan1|dou6
-(㊏ 壤 溫 度)	tou2|joeng5|wan1|dou6
 (土 壤 温 度)	tou2|joeng5|wan1|dou6
-(㊏ 壤 温 度)	tou2|joeng5|wan1|dou6
 (土 壤 温 度)	tou2|joeng5|wan1|dou6
-(㊏ 壤 温 度)	tou2|joeng5|wan1|dou6
 (土 瓜 灣)	tou2|gwaa1|waan4
-(㊏ 瓜 灣)	tou2|gwaa1|waan4
 (土 瓜 湾)	tou2|gwaa1|waan4
-(㊏ 瓜 湾)	tou2|gwaa1|waan4
 (土 話)	tou2|waa2
-(㊏ 話)	tou2|waa2
 (土 话)	tou2|waa2
-(㊏ 话)	tou2|waa2
 圠	caak3
 圢	ding1
 圣	sing3
@@ -12728,9 +10946,7 @@ _9      gau2||
 (在 劫 難 逃)	zoi6|gip3|naan4|tou4
 (在 劫 难 逃)	zoi6|gip3|naan4|tou4
 (在 線 上)	zoi6|sin3|soeng6
-(在 線 ㊤)	zoi6|sin3|soeng6
 (在 线 上)	zoi6|sin3|soeng6
-(在 线 ㊤)	zoi6|sin3|soeng6
 (在 位)	zoi6|wai6
 (在 行)	zoi6|hong4
 (在 行)	zoi6|hong4
@@ -12745,10 +10961,8 @@ _9      gau2||
 地	dei6
 (地 藏 王)	dei6|zong6|wong4
 (地 上)	dei6|soeng6
-(地 ㊤)	dei6|soeng6
 (地 位)	dei6|wai6
 (地 名)	dei6|meng2
-(地 ㊔)	dei6|meng2
 (地 毯)	dei6|taan2
 (地 痞)	dei6|mau1
 (地 處)	dei6|cyu2
@@ -12761,7 +10975,6 @@ _9      gau2||
 场	coeng4
 (场 面)	coeng4|min2
 (场 上)	coeng4|soeng6
-(场 ㊤)	coeng4|soeng6
 圻	kei4
 圽	mut6
 圾	kap1
@@ -12819,7 +11032,6 @@ _9      gau2||
 (坐 朝 问 道)	zo6|ciu4|man6|dou6
 (坐 朝 問 道)	zo6|ciu4|man6|dou6
 (坐 月 子)	zo6|jyut6|zi2
-(坐 ㊊ 子)	zo6|jyut6|zi2
 (坐 談 會)	zo6|taam4|wui2
 (坐 谈 会)	zo6|taam4|wui2
 (坐 化)	zo6|faa3
@@ -12961,7 +11173,6 @@ _9      gau2||
 埞	deng6
 域	wik6
 (域 名)	wik6|meng2
-(域 ㊔)	wik6|meng2
 埠	fau6
 埡	aa3
 埢	gyun6
@@ -12982,7 +11193,6 @@ _9      gau2||
 (執 著)	zap1|zoek6
 (執 著)	zap1|zoek6
 (執 正)	zap1|zeng3
-(執 ㊣)	zap1|zeng3
 埸	jik6
 培	pui4
 (培 里 克 利 斯)	pui4|leoi5|hak1|lei6|si1
@@ -12992,7 +11202,6 @@ _9      gau2||
 (基 里 巴 斯)	gei1|leoi5|baa1|si1
 (基 里 巴 斯)	gei1|leoi5|baa1|si1
 (基 本 上)	gei1|bun2|soeng6
-(基 本 ㊤)	gei1|bun2|soeng6
 埻	zeon2
 埼	kei4
 埽	sou3
@@ -13038,7 +11247,6 @@ _9      gau2||
 堰	jin2
 報	bou3
 (報 名)	bou3|meng2
-(報 ㊔)	bou3|meng2
 (報 販)	bou3|faan2
 (報 更)	bou3|gaang1
 (報 更)	bou3|gaang1
@@ -13047,7 +11255,6 @@ _9      gau2||
 場	coeng4
 (場 面)	coeng4|min2
 (場 上)	coeng4|soeng6
-(場 ㊤)	coeng4|soeng6
 堵	dou2
 堶	to4
 堺	gaai3
@@ -13232,7 +11439,6 @@ _9      gau2||
 (处 分)	cyu5|fan7
 (处 境)	cyu5|ging2
 (处 女)	cyu5|neoi5
-(处 ㊛)	cyu5|neoi5
 (处 女)	cyu5|neoi5
 (处 方)	cyu5|fong1
 (处 于)	cyu5|jyu7
@@ -13258,12 +11464,10 @@ _9      gau2||
 (复 利)	fuk1|lei6
 (复 利)	fuk1|lei6
 (复 印)	fuk1|jan3
-(复 ㊞)	fuk1|jan3
 (复 句)	fuk1|geoi3
 (复 句)	fuk1|geoi3
 (复 姓)	fuk1|sing3
 (复 写)	fuk1|se2
-(复 ㊢)	fuk1|se2
 (复 式)	fuk1|sik1
 (复 数)	fuk1|sou3
 (复 方)	fuk1|fong1
@@ -13271,7 +11475,6 @@ _9      gau2||
 (复 比)	fuk1|bei2
 (复 眼)	fuk1|ngaan5
 (复 社)	fuk1|se5
-(复 ㊓)	fuk1|se5
 (复 社)	fuk1|se5
 (复 线)	fuk1|sin3
 (复 听)	fuk1|ting3
@@ -13330,7 +11533,6 @@ _9      gau2||
 (多 重 要)	do1|zung6|jiu3
 (多 重)	do1|cung5
 (多 上)	do1|soeng6
-(多 ㊤)	do1|soeng6
 (多 與)	do1|jyu4
 (多 与)	do1|jyu4
 (多 刊)	do1|hon2
@@ -13343,40 +11545,25 @@ _9      gau2||
 (多 話)	do1|waa2
 (多 话)	do1|waa2
 (多 下)	do1|haa5
-(多 ㊦)	do1|haa5
 (多 相)	do1|soeng3
 (多 錢)	do7|cin2
 (多 钱)	do7|cin2
 夜	je6
 ㊰	je6
 (夜 夜 笙 歌)	je6|je6|sang1|go1
-(㊰ ㊰ 笙 歌)	je6|je6|sang1|go1
 (夜 靜 更 深)	je6|zing6|gang1|sam1
-(㊰ 靜 更 深)	je6|zing6|gang1|sam1
 (夜 靜 更 深)	je6|zing6|gang1|sam1
-(㊰ 靜 更 深)	je6|zing6|gang1|sam1
 (夜 静 更 深)	je6|zing6|gang1|sam1
-(㊰ 静 更 深)	je6|zing6|gang1|sam1
 (夜 静 更 深)	je6|zing6|gang1|sam1
-(㊰ 静 更 深)	je6|zing6|gang1|sam1
 (夜 冷 貨)	je6|laang1|fo3
-(㊰ 冷 貨)	je6|laang1|fo3
 (夜 冷 貨)	je6|laang1|fo3
-(㊰ 冷 貨)	je6|laang1|fo3
 (夜 冷 货)	je6|laang1|fo3
-(㊰ 冷 货)	je6|laang1|fo3
 (夜 冷 货)	je6|laang1|fo3
-(㊰ 冷 货)	je6|laang1|fo3
 (夜 光 表)	je6|gwong1|biu1
-(㊰ 光 表)	je6|gwong1|biu1
 (夜 里)	je6|leoi5
-(㊰ 里)	je6|leoi5
 (夜 里)	je6|leoi5
-(㊰ 里)	je6|leoi5
 (夜 更)	je6|gaang7
-(㊰ 更)	je6|gaang7
 (夜 更)	je6|gaang7
-(㊰ 更)	je6|gaang7
 夝	cing4
 够	gau3
 夠	gau3
@@ -13394,9 +11581,7 @@ _9      gau2||
 (大 不 里 士)	daai6|bat1|leoi5|si6
 (大 不 里 士)	daai6|bat1|leoi5|si6
 (大 吃 一 驚)	daai6|hek3|jat1|geng1
-(大 吃 ㊀ 驚)	daai6|hek3|jat1|geng1
 (大 吃 一 惊)	daai6|hek3|jat1|geng1
-(大 吃 ㊀ 惊)	daai6|hek3|jat1|geng1
 (大 廈 將 傾)	daai6|haa6|zoeng1|king1
 (大 厦 将 倾)	daai6|haa6|zoeng1|king1
 (大 海 撈 針)	daai6|hoi2|laau4|zam1
@@ -13406,30 +11591,20 @@ _9      gau2||
 (大 眾 捷 運)	daai6|zung3|zit3|wan6
 (大 众 捷 运)	daai6|zung3|zit3|wan6
 (大 興 土 木)	daai6|hing3|tou2|muk6
-(大 興 ㊏ 木)	daai6|hing3|tou2|muk6
-(大 興 土 ㊍)	daai6|hing3|tou2|muk6
 (大 兴 土 木)	daai6|hing3|tou2|muk6
-(大 兴 ㊏ 木)	daai6|hing3|tou2|muk6
-(大 兴 土 ㊍)	daai6|hing3|tou2|muk6
 (大 量 生 產)	daai6|loeng6|saang7|caan2
 (大 量 生 產)	daai6|loeng6|saang7|caan2
 (大 量 生 产)	daai6|loeng6|saang7|caan2
 (大 量 生 产)	daai6|loeng6|saang7|caan2
 (大 錯 特 錯)	daai6|co3|dak6|co3
-(大 錯 ㊕ 錯)	daai6|co3|dak6|co3
 (大 错 特 错)	daai6|co3|dak6|co3
-(大 错 ㊕ 错)	daai6|co3|dak6|co3
 (大 排 長 龍)	daai6|paai4|zoeng2|lung4
 (大 排 長 龍)	daai6|paai4|zoeng2|lung4
 (大 排 长 龙)	daai6|paai4|zoeng2|lung4
 (大 興 水 利)	daai6|hing3|seoi2|lei6
-(大 興 ㊌ 利)	daai6|hing3|seoi2|lei6
 (大 興 水 利)	daai6|hing3|seoi2|lei6
-(大 興 ㊌ 利)	daai6|hing3|seoi2|lei6
 (大 兴 水 利)	daai6|hing3|seoi2|lei6
-(大 兴 ㊌ 利)	daai6|hing3|seoi2|lei6
 (大 兴 水 利)	daai6|hing3|seoi2|lei6
-(大 兴 ㊌ 利)	daai6|hing3|seoi2|lei6
 (大 事 宣 傳)	daai6|si6|syun1|zyun6
 (大 事 宣 传)	daai6|si6|syun1|zyun6
 (大 相 逕 庭)	daai6|soeng3|ging3|ting4
@@ -13438,21 +11613,14 @@ _9      gau2||
 (大 異 其 趣)	daai6|ji6|kei4|cuk1
 (大 异 其 趣)	daai6|ji6|kei4|cuk1
 (大 喝 一 聲)	daai6|hot3|jat1|seng1
-(大 喝 ㊀ 聲)	daai6|hot3|jat1|seng1
 (大 喝 一 聲)	daai6|hot3|jat1|seng1
-(大 喝 ㊀ 聲)	daai6|hot3|jat1|seng1
 (大 喝 一 聲)	daai6|hot3|jat1|seng1
-(大 喝 ㊀ 聲)	daai6|hot3|jat1|seng1
 (大 喝 一 声)	daai6|hot3|jat1|seng1
-(大 喝 ㊀ 声)	daai6|hot3|jat1|seng1
 (大 喝 一 声)	daai6|hot3|jat1|seng1
-(大 喝 ㊀ 声)	daai6|hot3|jat1|seng1
 (大 喝 一 声)	daai6|hot3|jat1|seng1
-(大 喝 ㊀ 声)	daai6|hot3|jat1|seng1
 (大 腹 便 便)	daai6|fuk1|pin4|pin4
 (大 腹 便 便)	daai6|fuk1|pin4|pin4
 (大 干 一 票)	daai6|gon3|jat1|piu3
-(大 干 ㊀ 票)	daai6|gon3|jat1|piu3
 (大 而 無 當)	daai6|ji4|mou4|dong3
 (大 而 无 当)	daai6|ji4|mou4|dong3
 (大 風 大 浪)	daai6|fung3|daai6|long6
@@ -13460,9 +11628,7 @@ _9      gau2||
 (大 风 大 浪)	daai6|fung3|daai6|long6
 (大 风 大 浪)	daai6|fung3|daai6|long6
 (大 笑 一 聲)	daai6|siu3|jat1|seng1
-(大 笑 ㊀ 聲)	daai6|siu3|jat1|seng1
 (大 笑 一 声)	daai6|siu3|jat1|seng1
-(大 笑 ㊀ 声)	daai6|siu3|jat1|seng1
 (大 相 徑 庭)	daai6|soeng3|ging3|ting4
 (大 相 径 庭)	daai6|soeng3|ging3|ting4
 (大 使 級)	daai6|si2|kap1
@@ -13472,15 +11638,12 @@ _9      gau2||
 (大 使 馆)	daai6|si2|gun2
 (大 學 生)	daai6|hok6|saang1
 (大 学 生)	daai6|hok6|saang1
-(大 ㊫ 生)	daai6|hok6|saang1
 (大 藏 經)	daai6|zong6|ging1
 (大 藏 经)	daai6|zong6|ging1
 (大 頭 釘)	daai6|tau4|ding1
 (大 头 钉)	daai6|tau4|ding1
 (大 體 上)	daai6|tai2|soeng6
-(大 體 ㊤)	daai6|tai2|soeng6
 (大 体 上)	daai6|tai2|soeng6
-(大 体 ㊤)	daai6|tai2|soeng6
 (大 麻 里)	daai6|maa4|leoi5
 (大 麻 里)	daai6|maa4|leoi5
 (大 禹 嶺)	daai6|jyu5|ling5
@@ -13494,18 +11657,14 @@ _9      gau2||
 (大 霹 雳)	daai6|pik1|lik6
 (大 衿 衫)	daai6|kam1|saam1
 (大 賽 上)	daai6|coi3|soeng6
-(大 賽 ㊤)	daai6|coi3|soeng6
 (大 赛 上)	daai6|coi3|soeng6
-(大 赛 ㊤)	daai6|coi3|soeng6
 (大 覺 瞓)	daai6|gaau3|fan3
 (大 觉 瞓)	daai6|gaau3|fan3
 (大 致 上)	daai6|zi3|soeng6
-(大 致 ㊤)	daai6|zi3|soeng6
 (大 泡 和)	daai6|paau7|wo4
 (大 麯 酒)	daai6|kuk1|zau2
 (大 麴 酒)	daai6|kuk1|zau2
 (大 三)	daai6|saam1
-(大 ㊂)	daai6|saam1
 (大 伯)	daai6|baa3
 (大 使)	daai6|si3
 (大 校)	daai6|gaau3
@@ -13531,7 +11690,6 @@ _9      gau2||
 (天 與 人 歸)	tin1|jyu4|jan4|gwai1
 (天 与 人 归)	tin1|jyu4|jan4|gwai1
 (天 上)	tin1|soeng6
-(天 ㊤)	tin1|soeng6
 (天 使)	tin1|si3
 (天 分)	tin1|fan6
 (天 呀)	tin1|aa6
@@ -13542,23 +11700,15 @@ _9      gau2||
 (天 顶)	tin1|deng2
 太	taai3
 (太 歲 爺 上 動 土)	taai3|seoi3|je4|soeng6|dung6|tou2
-(太 歲 爺 ㊤ 動 土)	taai3|seoi3|je4|soeng6|dung6|tou2
-(太 歲 爺 上 動 ㊏)	taai3|seoi3|je4|soeng6|dung6|tou2
 (太 岁 爷 上 动 土)	taai3|seoi3|je4|soeng6|dung6|tou2
-(太 岁 爷 ㊤ 动 土)	taai3|seoi3|je4|soeng6|dung6|tou2
-(太 岁 爷 上 动 ㊏)	taai3|seoi3|je4|soeng6|dung6|tou2
 (太 上 老 君)	taai3|soeng6|lou5|gwan1
-(太 ㊤ 老 君)	taai3|soeng6|lou5|gwan1
 (太 上 老 君)	taai3|soeng6|lou5|gwan1
-(太 ㊤ 老 君)	taai3|soeng6|lou5|gwan1
 (太 上 皇)	taai3|soeng6|wong4
-(太 ㊤ 皇)	taai3|soeng6|wong4
 (太 麻 里)	taai3|maa4|leoi5
 (太 麻 里)	taai3|maa4|leoi5
 (太 太)	taai3|taai2
 (太 守)	taai3|sau3
 (太 監)	taai3|gaam3
-(太 ㊬)	taai3|gaam3
 (太 监)	taai3|gaam3
 (太 假)	taai3|gaa2
 (太 近)	taai3|kan5
@@ -13596,7 +11746,6 @@ _9      gau2||
 夲	tou1
 头	tau4
 (头 上)	tau4|soeng6
-(头 ㊤)	tau4|soeng6
 (头 里)	tau4|leoi5
 (头 里)	tau4|leoi5
 夶	bei2
@@ -13605,8 +11754,6 @@ _9      gau2||
 (夸 多 斗 靡)	kwaa1|do1|dau3|mei5
 夹	gaap3
 (夹 七 夹 八)	gap3|cat1|gap3|baat3
-(夹 ㊆ 夹 八)	gap3|cat1|gap3|baat3
-(夹 七 夹 ㊇)	gap3|cat1|gap3|baat3
 (夹 起 来)	gap3|hei2|loi4
 (夹 持)	gip6|ci4
 (夹 生)	gaap3|saang1
@@ -13615,8 +11762,6 @@ _9      gau2||
 夼	kong3
 夾	gaap3
 (夾 七 夾 八)	gap3|cat1|gap3|baat3
-(夾 ㊆ 夾 八)	gap3|cat1|gap3|baat3
-(夾 七 夾 ㊇)	gap3|cat1|gap3|baat3
 (夾 起 來)	gap3|hei2|loi4
 (夾 起 來)	gap3|hei2|loi4
 (夾 持)	gip6|ci4
@@ -13710,71 +11855,45 @@ _9      gau2||
 ㊛	neoi5
 女	neoi5
 (女 為 悅 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
-(㊛ 為 悅 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 為 悅 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 為 悅 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
-(㊛ 為 悅 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 為 悅 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
-(㊛ 為 悅 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 为 悦 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
-(㊛ 为 悦 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 为 悦 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 为 悦 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
-(㊛ 为 悦 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 为 悦 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
-(㊛ 为 悦 己 者 容)	neoi5|wai6|jyut6|gei2|ze2|jung4
 (女 用 內 衣)	neoi5|jung6|noi6|ji3
-(㊛ 用 內 衣)	neoi5|jung6|noi6|ji3
 (女 用 內 衣)	neoi5|jung6|noi6|ji3
 (女 用 内 衣)	neoi5|jung6|noi6|ji3
-(㊛ 用 内 衣)	neoi5|jung6|noi6|ji3
 (女 用 内 衣)	neoi5|jung6|noi6|ji3
 (女 生 宿 舍)	neoi5|sang1|suk1|se2
-(㊛ 生 宿 舍)	neoi5|sang1|suk1|se2
 (女 生 宿 舍)	neoi5|sang1|suk1|se2
 (女 儐 相)	neoi5|ban1|soeng3
-(㊛ 儐 相)	neoi5|ban1|soeng3
 (女 儐 相)	neoi5|ban1|soeng3
 (女 傧 相)	neoi5|ban1|soeng3
-(㊛ 傧 相)	neoi5|ban1|soeng3
 (女 傧 相)	neoi5|ban1|soeng3
 (女 舍 監)	neoi5|se3|gaam1
-(女 舍 ㊬)	neoi5|se3|gaam1
-(㊛ 舍 監)	neoi5|se3|gaam1
 (女 舍 監)	neoi5|se3|gaam1
-(女 舍 ㊬)	neoi5|se3|gaam1
 (女 舍 监)	neoi5|se3|gaam1
-(㊛ 舍 监)	neoi5|se3|gaam1
 (女 舍 监)	neoi5|se3|gaam1
 (女 人 家)	neoi5|jan4|gaa1
-(㊛ 人 家)	neoi5|jan4|gaa1
 (女 人 家)	neoi5|jan4|gaa1
 (女 大 使)	neoi5|daai6|si2
-(㊛ 大 使)	neoi5|daai6|si2
 (女 大 使)	neoi5|daai6|si2
 (女 人 腔)	neoi5|jan4|hong1
-(㊛ 人 腔)	neoi5|jan4|hong1
 (女 人 腔)	neoi5|jan4|hong1
 (女 人 味)	neoi5|jan4|mei6
-(㊛ 人 味)	neoi5|jan4|mei6
 (女 人 味)	neoi5|jan4|mei6
 (女 宿 舍)	neoi5|suk1|se2
-(㊛ 宿 舍)	neoi5|suk1|se2
 (女 宿 舍)	neoi5|suk1|se2
 (女 人)	neoi5|jan2
-(㊛ 人)	neoi5|jan2
 (女 人)	neoi5|jan2
 (女 樂)	neoi5|ngok6
-(㊛ 樂)	neoi5|ngok6
 (女 樂)	neoi5|ngok6
 (女 樂)	neoi5|ngok6
-(㊛ 樂)	neoi5|ngok6
 (女 樂)	neoi5|ngok6
-(㊛ 樂)	neoi5|ngok6
 (女 樂)	neoi5|ngok6
-(㊛ 樂)	neoi5|ngok6
 (女 乐)	neoi5|ngok6
-(㊛ 乐)	neoi5|ngok6
 (女 乐)	neoi5|ngok6
 奴	nou4
 奵	ding2
@@ -13814,11 +11933,8 @@ _9      gau2||
 (好 逸 惡 勞)	hou3|jat6|wu3|lou4
 (好 逸 惡 勞)	hou3|jat6|wu3|lou4
 (好 逸 恶 劳)	hou3|jat6|wu3|lou4
-(好 逸 恶 ㊘)	hou3|jat6|wu3|lou4
 (好 逸 恶 劳)	hou3|jat6|wu3|lou4
-(好 逸 恶 ㊘)	hou3|jat6|wu3|lou4
 (好 逸 恶 劳)	hou3|jat6|wu3|lou4
-(好 逸 恶 ㊘)	hou3|jat6|wu3|lou4
 (好 整 以 暇)	hou3|zing2|ji5|haa6
 (好 行 小 慧)	hou3|hang4|siu2|wai6
 (好 行 小 慧)	hou3|hang4|siu2|wai6
@@ -13830,7 +11946,6 @@ _9      gau2||
 (好 奇)	hou3|kei4
 (好 學)	hou3|hok6
 (好 学)	hou3|hok6
-(好 ㊫)	hou3|hok6
 (好 客)	hou3|haak3
 (好 強)	hou3|koeng4
 (好 强)	hou3|koeng4
@@ -13859,7 +11974,6 @@ _9      gau2||
 (好 請)	hou2|ceng2
 (好 请)	hou2|ceng2
 (好 正)	hou2|zeng3
-(好 ㊣)	hou2|zeng3
 (好 近)	hou2|kan5
 (好 問)	hou3|man6
 (好 问)	hou3|man6
@@ -13884,7 +11998,6 @@ _9      gau2||
 (如 履 平 地)	jyu4|leoi5|ping4|dei6
 (如 履 平 地)	jyu4|leoi5|ping4|dei6
 (如 上)	jyu4|soeng6
-(如 ㊤)	jyu4|soeng6
 妃	fei1
 妄	mong5
 (妄 自 菲 薄)	mong5|zi6|fei2|bok6
@@ -14260,9 +12373,7 @@ _9      gau2||
 (孝 悌)	haau3|tai5
 孟	maang6
 (孟 母 三 遷)	maang6|mou5|saam1|cin1
-(孟 母 ㊂ 遷)	maang6|mou5|saam1|cin1
 (孟 母 三 迁)	maang6|mou5|saam1|cin1
-(孟 母 ㊂ 迁)	maang6|mou5|saam1|cin1
 孢	baau1
 季	gwai3
 孤	gu1
@@ -14271,15 +12382,10 @@ _9      gau2||
 学	hok6
 ㊫	hok6
 (学 生 运 动)	hok6|saang7|wan6|dung6
-(㊫ 生 运 动)	hok6|saang7|wan6|dung6
 (学 生 会)	hok6|saang7|wui2
-(㊫ 生 会)	hok6|saang7|wui2
 (学 生 证)	hok6|saang7|zing3
-(㊫ 生 证)	hok6|saang7|zing3
 (学 生)	hok6|sang1
-(㊫ 生)	hok6|sang1
 (学 长)	hok6|zoeng2
-(㊫ 长)	hok6|zoeng2
 孨	zyun2
 孩	haai4
 孪	lyun4
@@ -14316,9 +12422,7 @@ _9      gau2||
 宇	jyu5
 守	sau2
 (守 正 不 阿)	sau2|zing3|bat1|o1
-(守 ㊣ 不 阿)	sau2|zing3|bat1|o1
 (守 正 不 阿)	sau2|zing3|bat1|o1
-(守 ㊣ 不 阿)	sau2|zing3|bat1|o1
 (守 分)	sau2|fan6
 (守 喪)	sau2|song1
 (守 丧)	sau2|song1
@@ -14359,7 +12463,6 @@ _9      gau2||
 (定 貨)	deng6|fo3
 (定 货)	deng6|fo3
 (定 金)	deng6|gam1
-(定 ㊎)	deng6|gam1
 (定 金)	deng6|gam1
 (定 倒)	deng6|dou2
 (定 會)	ding6|wui5
@@ -14373,9 +12476,7 @@ _9      gau2||
 (宝 藏)	bou2|zong6
 实	sat6
 (实 质 上)	sat6|zat1|soeng6
-(实 质 ㊤)	sat6|zat1|soeng6
 (实 际 上)	sat6|zai3|soeng6
-(实 际 ㊤)	sat6|zai3|soeng6
 (实 干)	sat6|gon3
 実	sat6
 宠	cung2
@@ -14478,9 +12579,7 @@ _9      gau2||
 寥	liu4
 實	sat6
 (實 質 上)	sat6|zat1|soeng6
-(實 質 ㊤)	sat6|zat1|soeng6
 (實 際 上)	sat6|zai3|soeng6
-(實 際 ㊤)	sat6|zai3|soeng6
 寧	ning4
 寧	ning4
 寧	ning4
@@ -14520,8 +12619,6 @@ _9      gau2||
 尃	fu1
 射	se6
 (射 中)	se6|zung3
-(射 🀄)	se6|zung3
-(射 ㊥)	se6|zung3
 尅	hak1
 将	zoeng3
 (将 信 将 疑)	zoeng1|seon3|zoeng1|ji4
@@ -14573,16 +12670,13 @@ _9      gau2||
 (小 兴 安 岭)	siu2|hing1|on1|leng5
 (小 學 生)	siu2|hok6|saang7
 (小 学 生)	siu2|hok6|saang7
-(小 ㊫ 生)	siu2|hok6|saang7
 (小 籠 包)	siu2|lung4|baau1
 (小 籠 包)	siu2|lung4|baau1
 (小 笼 包)	siu2|lung4|baau1
 (小 除 夕)	siu2|cyu4|zik6
 (小 脏 鬼)	siu2|zong1|gwai2
 (小 癟 三)	siu2|bit6|saam1
-(小 癟 ㊂)	siu2|bit6|saam1
 (小 瘪 三)	siu2|bit6|saam1
-(小 瘪 ㊂)	siu2|bit6|saam1
 (小 螞 蟻)	siu2|maa5|ngai5
 (小 蚂 蚁)	siu2|maa5|ngai5
 (小 廚 房)	siu2|cyu4|fong2
@@ -14597,9 +12691,7 @@ _9      gau2||
 (小 嘍 羅)	siu2|lau4|lo4
 (小 喽 罗)	siu2|lau4|lo4
 (小 秘 密)	siu2|bit1|mat6
-(小 ㊙ 密)	siu2|bit1|mat6
 (小 三)	siu2|saam1
-(小 ㊂)	siu2|saam1
 (小 傳)	siu2|zyun6
 (小 传)	siu2|zyun6
 (小 陘)	siu2|jing4
@@ -14630,7 +12722,6 @@ _9      gau2||
 (少 塊 膶)	siu2|faai3|jeon2
 (少 块 膶)	siu2|faai3|jeon2
 (少 女)	siu3|neoi5
-(少 ㊛)	siu3|neoi5
 (少 女)	siu3|neoi5
 (少 婦)	siu3|fu5
 (少 妇)	siu3|fu5
@@ -14655,13 +12746,10 @@ _9      gau2||
 (少 帥)	siu3|seoi3
 (少 帅)	siu3|seoi3
 (少 印)	siu3|jan3
-(少 ㊞)	siu3|jan3
 (少 東)	siu3|dung1
 (少 东)	siu3|dung1
-(少 🀀)	siu3|dung1
 (少 吸)	siu2|ngap1
 (少 男)	siu3|naam4
-(少 ㊚)	siu3|naam4
 (少 吊)	siu3|diu3
 (少 奶)	siu3|naai1
 (少 猜)	siu3|caai1
@@ -14753,7 +12841,6 @@ _9      gau2||
 (屏 弃)	bing2|hei3
 (屏 埋)	beng3|maai4
 (屏 上)	ping4|soeng6
-(屏 ㊤)	ping4|soeng6
 屐	kek6
 屑	sit3
 屓	ai3
@@ -14802,11 +12889,8 @@ _9      gau2||
 (山 川 相 隔)	saan1|cyun1|soeng3|gaak3
 (山 楂 片)	saan1|zaa1|pin3
 (山 坡 上)	saan1|bo1|soeng6
-(山 坡 ㊤)	saan1|bo1|soeng6
 (山 腰 上)	saan1|jiu1|soeng6
-(山 腰 ㊤)	saan1|jiu1|soeng6
 (山 上)	saan1|soeng6
-(山 ㊤)	saan1|soeng6
 (山 頂)	saan1|deng2
 (山 顶)	saan1|deng2
 (山 斗)	saan1|dau3
@@ -14817,8 +12901,6 @@ _9      gau2||
 (山 难)	saan1|naan6
 (山 竽)	saan1|jyu4
 (山 中)	saan1|zung3
-(山 🀄)	saan1|zung3
-(山 ㊥)	saan1|zung3
 屴	lak6
 屸	lung4
 屹	ngat6
@@ -14847,7 +12929,6 @@ _9      gau2||
 岛	dou2
 (岛 屿)	dou2|zeoi6
 (岛 上)	dou2|soeng6
-(岛 ㊤)	dou2|soeng6
 岜	baa1
 岝	zaak3
 岞	zok3
@@ -14865,16 +12946,13 @@ _9      gau2||
 岬	gaap3
 岭	leng5
 (岭 上 开 花)	leng5|soeng6|hoi1|faa1
-(岭 ㊤ 开 花)	leng5|soeng6|hoi1|faa1
 (岭 南)	ling5|naam4
-(岭 🀁)	ling5|naam4
 岱	doi6
 岳	ngok6
 岵	wu6
 岷	man4
 岸	ngon6
 (岸 上)	ngon6|soeng6
-(岸 ㊤)	ngon6|soeng6
 岺	ling4
 岽	dung3
 岿	kwai1
@@ -14916,7 +12994,6 @@ _9      gau2||
 島	dou2
 (島 嶼)	dou2|zeoi6
 (島 上)	dou2|soeng6
-(島 ㊤)	dou2|soeng6
 峻	zeon3
 峼	kuk1
 峽	haap6
@@ -15058,13 +13135,9 @@ _9      gau2||
 嶺	leng5
 嶺	leng5
 (嶺 上 開 花)	leng5|soeng6|hoi1|faa1
-(嶺 ㊤ 開 花)	leng5|soeng6|hoi1|faa1
 (嶺 上 開 花)	leng5|soeng6|hoi1|faa1
-(嶺 ㊤ 開 花)	leng5|soeng6|hoi1|faa1
 (嶺 南)	ling5|naam4
-(嶺 🀁)	ling5|naam4
 (嶺 南)	ling5|naam4
-(嶺 🀁)	ling5|naam4
 嶼	jyu4
 嶽	ngok6
 巁	lai6
@@ -15107,9 +13180,7 @@ _9      gau2||
 (工 程 塑 料)	gung1|cing4|sok3|liu2
 (工 科 學 生)	gung1|fo1|hok6|saang1
 (工 科 学 生)	gung1|fo1|hok6|saang1
-(工 科 ㊫ 生)	gung1|fo1|hok6|saang1
 (工 作 上)	gung1|zok3|soeng6
-(工 作 ㊤)	gung1|zok3|soeng6
 (工 錢)	gung1|cin4
 (工 钱)	gung1|cin4
 (工 房)	gung1|fong2
@@ -15117,62 +13188,29 @@ _9      gau2||
 ㊧	zo2
 🈬	zo2
 (左 支 右 絀)	zo2|zi1|jau6|zyut6
-(左 支 ㊨ 絀)	zo2|zi1|jau6|zyut6
-(㊧ 支 右 絀)	zo2|zi1|jau6|zyut6
 (左 支 右 绌)	zo2|zi1|jau6|zyut6
-(左 支 ㊨ 绌)	zo2|zi1|jau6|zyut6
-(㊧ 支 右 绌)	zo2|zi1|jau6|zyut6
 (左 鄰 右 舍)	zo2|leon4|jau6|se3
-(左 鄰 ㊨ 舍)	zo2|leon4|jau6|se3
-(㊧ 鄰 右 舍)	zo2|leon4|jau6|se3
 (左 邻 右 舍)	zo2|leon4|jau6|se3
-(左 邻 ㊨ 舍)	zo2|leon4|jau6|se3
-(㊧ 邻 右 舍)	zo2|leon4|jau6|se3
 (左 鄰 右 里)	zo2|leon4|jau6|leoi5
-(左 鄰 ㊨ 里)	zo2|leon4|jau6|leoi5
-(㊧ 鄰 右 里)	zo2|leon4|jau6|leoi5
 (左 鄰 右 里)	zo2|leon4|jau6|leoi5
-(左 鄰 ㊨ 里)	zo2|leon4|jau6|leoi5
-(㊧ 鄰 右 里)	zo2|leon4|jau6|leoi5
 (左 邻 右 里)	zo2|leon4|jau6|leoi5
-(左 邻 ㊨ 里)	zo2|leon4|jau6|leoi5
-(㊧ 邻 右 里)	zo2|leon4|jau6|leoi5
 (左 邻 右 里)	zo2|leon4|jau6|leoi5
-(左 邻 ㊨ 里)	zo2|leon4|jau6|leoi5
-(㊧ 邻 右 里)	zo2|leon4|jau6|leoi5
 (左 氏 傳)	zo2|si6|zyun6
-(㊧ 氏 傳)	zo2|si6|zyun6
 (左 氏 传)	zo2|si6|zyun6
-(㊧ 氏 传)	zo2|si6|zyun6
 (左 上)	zo2|soeng6
-(㊧ 上)	zo2|soeng6
-(左 ㊤)	zo2|soeng6
 (左 傳)	zo2|zyun6
-(㊧ 傳)	zo2|zyun6
 (左 传)	zo2|zyun6
-(㊧ 传)	zo2|zyun6
 (左 券)	zo2|gyun3
-(㊧ 券)	zo2|gyun3
 (左 轉)	zo2|zyun3
-(㊧ 轉)	zo2|zyun3
 (左 转)	zo2|zyun3
-(㊧ 转)	zo2|zyun3
 (左 軚)	zo2|taai5
-(㊧ 軚)	zo2|taai5
 (左 撓)	zo2|jaau1
-(㊧ 撓)	zo2|jaau1
 (左 挠)	zo2|jaau1
-(㊧ 挠)	zo2|jaau1
 (左 輪)	zo2|leon2
-(㊧ 輪)	zo2|leon2
 (左 輪)	zo2|leon2
-(㊧ 輪)	zo2|leon2
 (左 轮)	zo2|leon2
-(㊧ 轮)	zo2|leon2
 (左 帶)	zo2|taai5
-(㊧ 帶)	zo2|taai5
 (左 带)	zo2|taai5
-(㊧ 带)	zo2|taai5
 巧	haau2
 (巧 克 力 糖)	haau2|hak1|lik6|tong2
 (巧 克 力 糖)	haau2|hak1|lik6|tong2
@@ -15235,7 +13273,6 @@ _9      gau2||
 (市 話)	si5|waa2
 (市 话)	si5|waa2
 (市 上)	si5|soeng6
-(市 ㊤)	si5|soeng6
 布	bou3
 (布 爾 什 維 克)	bou3|ji5|sap6|wai4|hak1
 (布 爾 什 維 克)	bou3|ji5|sap6|wai4|hak1
@@ -15265,9 +13302,7 @@ _9      gau2||
 帋	zi2
 希	hei1
 (希 爾 伯 特)	hei1|ji5|baa3|dak6
-(希 爾 伯 ㊕)	hei1|ji5|baa3|dak6
 (希 尔 伯 特)	hei1|ji5|baa3|dak6
-(希 尔 伯 ㊕)	hei1|ji5|baa3|dak6
 (希 伯 來)	hei1|baa3|loi4
 (希 伯 來)	hei1|baa3|loi4
 (希 伯 来)	hei1|baa3|loi4
@@ -15279,13 +13314,9 @@ _9      gau2||
 帔	pei3
 帕	paak3
 (帕 特 里 克)	paak3|dak6|leoi5|hak1
-(帕 ㊕ 里 克)	paak3|dak6|leoi5|hak1
 (帕 特 里 克)	paak3|dak6|leoi5|hak1
-(帕 ㊕ 里 克)	paak3|dak6|leoi5|hak1
 (帕 特 里 夏)	paak3|dak6|leoi5|haa6
-(帕 ㊕ 里 夏)	paak3|dak6|leoi5|haa6
 (帕 特 里 夏)	paak3|dak6|leoi5|haa6
-(帕 ㊕ 里 夏)	paak3|dak6|leoi5|haa6
 帖	tip3
 帗	fat1
 帘	lim4
@@ -15319,7 +13350,6 @@ _9      gau2||
 (席 丰 履 厚)	zik6|fung1|leoi5|hau5
 (席 位)	zik6|wai6
 (席 上)	zik6|soeng6
-(席 ㊤)	zik6|soeng6
 帮	bong1
 (帮 轻)	bong1|heng1
 帯	daai3
@@ -15414,13 +13444,10 @@ _9      gau2||
 (平 媛 铁 路)	ping4|wun4|tit3|lou6
 (平 起 平 坐)	ping4|hei2|ping4|zo6
 (平 假 名)	ping4|gaa2|ming4
-(平 假 ㊔)	ping4|gaa2|ming4
 (平 安 里)	ping4|ngon1|leoi5
 (平 安 里)	ping4|ngon1|leoi5
 (平 靚 正)	peng4|leng3|zeng3
-(平 靚 ㊣)	peng4|leng3|zeng3
 (平 靓 正)	peng4|leng3|zeng3
-(平 靓 ㊣)	peng4|leng3|zeng3
 (平 淡)	ping4|daam6
 (平 頂)	ping4|deng2
 (平 顶)	ping4|deng2
@@ -15491,7 +13518,6 @@ _9      gau2||
 床	cong4
 (床 铺)	cong4|pou1
 (床 上)	cong4|soeng6
-(床 ㊤)	cong4|soeng6
 (床 席)	cong4|zek6
 (床 架)	cong4|gaa2
 庋	gei2
@@ -15510,11 +13536,9 @@ _9      gau2||
 (应 如 何 办 理)	jing7|jyu4|ho4|baan6|lei5
 (应 如 何 办 理)	jing7|jyu4|ho4|baan6|lei5
 (应 有 尽 有)	jing1|jau5|zeon6|jau5
-(应 ㊒ 尽 ㊒)	jing1|jau5|zeon6|jau5
 (应 分)	jing1|fan6
 (应 得)	jing1|dak1
 (应 有)	jing7|jau5
-(应 ㊒)	jing7|jau5
 (应 当)	jing7|dong7
 (应 该)	jing1|goi1
 (应 然)	jing1|jin4
@@ -15528,7 +13552,6 @@ _9      gau2||
 庖	paau4
 店	dim3
 (店 小 二)	dim3|siu2|ji2
-(店 小 ㊁)	dim3|siu2|ji2
 (店 鋪)	dim3|pou3
 (店 長)	dim3|zoeng2
 (店 长)	dim3|zoeng2
@@ -15537,7 +13560,6 @@ _9      gau2||
 庛	ci3
 府	fu2
 (府 上)	fu2|soeng6
-(府 ㊤)	fu2|soeng6
 庞	pong4
 废	fai3
 庠	coeng4
@@ -15564,14 +13586,10 @@ _9      gau2||
 (度 身)	dok6|san1
 (度 身)	dok6|san1
 (度 水)	dok6|seoi2
-(度 ㊌)	dok6|seoi2
 (度 水)	dok6|seoi2
-(度 ㊌)	dok6|seoi2
 座	zo6
 (座 右 銘)	zo6|jau6|ming5
-(座 ㊨ 銘)	zo6|jau6|ming5
 (座 右 铭)	zo6|jau6|ming5
-(座 ㊨ 铭)	zo6|jau6|ming5
 庪	gei2
 庫	fu3
 (庫 布 里 克)	fu3|bou3|leoi5|hak1
@@ -15583,7 +13601,6 @@ _9      gau2||
 (庭 長)	ting4|zoeng2
 (庭 长)	ting4|zoeng2
 (庭 上)	ting4|soeng6
-(庭 ㊤)	ting4|soeng6
 庮	jau4
 庳	bei1
 庵	am1
@@ -15696,7 +13713,6 @@ _9      gau2||
 引	jan5
 (引 吭 高 歌)	jan5|hong4|gou1|go1
 (引 上)	jan5|soeng6
-(引 ㊤)	jan5|soeng6
 弗	fat1
 (弗 洛 里 斯 島)	fat1|lok6|leoi5|si1|dou2
 (弗 洛 里 斯 島)	fat1|lok6|leoi5|si1|dou2
@@ -15765,7 +13781,6 @@ _9      gau2||
 (強 顏 歡 笑)	koeng5|ngaan4|fun1|siu3
 (強 出 頭)	koeng5|ceot1|tau4
 (強 積 金)	koeng5|zik1|gam1
-(強 積 ㊎)	koeng5|zik1|gam1
 (強 積 金)	koeng5|zik1|gam1
 (強 忍)	koeng5|jan2
 (強 求)	koeng5|kau4
@@ -15789,7 +13804,6 @@ _9      gau2||
 (强 颜 欢 笑)	koeng5|ngaan4|fun1|siu3
 (强 出 头)	koeng5|ceot1|tau4
 (强 积 金)	koeng5|zik1|gam1
-(强 积 ㊎)	koeng5|zik1|gam1
 (强 积 金)	koeng5|zik1|gam1
 (强 干)	koeng4|gon3
 (强 忍)	koeng5|jan2
@@ -15853,12 +13867,8 @@ _9      gau2||
 (形 影 相 隨)	jing4|jing2|soeng1|ceoi4
 (形 影 相 随)	jing4|jing2|soeng1|ceoi4
 (形 而 上 學)	jing4|ji4|soeng6|hok6
-(形 而 ㊤ 學)	jing4|ji4|soeng6|hok6
 (形 而 上 学)	jing4|ji4|soeng6|hok6
-(形 而 上 ㊫)	jing4|ji4|soeng6|hok6
-(形 而 ㊤ 学)	jing4|ji4|soeng6|hok6
 (形 式 上)	jing4|sik1|soeng6
-(形 式 ㊤)	jing4|sik1|soeng6
 (形 相)	jing4|soeng3
 彣	man4
 彤	tung4
@@ -15895,7 +13905,6 @@ _9      gau2||
 (往 往 會)	wong5|wong5|wui5
 (往 往 会)	wong5|wong5|wui5
 (往 上)	wong5|soeng6
-(往 ㊤)	wong5|soeng6
 征	zing1
 (征 剿)	zing1|caau1
 徂	cou4
@@ -15905,9 +13914,7 @@ _9      gau2||
 徇	seon1
 很	han2
 (很 大 程 度 上)	han2|daai6|cing4|dou6|soeng6
-(很 大 程 度 ㊤)	han2|daai6|cing4|dou6|soeng6
 (很 大 程 度 上)	han2|daai6|cing4|dou6|soeng6
-(很 大 程 度 ㊤)	han2|daai6|cing4|dou6|soeng6
 (很 會)	han2|wui6
 (很 会)	han2|wui6
 徉	joeng4
@@ -15923,7 +13930,6 @@ _9      gau2||
 後	hau6
 🈝	hau6
 (後 會 有 期)	hau6|wui6|jau5|kei4
-(後 會 ㊒ 期)	hau6|wui6|jau5|kei4
 (後 生 動 物)	hau6|sang1|dung6|mat6
 (後 壁)	hau6|bik3
 (後 生)	hau6|saang1
@@ -15998,9 +14004,7 @@ _9      gau2||
 (心 不 在 焉)	sam1|bat1|zoi6|jin4
 (心 不 在 焉)	sam1|bat1|zoi6|jin4
 (心 有 餘 悸)	sam1|jau5|jyu4|gwai6
-(心 ㊒ 餘 悸)	sam1|jau5|jyu4|gwai6
 (心 有 余 悸)	sam1|jau5|jyu4|gwai6
-(心 ㊒ 余 悸)	sam1|jau5|jyu4|gwai6
 (心 肌 梗 塞)	sam1|gei1|gang2|sak1
 (心 肌 梗 塞)	sam1|gei1|gang2|sak1
 (心 領 神 會)	sam7|ling5|san4|wui6
@@ -16018,12 +14022,8 @@ _9      gau2||
 (心 惊 惊)	sam1|geng1|geng1
 (心 郁 郁)	sam1|juk1|juk1
 (心 理 上)	sam1|lei5|soeng6
-(心 理 ㊤)	sam1|lei5|soeng6
 (心 理 上)	sam1|lei5|soeng6
-(心 理 ㊤)	sam1|lei5|soeng6
 (心 中)	sam1|zung7
-(心 🀄)	sam1|zung7
-(心 ㊥)	sam1|zung7
 (心 坎)	sam1|ham2
 (心 折)	sam1|zip3
 (心 里)	sam1|leoi5
@@ -16032,7 +14032,6 @@ _9      gau2||
 (心 會)	sam7|wui6
 (心 会)	sam7|wui6
 (心 上)	sam1|soeng6
-(心 ㊤)	sam1|soeng6
 (心 郁)	sam1|juk1
 (心 裏)	sam1|leoi5
 (心 裏)	sam1|leoi5
@@ -16107,8 +14106,6 @@ _9      gau2||
 忼	hung2
 忽	fat1
 (忽 上 忽 下)	fat1|soeng6|fat1|haa6
-(忽 上 忽 ㊦)	fat1|soeng6|fat1|haa6
-(忽 ㊤ 忽 下)	fat1|soeng6|fat1|haa6
 忾	koi3
 忿	fan5
 (忿 氣)	fan6|hei3
@@ -16324,17 +14321,9 @@ _9      gau2||
 惄	nik6
 情	cing4
 (情 人 眼 里 出 西 施)	cing4|jan4|ngaan5|leoi5|ceot1|sai1|si1
-(情 人 眼 里 出 🀂 施)	cing4|jan4|ngaan5|leoi5|ceot1|sai1|si1
 (情 人 眼 里 出 西 施)	cing4|jan4|ngaan5|leoi5|ceot1|sai1|si1
-(情 人 眼 里 出 🀂 施)	cing4|jan4|ngaan5|leoi5|ceot1|sai1|si1
 (情 人 眼 里 有 西 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
-(情 人 眼 里 有 🀂 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
-(情 人 眼 里 ㊒ 西 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
-(情 人 眼 里 ㊒ 🀂 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
 (情 人 眼 里 有 西 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
-(情 人 眼 里 有 🀂 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
-(情 人 眼 里 ㊒ 西 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
-(情 人 眼 里 ㊒ 🀂 施)	cing4|jan4|ngaan5|leoi5|jau5|sai1|si1
 (情 深 義 重)	cing4|sam1|ji6|zung6
 (情 深 义 重)	cing4|sam1|ji6|zung6
 (情 分)	cing4|fan6
@@ -16437,9 +14426,7 @@ _9      gau2||
 愞	no6
 感	gam2
 (感 覺 上)	gam2|gok3|soeng6
-(感 覺 ㊤)	gam2|gok3|soeng6
 (感 觉 上)	gam2|gok3|soeng6
-(感 觉 ㊤)	gam2|gok3|soeng6
 愠	wan3
 愢	soi1
 愣	ling6
@@ -16585,11 +14572,9 @@ _9      gau2||
 (應 如 何 辦 理)	jing7|jyu4|ho4|baan6|lei5
 (應 如 何 辦 理)	jing7|jyu4|ho4|baan6|lei5
 (應 有 盡 有)	jing1|jau5|zeon6|jau5
-(應 ㊒ 盡 ㊒)	jing1|jau5|zeon6|jau5
 (應 分)	jing1|fan6
 (應 得)	jing1|dak1
 (應 有)	jing7|jau5
-(應 ㊒)	jing7|jau5
 (應 當)	jing7|dong7
 (應 該)	jing1|goi1
 (應 然)	jing1|jin4
@@ -16673,9 +14658,7 @@ _9      gau2||
 (战 斗)	zin3|dau3
 戙	dong6
 (戙 篤 企)	dung6|duk1|kei5
-(戙 篤 ㊭)	dung6|duk1|kei5
 (戙 笃 企)	dung6|duk1|kei5
-(戙 笃 ㊭)	dung6|duk1|kei5
 (戙 高)	dung6|gou1
 戚	cik1
 戛	aat3
@@ -16746,13 +14729,11 @@ _9      gau2||
 (手 表)	sau2|biu1
 (手 重)	sau2|cung5
 (手 上)	sau2|soeng6
-(手 ㊤)	sau2|soeng6
 (手 膀)	sau2|pong4
 扌	sau2
 才	coi4
 (才 疏 學 淺)	coi4|so7|hok6|cin2
 (才 疏 学 浅)	coi4|so7|hok6|cin2
-(才 疏 ㊫ 浅)	coi4|so7|hok6|cin2
 (才 華 蓋 世)	coi4|waa4|koi3|sai3
 (才 華 蓋 世)	coi4|waa4|koi3|sai3
 (才 华 盖 世)	coi4|waa4|koi3|sai3
@@ -16763,13 +14744,10 @@ _9      gau2||
 (才 思 敏 捷)	caai4|si1|man2|jit6
 (才 思 敏 捷)	caai4|si1|man2|jit6
 (才 上 到)	coi4|soeng5|dou3
-(才 ㊤ 到)	coi4|soeng5|dou3
 (才 女)	coi4|neoi2
-(才 ㊛)	coi4|neoi2
 (才 女)	coi4|neoi2
 (才 干)	coi4|gon3
 (才 上)	coi4|soeng6
-(才 ㊤)	coi4|soeng6
 扎	zaat3
 (扎 爾 達 里)	zaat3|ji5|daat6|leoi5
 (扎 爾 達 里)	zaat3|ji5|daat6|leoi5
@@ -16812,8 +14790,6 @@ _9      gau2||
 (打 敗 仗)	daa2|baai6|zoeng3
 (打 败 仗)	daa2|baai6|zoeng3
 (打 中)	daa2|zung3
-(打 🀄)	daa2|zung3
-(打 ㊥)	daa2|zung3
 (打 坐)	daa2|zo6
 (打 岔)	daa2|caa3
 (打 拼)	daa2|ping1
@@ -16826,7 +14802,6 @@ _9      gau2||
 (打 转)	daa2|zyun3
 (打 斗)	daa2|dau3
 (打 上)	daa2|soeng6
-(打 ㊤)	daa2|soeng6
 (打 醒)	daa2|seng2
 扔	jing4
 払	fat1
@@ -16849,7 +14824,6 @@ _9      gau2||
 (执 着)	zap1|zoek6
 (执 着)	zap1|zoek6
 (执 正)	zap1|zeng3
-(执 ㊣)	zap1|zeng3
 扨	jan6
 扩	kong3
 扪	mun4
@@ -16869,7 +14843,6 @@ _9      gau2||
 扵	jyu1
 扶	fu4
 (扶 正)	fu4|zeng3
-(扶 ㊣)	fu4|zeng3
 批	pai1
 (批 量 生 產)	pai1|loeng6|saang7|caan2
 (批 量 生 產)	pai1|loeng6|saang7|caan2
@@ -16879,8 +14852,6 @@ _9      gau2||
 (批 次 档)	pai1|ci3|dong2
 (批 斗)	pai1|dau3
 (批 中)	pai1|zung3
-(批 🀄)	pai1|zung3
-(批 ㊥)	pai1|zung3
 扺	zi2
 扻	ham2
 扼	aak1
@@ -16889,11 +14860,7 @@ _9      gau2||
 找	zaau2
 承	sing4
 (承 上 啟 下)	sing4|soeng6|kai2|haa6
-(承 上 啟 ㊦)	sing4|soeng6|kai2|haa6
-(承 ㊤ 啟 下)	sing4|soeng6|kai2|haa6
 (承 上 启 下)	sing4|soeng6|kai2|haa6
-(承 上 启 ㊦)	sing4|soeng6|kai2|haa6
-(承 ㊤ 启 下)	sing4|soeng6|kai2|haa6
 (承 重)	sing4|cung5
 技	gei6
 抂	kwong4
@@ -16927,17 +14894,9 @@ _9      gau2||
 投	tau4
 🈧	tau4
 (投 籃 不 中)	tau4|laam4|bat1|zung3
-(投 籃 不 🀄)	tau4|laam4|bat1|zung3
-(投 籃 不 ㊥)	tau4|laam4|bat1|zung3
 (投 籃 不 中)	tau4|laam4|bat1|zung3
-(投 籃 不 🀄)	tau4|laam4|bat1|zung3
-(投 籃 不 ㊥)	tau4|laam4|bat1|zung3
 (投 篮 不 中)	tau4|laam4|bat1|zung3
-(投 篮 不 🀄)	tau4|laam4|bat1|zung3
-(投 篮 不 ㊥)	tau4|laam4|bat1|zung3
 (投 篮 不 中)	tau4|laam4|bat1|zung3
-(投 篮 不 🀄)	tau4|laam4|bat1|zung3
-(投 篮 不 ㊥)	tau4|laam4|bat1|zung3
 (投 閒 置 散)	tau4|haan4|zi3|saan2
 (投 閑 置 散)	tau4|haan4|zi3|saan2
 (投 闲 置 散)	tau4|haan4|zi3|saan2
@@ -16945,8 +14904,6 @@ _9      gau2||
 (投 錢 箱)	tau4|cin4|soeng1
 (投 钱 箱)	tau4|cin4|soeng1
 (投 中)	tau4|zung3
-(投 🀄)	tau4|zung3
-(投 ㊥)	tau4|zung3
 (投 降)	tau4|hong4
 (投 降)	tau4|hong4
 抖	dau2
@@ -16977,7 +14934,6 @@ _9      gau2||
 护	wu6
 报	bou3
 (报 名)	bou3|meng2
-(报 ㊔)	bou3|meng2
 (报 贩)	bou3|faan2
 (报 更)	bou3|gaang1
 (报 更)	bou3|gaang1
@@ -17018,8 +14974,6 @@ _9      gau2||
 (抽 樣 調 查)	cau1|joeng6|diu6|caa4
 (抽 样 调 查)	cau1|joeng6|diu6|caa4
 (抽 中)	cau1|zung3
-(抽 🀄)	cau1|zung3
-(抽 ㊥)	cau1|zung3
 (抽 樣)	cau1|joeng2
 (抽 样)	cau1|joeng2
 抾	gip3
@@ -17040,11 +14994,7 @@ _9      gau2||
 拉	laai1
 拉	laai1
 (拉 三 扯 四)	laai1|saam1|ce2|sei3
-(拉 ㊂ 扯 四)	laai1|saam1|ce2|sei3
-(拉 三 扯 ㊃)	laai1|saam1|ce2|sei3
 (拉 三 扯 四)	laai1|saam1|ce2|sei3
-(拉 ㊂ 扯 四)	laai1|saam1|ce2|sei3
-(拉 三 扯 ㊃)	laai1|saam1|ce2|sei3
 (拉 里)	laai1|leoi5
 (拉 里)	laai1|leoi5
 (拉 里)	laai1|leoi5
@@ -17158,7 +15108,6 @@ _9      gau2||
 (持 重)	ci4|zung6
 挂	gwaa3
 (挂 在 盒 子 上)	gwaa3|zoi6|hap6|zi2|soeng6
-(挂 在 盒 子 ㊤)	gwaa3|zoi6|hap6|zi2|soeng6
 挃	zat1
 指	zi2
 🈯	zi2
@@ -17166,13 +15115,8 @@ _9      gau2||
 (指 手 画 脚)	zi2|sau2|waak6|goek3
 (指 手 画 脚)	zi2|sau2|waak6|goek3
 (指 東 畫 西)	zi2|dung1|waak6|sai1
-(指 東 畫 🀂)	zi2|dung1|waak6|sai1
 (指 东 画 西)	zi2|dung1|waak6|sai1
-(指 东 画 🀂)	zi2|dung1|waak6|sai1
-(指 🀀 画 西)	zi2|dung1|waak6|sai1
 (指 东 画 西)	zi2|dung1|waak6|sai1
-(指 东 画 🀂)	zi2|dung1|waak6|sai1
-(指 🀀 画 西)	zi2|dung1|waak6|sai1
 (指 天 畫 地)	zi2|tin1|waak6|dei6
 (指 天 画 地)	zi2|tin1|waak6|dei6
 (指 天 画 地)	zi2|tin1|waak6|dei6
@@ -17180,7 +15124,6 @@ _9      gau2||
 (指 挥 处)	zi2|fai1|cyu2
 (指 使)	zi2|si2
 (指 正)	zi2|zing1
-(指 ㊣)	zi2|zing1
 挈	kit3
 按	on3
 (按 序 存 取 存 貯)	on3|zeoi6|cyun4|ceoi2|cyun4|cyu2
@@ -17193,11 +15136,7 @@ _9      gau2||
 挐	jyu4
 挑	tiu1
 (挑 三 揀 四)	tiu1|saam1|gaan2|sei3
-(挑 ㊂ 揀 四)	tiu1|saam1|gaan2|sei3
-(挑 三 揀 ㊃)	tiu1|saam1|gaan2|sei3
 (挑 三 拣 四)	tiu1|saam1|gaan2|sei3
-(挑 ㊂ 拣 四)	tiu1|saam1|gaan2|sei3
-(挑 三 拣 ㊃)	tiu1|saam1|gaan2|sei3
 (挑 撥 離 間)	tiu1|but6|lei4|gaan3
 (挑 撥 離 間)	tiu1|but6|lei4|gaan3
 (挑 拨 离 间)	tiu1|but6|lei4|gaan3
@@ -17234,7 +15173,6 @@ _9      gau2||
 (挨 個 兒)	aai1|go3|ji4
 (挨 个 儿)	aai1|go3|ji4
 (挨 上 去)	aai1|soeng6|heoi3
-(挨 ㊤ 去)	aai1|soeng6|heoi3
 (挨 打)	aai1|daa2
 (挨 著)	aai1|zyu3
 (挨 著)	aai1|zyu3
@@ -17309,7 +15247,6 @@ _9      gau2||
 捯	dou3
 捱	ngaai4
 (捱 夜)	ngaai4|je2
-(捱 ㊰)	ngaai4|je2
 捲	gyun2
 捵	can2
 (捵 嚟 捵 去)	din2|lei4|din2|heoi3
@@ -17345,7 +15282,6 @@ _9      gau2||
 掐	haap3
 排	paai4
 (排 名 表)	paai4|ming4|biu2
-(排 ㊔ 表)	paai4|ming4|biu2
 掔	haan1
 掖	jat6
 掗	aa3
@@ -17353,7 +15289,6 @@ _9      gau2||
 掙	zang7
 掛	gwaa3
 (掛 在 盒 子 上)	gwaa3|zoi6|hap6|zi2|soeng6
-(掛 在 盒 子 ㊤)	gwaa3|zoi6|hap6|zi2|soeng6
 掜	ngai5
 掞	sim3
 掟	deng3
@@ -17600,7 +15535,6 @@ _9      gau2||
 撝	fai1
 撞	zong6
 (撞 正)	zong6|zeng3
-(撞 ㊣)	zong6|zeng3
 撟	giu2
 撠	gik1
 撢	taam2
@@ -17643,8 +15577,6 @@ _9      gau2||
 擉	cok3
 擊	gik1
 (擊 中)	gik1|zung3
-(擊 🀄)	gik1|zung3
-(擊 ㊥)	gik1|zung3
 擋	dong2
 操	cou1
 (操 守)	cou3|sau2
@@ -17773,9 +15705,7 @@ _9      gau2||
 (改 量)	goi2|loeng4
 攻	gung1
 (攻 心 為 上)	gung1|sam1|wai4|soeng6
-(攻 心 為 ㊤)	gung1|sam1|wai4|soeng6
 (攻 心 为 上)	gung1|sam1|wai4|soeng6
-(攻 心 为 ㊤)	gung1|sam1|wai4|soeng6
 攽	baan1
 放	fong3
 (放 松)	fong3|sung7
@@ -17784,7 +15714,6 @@ _9      gau2||
 (放 生)	fong3|saang1
 政	zing3
 (政 治 上)	zing3|zi6|soeng6
-(政 治 ㊤)	zing3|zi6|soeng6
 敁	dim1
 敃	man5
 故	gu3
@@ -17937,11 +15866,7 @@ _9      gau2||
 (料 算)	liu6|syun3
 (料 算)	liu6|syun3
 (料 中)	liu6|zung3
-(料 🀄)	liu6|zung3
-(料 ㊥)	liu6|zung3
 (料 中)	liu6|zung3
-(料 🀄)	liu6|zung3
-(料 ㊥)	liu6|zung3
 斛	huk6
 斜	ce4
 斝	gaa2
@@ -18057,68 +15982,30 @@ _9      gau2||
 日	jat6
 ㊐	jat6
 (日 正 當 中)	jat6|zing3|dong1|zung1
-(日 正 當 🀄)	jat6|zing3|dong1|zung1
-(日 ㊣ 當 中)	jat6|zing3|dong1|zung1
-(日 ㊣ 當 🀄)	jat6|zing3|dong1|zung1
-(日 正 當 ㊥)	jat6|zing3|dong1|zung1
-(㊐ 正 當 中)	jat6|zing3|dong1|zung1
-(㊐ 正 當 🀄)	jat6|zing3|dong1|zung1
 (日 正 当 中)	jat6|zing3|dong1|zung1
-(日 正 当 🀄)	jat6|zing3|dong1|zung1
-(日 ㊣ 当 中)	jat6|zing3|dong1|zung1
-(日 ㊣ 当 🀄)	jat6|zing3|dong1|zung1
-(日 正 当 ㊥)	jat6|zing3|dong1|zung1
-(㊐ 正 当 中)	jat6|zing3|dong1|zung1
-(㊐ 正 当 🀄)	jat6|zing3|dong1|zung1
 (日 就 月 將)	jat6|zau6|jyut6|zoeng1
-(日 就 ㊊ 將)	jat6|zau6|jyut6|zoeng1
-(㊐ 就 月 將)	jat6|zau6|jyut6|zoeng1
 (日 就 月 将)	jat6|zau6|jyut6|zoeng1
-(日 就 ㊊ 将)	jat6|zau6|jyut6|zoeng1
-(㊐ 就 月 将)	jat6|zau6|jyut6|zoeng1
 (日 上 三 竿)	jat6|soeng5|saam1|gon1
-(日 ㊤ 三 竿)	jat6|soeng5|saam1|gon1
-(日 上 ㊂ 竿)	jat6|soeng5|saam1|gon1
-(㊐ 上 三 竿)	jat6|soeng5|saam1|gon1
 (日 省 月 試)	jat6|saang2|jyut6|si5
-(日 省 ㊊ 試)	jat6|saang2|jyut6|si5
-(㊐ 省 月 試)	jat6|saang2|jyut6|si5
 (日 省 月 試)	jat6|saang2|jyut6|si5
-(日 省 ㊊ 試)	jat6|saang2|jyut6|si5
-(㊐ 省 月 試)	jat6|saang2|jyut6|si5
 (日 省 月 试)	jat6|saang2|jyut6|si5
-(日 省 ㊊ 试)	jat6|saang2|jyut6|si5
-(㊐ 省 月 试)	jat6|saang2|jyut6|si5
 (日 省 月 试)	jat6|saang2|jyut6|si5
-(日 省 ㊊ 试)	jat6|saang2|jyut6|si5
-(㊐ 省 月 试)	jat6|saang2|jyut6|si5
 (日 本 話)	jat6|bun2|waa2
-(㊐ 本 話)	jat6|bun2|waa2
 (日 本 话)	jat6|bun2|waa2
-(㊐ 本 话)	jat6|bun2|waa2
 (日 更 新)	jat6|gang1|san1
-(㊐ 更 新)	jat6|gang1|san1
 (日 更 新)	jat6|gang1|san1
-(㊐ 更 新)	jat6|gang1|san1
 (日 刊)	jat6|hon2
-(㊐ 刊)	jat6|hon2
 (日 暈)	jat6|wan6
-(㊐ 暈)	jat6|wan6
 (日 暈)	jat6|wan6
-(㊐ 暈)	jat6|wan6
 (日 晕)	jat6|wan6
-(㊐ 晕)	jat6|wan6
 (日 更)	jat6|gaang7
-(㊐ 更)	jat6|gaang7
 (日 更)	jat6|gaang7
-(㊐ 更)	jat6|gaang7
 旦	daan3
 旧	gau6
 旨	zi2
 早	zou2
 (早 餐 券)	zou2|caan1|gyun3
 (早 上)	zou2|soeng6
-(早 ㊤)	zou2|soeng6
 (早 生)	zou2|saang1
 旬	ceon4
 旭	juk1
@@ -18150,7 +16037,6 @@ _9      gau2||
 昆	kwan7
 (昆 蟲 學 家)	gwan1|cung4|hok6|gaa1
 (昆 虫 学 家)	gwan1|cung4|hok6|gaa1
-(昆 虫 ㊫ 家)	gwan1|cung4|hok6|gaa1
 (昆 明 城)	gwan1|ming4|sing4
 (昆 弟)	gwan1|dai6
 昇	sing1
@@ -18220,7 +16106,6 @@ _9      gau2||
 昞	bing2
 星	sing1
 (星 期 三)	sing1|kei4|saam1
-(星 期 ㊂)	sing1|kei4|saam1
 (星 加 坡)	sing1|gaa3|bo1
 (星 宿)	sing1|sau3
 (星 相)	sing1|soeng3
@@ -18235,7 +16120,6 @@ _9      gau2||
 昦	hou6
 昧	mui6
 (昧 水)	mei6|seoi2
-(昧 ㊌)	mei6|seoi2
 昨	zok6
 昪	bin6
 昫	heoi2
@@ -18278,7 +16162,6 @@ _9      gau2||
 晗	ham4
 晚	maan5
 (晚 上)	maan5|soeng6
-(晚 ㊤)	maan5|soeng6
 晛	jin5
 晜	gwan1
 晝	zau3
@@ -18304,11 +16187,8 @@ _9      gau2||
 (普 里 什 蒂 纳)	pou2|leoi5|sam6|dai3|naap6
 (普 里 什 蒂 纳)	pou2|leoi5|sam6|dai3|naap6
 (普 里 切 特)	pou2|leoi5|cit3|dak6
-(普 里 切 ㊕)	pou2|leoi5|cit3|dak6
 (普 里 切 特)	pou2|leoi5|cit3|dak6
-(普 里 切 ㊕)	pou2|leoi5|cit3|dak6
 (普 里 切 特)	pou2|leoi5|cit3|dak6
-(普 里 切 ㊕)	pou2|leoi5|cit3|dak6
 景	ging2
 (景 颇)	ging2|po1
 晰	sik1
@@ -18415,9 +16295,7 @@ _9      gau2||
 (更 其 刀)	gang7|kei4|dou1
 (更 其 刀)	gang7|kei4|dou1
 (更 名)	gang1|ming4
-(更 ㊔)	gang1|ming4
 (更 名)	gang1|ming4
-(更 ㊔)	gang1|ming4
 (更 夫)	gaang1|fu1
 (更 夫)	gaang1|fu1
 (更 始)	gang1|ci2
@@ -18437,9 +16315,7 @@ _9      gau2||
 (更 替)	gang1|tai3
 (更 替)	gang1|tai3
 (更 正)	gang1|zing1
-(更 ㊣)	gang1|zing1
 (更 正)	gang1|zing1
-(更 ㊣)	gang1|zing1
 (更 生)	gang1|sang1
 (更 生)	gang1|sang1
 (更 衣)	gang1|ji1
@@ -18466,11 +16342,9 @@ _9      gau2||
 曷	hot3
 書	syu1
 (書 本 上)	syu1|bun2|soeng6
-(書 本 ㊤)	syu1|bun2|soeng6
 (書 房)	syu1|fong2
 (書 札)	syu1|zaat3
 (書 上)	syu7|soeng6
-(書 ㊤)	syu7|soeng6
 曹	cou4
 曼	maan6
 曽	cang4
@@ -18504,7 +16378,6 @@ _9      gau2||
 (會 戰)	wui6|zin3
 (會 盟)	wui6|mang4
 (會 社)	wui6|se5
-(會 ㊓)	wui6|se5
 (會 社)	wui6|se5
 (會 考)	wui6|haau2
 (會 計)	wui6|gai3
@@ -18523,61 +16396,33 @@ _9      gau2||
 ㊊	jyut6
 🈷	jyut6
 (月 球 上)	jyut6|kau4|soeng6
-(月 球 ㊤)	jyut6|kau4|soeng6
-(㊊ 球 上)	jyut6|kau4|soeng6
 (月 刊)	jyut6|hon2
-(㊊ 刊)	jyut6|hon2
 (月 暈)	jyut6|wan6
-(㊊ 暈)	jyut6|wan6
 (月 暈)	jyut6|wan6
-(㊊ 暈)	jyut6|wan6
 (月 晕)	jyut6|wan6
-(㊊ 晕)	jyut6|wan6
 有	jau5
 ㊒	jau5
 🈶	jau5
 (有 價 證 券)	jau5|gaa3|zing3|gyun3
-(㊒ 價 證 券)	jau5|gaa3|zing3|gyun3
 (有 价 证 券)	jau5|gaa3|zing3|gyun3
-(㊒ 价 证 券)	jau5|gaa3|zing3|gyun3
 (有 朝 一 日)	jau5|ziu1|jat1|jat6
-(有 朝 ㊀ 日)	jau5|ziu1|jat1|jat6
-(㊒ 朝 一 日)	jau5|ziu1|jat1|jat6
-(有 朝 一 ㊐)	jau5|ziu1|jat1|jat6
 (有 價 証 券)	jau5|gaa3|zing3|gyun3
-(㊒ 價 証 券)	jau5|gaa3|zing3|gyun3
 (有 价 証 券)	jau5|gaa3|zing3|gyun3
-(㊒ 价 証 券)	jau5|gaa3|zing3|gyun3
 (有 隙 可 乘)	jau5|gwik1|ho2|sing6
-(㊒ 隙 可 乘)	jau5|gwik1|ho2|sing6
 (有 缘 千 里)	jau5|jyun4|cin1|lei5
-(㊒ 缘 千 里)	jau5|jyun4|cin1|lei5
 (有 缘 千 里)	jau5|jyun4|cin1|lei5
-(㊒ 缘 千 里)	jau5|jyun4|cin1|lei5
 (有 彈 有 贊)	jau5|taan4|jau5|zaan3
-(㊒ 彈 ㊒ 贊)	jau5|taan4|jau5|zaan3
 (有 弹 有 赞)	jau5|taan4|jau5|zaan3
-(㊒ 弹 ㊒ 赞)	jau5|taan4|jau5|zaan3
 (有 行 無 市)	jau5|hong4|mou4|si5
-(㊒ 行 無 市)	jau5|hong4|mou4|si5
 (有 行 無 市)	jau5|hong4|mou4|si5
-(㊒ 行 無 市)	jau5|hong4|mou4|si5
 (有 行 无 市)	jau5|hong4|mou4|si5
-(㊒ 行 无 市)	jau5|hong4|mou4|si5
 (有 行 无 市)	jau5|hong4|mou4|si5
-(㊒ 行 无 市)	jau5|hong4|mou4|si5
 (有 聲)	jau5|seng1
-(㊒ 聲)	jau5|seng1
 (有 声)	jau5|seng1
-(㊒ 声)	jau5|seng1
 (有 勁)	jau5|ging3
-(㊒ 勁)	jau5|ging3
 (有 劲)	jau5|ging3
-(㊒ 劲)	jau5|ging3
 (有 只)	jau5|zek3
-(㊒ 只)	jau5|zek3
 (有 伴)	jau5|pun5
-(㊒ 伴)	jau5|pun5
 朊	gun2
 朋	pang4
 (朋 比 為 奸)	pang4|bei2|wai4|gaan1
@@ -18605,8 +16450,6 @@ _9      gau2||
 望	mong6
 朝	ciu4
 (朝 三 暮 四)	ziu1|saam1|mou6|sei3
-(朝 ㊂ 暮 四)	ziu1|saam1|mou6|sei3
-(朝 三 暮 ㊃)	ziu1|saam1|mou6|sei3
 (朝 令 夕 改)	ziu1|ling6|zik6|goi2
 (朝 令 夕 改)	ziu1|ling6|zik6|goi2
 (朝 思 暮 想)	ziu1|si1|mou6|soeng2
@@ -18614,8 +16457,6 @@ _9      gau2||
 (朝 夕 相 處)	ziu7|zik6|soeng7|cyu5
 (朝 夕 相 处)	ziu7|zik6|soeng7|cyu5
 (朝 九 晚 五)	ziu7|gau2|maan5|ng5
-(朝 ㊈ 晚 五)	ziu7|gau2|maan5|ng5
-(朝 九 晚 ㊄)	ziu7|gau2|maan5|ng5
 (朝 于 斯)	ziu1|jyu1|si1
 (朝 頭 早)	ziu1|tau4|zou2
 (朝 夕)	ziu7|zik6
@@ -18638,39 +16479,22 @@ _9      gau2||
 木	muk6
 ㊍	muk6
 (木 里 藏 族 自 治 縣)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
-(㊍ 里 藏 族 自 治 縣)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
 (木 里 藏 族 自 治 縣)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
-(㊍ 里 藏 族 自 治 縣)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
 (木 里 藏 族 自 治 县)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
-(㊍ 里 藏 族 自 治 县)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
 (木 里 藏 族 自 治 县)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
-(㊍ 里 藏 族 自 治 县)	muk6|leoi5|zong6|zuk6|zi6|zi6|jyun2
 (木 材 乾 餾)	muk6|coi4|gon1|lau6
-(㊍ 材 乾 餾)	muk6|coi4|gon1|lau6
 (木 材 乾 馏)	muk6|coi4|gon1|lau6
-(㊍ 材 乾 馏)	muk6|coi4|gon1|lau6
 (木 匠 鋪)	muk6|zoeng3|pou2
-(㊍ 匠 鋪)	muk6|zoeng3|pou2
 (木 匠 铺)	muk6|zoeng3|pou2
-(㊍ 匠 铺)	muk6|zoeng3|pou2
 (木 材 行)	muk6|coi4|hong4
-(㊍ 材 行)	muk6|coi4|hong4
 (木 材 行)	muk6|coi4|hong4
-(㊍ 材 行)	muk6|coi4|hong4
 (木 塞 子)	muk6|sak1|zi2
-(㊍ 塞 子)	muk6|sak1|zi2
 (木 塞 子)	muk6|sak1|zi2
-(㊍ 塞 子)	muk6|sak1|zi2
 (木 薯)	muk6|syu5
-(㊍ 薯)	muk6|syu5
 (木 房)	muk6|fong2
-(㊍ 房)	muk6|fong2
 (木 椅)	muk6|ji1
-(㊍ 椅)	muk6|ji1
 (木 履)	muk6|leoi5
-(㊍ 履)	muk6|leoi5
 (木 履)	muk6|leoi5
-(㊍ 履)	muk6|leoi5
 未	mei6
 (未 降)	mei6|hong4
 (未 降)	mei6|hong4
@@ -18760,7 +16584,6 @@ _9      gau2||
 (村 話)	cyun1|waa2
 (村 话)	cyun1|waa2
 (村 上)	cyun1|soeng6
-(村 ㊤)	cyun1|soeng6
 (村 坊)	cyun1|fong4
 杓	soek3
 杕	dai6
@@ -18801,15 +16624,11 @@ _9      gau2||
 (杰 里 米)	git6|leoi5|mai5
 東	dung1
 (東 逃 西 竄)	dung1|tou4|sai1|cyun2
-(東 逃 🀂 竄)	dung1|tou4|sai1|cyun2
 (東 鄰 西 舍)	dung1|leon4|sai1|se5
-(東 鄰 🀂 舍)	dung1|leon4|sai1|se5
 (東 倉 里)	dung1|cong1|leoi5
 (東 倉 里)	dung1|cong1|leoi5
 (東 三 省)	dung1|saam1|saang2
-(東 ㊂ 省)	dung1|saam1|saang2
 (東 三 省)	dung1|saam1|saang2
-(東 ㊂ 省)	dung1|saam1|saang2
 (東 莞)	dung1|gun2
 (東 湧)	dung1|cung1
 杲	gou2
@@ -18828,7 +16647,6 @@ _9      gau2||
 杼	cyu5
 松	cung4
 (松 一 口 气)	sung7|jat1|hau2|hei3
-(松 ㊀ 口 气)	sung7|jat1|hau2|hei3
 (松 了 口 氣)	sung1|liu5|hau2|hei3
 (松 了 口 氣)	sung1|liu5|hau2|hei3
 (松 了 口 气)	sung1|liu5|hau2|hei3
@@ -18839,7 +16657,6 @@ _9      gau2||
 (松 滋)	sung7|zi1
 (松 动)	sung7|dung6
 (松 土)	sung7|tou2
-(松 ㊏)	sung7|tou2
 (松 垮)	sung7|kwaa1
 (松 弛)	sung7|ci4
 (松 快)	sung7|faai3
@@ -18883,15 +16700,10 @@ _9      gau2||
 林	lam4
 林	lam4
 (林 木 參 天)	lam4|muk6|caam1|tin1
-(林 ㊍ 參 天)	lam4|muk6|caam1|tin1
 (林 木 參 天)	lam4|muk6|caam1|tin1
-(林 ㊍ 參 天)	lam4|muk6|caam1|tin1
 (林 木 參 天)	lam4|muk6|caam1|tin1
-(林 ㊍ 參 天)	lam4|muk6|caam1|tin1
 (林 木 参 天)	lam4|muk6|caam1|tin1
-(林 ㊍ 参 天)	lam4|muk6|caam1|tin1
 (林 木 参 天)	lam4|muk6|caam1|tin1
-(林 ㊍ 参 天)	lam4|muk6|caam1|tin1
 (林 相)	lam4|soeng3
 (林 相)	lam4|soeng3
 枘	jeoi6
@@ -19035,7 +16847,6 @@ _9      gau2||
 (校 對)	gaau3|deoi3
 (校 对)	gaau3|deoi3
 (校 正)	gaau3|zing3
-(校 ㊣)	gaau3|zing3
 (校 準)	gaau3|zeon2
 (校 准)	gaau3|zeon2
 (校 舍)	haau6|se3
@@ -19068,7 +16879,6 @@ _9      gau2||
 (核 戰 斗 部)	hat6|zin3|dau3|bou6
 根	gan1
 (根 本 上)	gan1|bun2|soeng6
-(根 本 ㊤)	gan1|bun2|soeng6
 栻	cik1
 格	gaak3
 (格 里 姆 斯 塔)	gaak3|leoi5|mou5|si1|taap3
@@ -19098,12 +16908,9 @@ _9      gau2||
 桋	ji4
 桌	coek3
 (桌 面 上)	coek3|min6|soeng6
-(桌 面 ㊤)	coek3|min6|soeng6
 (桌 面)	coek3|min2
 (桌 上)	coek5|soeng6
-(桌 ㊤)	coek5|soeng6
 (桌 下)	zoek3|haa6
-(桌 ㊦)	zoek3|haa6
 桎	zat6
 桐	tung4
 桑	song1
@@ -19145,9 +16952,7 @@ _9      gau2||
 梁	loeng4
 梁	loeng4
 (梁 上 君 子)	loeng4|soeng6|gwan1|zi2
-(梁 ㊤ 君 子)	loeng4|soeng6|gwan1|zi2
 (梁 上 君 子)	loeng4|soeng6|gwan1|zi2
-(梁 ㊤ 君 子)	loeng4|soeng6|gwan1|zi2
 (梁 琤)	loeng4|zaang1
 (梁 琤)	loeng4|zaang1
 (梁 爭)	loeng4|zaang1
@@ -19361,7 +17166,6 @@ _9      gau2||
 楻	wong4
 楼	lau4
 (楼 上)	lau4|soeng6
-(楼 ㊤)	lau4|soeng6
 (楼 观)	lau4|gun3
 楽	lok6
 榀	ban2
@@ -19518,13 +17322,10 @@ _9      gau2||
 樏	lai5
 樑	loeng4
 (樑 上 君 子)	loeng4|soeng6|gwan1|zi2
-(樑 ㊤ 君 子)	loeng4|soeng6|gwan1|zi2
 樓	lau4
 樓	lau4
 (樓 上)	lau4|soeng6
-(樓 ㊤)	lau4|soeng6
 (樓 上)	lau4|soeng6
-(樓 ㊤)	lau4|soeng6
 (樓 觀)	lau4|gun3
 (樓 觀)	lau4|gun3
 樔	caau4
@@ -19786,45 +17587,24 @@ _9      gau2||
 正	zing3
 ㊣	zing3
 (正 襟 危 坐)	zing3|kam1|ngai4|zo6
-(㊣ 襟 危 坐)	zing3|kam1|ngai4|zo6
 (正 冠 納 履)	zing3|gun1|naap6|leoi5
-(㊣ 冠 納 履)	zing3|gun1|naap6|leoi5
 (正 冠 納 履)	zing3|gun1|naap6|leoi5
-(㊣ 冠 納 履)	zing3|gun1|naap6|leoi5
 (正 冠 纳 履)	zing3|gun1|naap6|leoi5
-(㊣ 冠 纳 履)	zing3|gun1|naap6|leoi5
 (正 冠 纳 履)	zing3|gun1|naap6|leoi5
-(㊣ 冠 纳 履)	zing3|gun1|naap6|leoi5
 (正 處 於)	zing3|cyu2|jyu1
-(㊣ 處 於)	zing3|cyu2|jyu1
 (正 处 于)	zing3|cyu2|jyu1
-(㊣ 处 于)	zing3|cyu2|jyu1
 (正 傳)	zing3|zyun6
-(㊣ 傳)	zing3|zyun6
 (正 传)	zing3|zyun6
-(㊣ 传)	zing3|zyun6
 (正 房)	zing3|fong2
-(㊣ 房)	zing3|fong2
 (正 月)	zing1|jyut6
-(㊣ 月)	zing1|jyut6
-(正 ㊊)	zing1|jyut6
 (正 當)	zing3|dong3
-(㊣ 當)	zing3|dong3
 (正 当)	zing3|dong3
-(㊣ 当)	zing3|dong3
 (正 使)	zing3|si2
-(㊣ 使)	zing3|si2
 (正 上)	zing3|soeng6
-(㊣ 上)	zing3|soeng6
-(正 ㊤)	zing3|soeng6
 (正 鵠)	zing3|huk1
-(㊣ 鵠)	zing3|huk1
 (正 鹄)	zing3|huk1
-(㊣ 鹄)	zing3|huk1
 (正 應)	zing3|jing1
-(㊣ 應)	zing3|jing1
 (正 应)	zing3|jing1
-(㊣ 应)	zing3|jing1
 此	ci2
 (此 風 不 可 長)	ci2|fung1|bat1|ho2|zoeng2
 (此 風 不 可 長)	ci2|fung1|bat1|ho2|zoeng2
@@ -19839,13 +17619,9 @@ _9      gau2||
 (步 话 机)	bou6|waa2|gei1
 武	mou5
 (武 漢 三 鎮)	mou5|hon3|saam1|zan3
-(武 漢 ㊂ 鎮)	mou5|hon3|saam1|zan3
 (武 漢 三 鎮)	mou5|hon3|saam1|zan3
-(武 漢 ㊂ 鎮)	mou5|hon3|saam1|zan3
 (武 漢 三 鎮)	mou5|hon3|saam1|zan3
-(武 漢 ㊂ 鎮)	mou5|hon3|saam1|zan3
 (武 汉 三 镇)	mou5|hon3|saam1|zan3
-(武 汉 ㊂ 镇)	mou5|hon3|saam1|zan3
 (武 斷)	mou5|dyun6
 (武 断)	mou5|dyun6
 歧	kei4
@@ -19957,11 +17733,7 @@ _9      gau2||
 毎	mui5
 每	mui5
 (每 試 必 中)	mui5|si3|bit1|zung3
-(每 試 必 🀄)	mui5|si3|bit1|zung3
-(每 試 必 ㊥)	mui5|si3|bit1|zung3
 (每 试 必 中)	mui5|si3|bit1|zung3
-(每 试 必 🀄)	mui5|si3|bit1|zung3
-(每 试 必 ㊥)	mui5|si3|bit1|zung3
 (每 打)	mui5|daa1
 毐	oi2
 毒	duk6
@@ -19975,7 +17747,6 @@ _9      gau2||
 (比 擬)	bei2|ji4
 (比 拟)	bei2|ji4
 (比 上)	bei2|soeng6
-(比 ㊤)	bei2|soeng6
 毕	bat1
 (毕 业 相)	bat1|jip6|soeng2
 毖	bei3
@@ -20085,24 +17856,14 @@ _9      gau2||
 水	seoi2
 ㊌	seoi2
 (水 滴 石 穿)	seoi2|dik1|sek6|cyun1
-(㊌ 滴 石 穿)	seoi2|dik1|sek6|cyun1
 (水 滸 傳)	seoi2|wu2|zyun2
-(㊌ 滸 傳)	seoi2|wu2|zyun2
 (水 浒 传)	seoi2|wu2|zyun2
-(㊌ 浒 传)	seoi2|wu2|zyun2
 (水 上)	seoi2|soeng6
-(水 ㊤)	seoi2|soeng6
-(㊌ 上)	seoi2|soeng6
 (水 分)	seoi2|fan6
-(㊌ 分)	seoi2|fan6
 (水 泡)	seoi2|pou5
-(㊌ 泡)	seoi2|pou5
 (水 表)	seoi2|biu1
-(㊌ 表)	seoi2|biu1
 (水 里)	seoi2|leoi5
-(㊌ 里)	seoi2|leoi5
 (水 里)	seoi2|leoi5
-(㊌ 里)	seoi2|leoi5
 氵	seoi2
 氷	bing1
 永	wing5
@@ -20146,14 +17907,11 @@ _9      gau2||
 汝	jyu5
 汞	hung3
 (汞 合 金)	hung6|hap6|gam1
-(汞 合 ㊎)	hung6|hap6|gam1
 (汞 合 金)	hung6|hap6|gam1
 江	gong1
 (江 上)	gong1|soeng6
-(江 ㊤)	gong1|soeng6
 池	ci4
 (池 上)	ci4|soeng6
-(池 ㊤)	ci4|soeng6
 污	wu1
 (污 染 重)	wu1|jim5|cung5
 (污 漬)	wu1|zik1
@@ -20266,9 +18024,7 @@ _9      gau2||
 (沈 溺)	cam4|nik1
 (沈 溺)	cam4|nik1
 (沈 下)	cam4|haa6
-(沈 ㊦)	cam4|haa6
 (沈 下)	cam4|haa6
-(沈 ㊦)	cam4|haa6
 (沈 湎)	cam4|min5
 (沈 湎)	cam4|min5
 (沈 默)	cam4|mak6
@@ -20365,7 +18121,6 @@ _9      gau2||
 (河 鱒)	ho4|zyun1
 (河 鳟)	ho4|zyun1
 (河 上)	ho4|soeng6
-(河 ㊤)	ho4|soeng6
 沴	leoi6
 沶	ji4
 沷	fat3
@@ -20384,7 +18139,6 @@ _9      gau2||
 沾	zim1
 沿	jyun4
 (沿 途 上)	jyun4|tou4|soeng6
-(沿 途 ㊤)	jyun4|tou4|soeng6
 況	fong3
 泂	gwing2
 泃	gau1
@@ -20408,9 +18162,7 @@ _9      gau2||
 泔	gam1
 法	faat3
 (法 律 上)	faat3|leot6|soeng6
-(法 律 ㊤)	faat3|leot6|soeng6
 (法 律 上)	faat3|leot6|soeng6
-(法 律 ㊤)	faat3|leot6|soeng6
 (法 國 話)	faat3|gwok3|waa2
 (法 国 话)	faat3|gwok3|waa2
 (法 相)	faat3|soeng3
@@ -20454,9 +18206,7 @@ _9      gau2||
 注	zyu3
 ㊟	zyu3
 (注 塑)	zyu3|sok3
-(㊟ 塑)	zyu3|sok3
 (注 重)	zyu3|zung6
-(㊟ 重)	zyu3|zung6
 泪	leoi6
 泫	jyun5
 泬	hyut3
@@ -20622,38 +18372,24 @@ _9      gau2||
 海	hoi2
 海	hoi2
 (海 水 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 鬥 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
-(海 ㊌ 不 可 斗 量)	hoi2|seoi2|bat1|ho2|dau2|loeng4
 (海 水 淡 化 廠)	hoi2|seoi2|daam6|faa3|cong2
-(海 ㊌ 淡 化 廠)	hoi2|seoi2|daam6|faa3|cong2
 (海 水 淡 化 廠)	hoi2|seoi2|daam6|faa3|cong2
-(海 ㊌ 淡 化 廠)	hoi2|seoi2|daam6|faa3|cong2
 (海 市 蜃 樓)	hoi2|si5|san6|lau4
 (海 市 蜃 樓)	hoi2|si5|san6|lau4
 (海 市 蜃 樓)	hoi2|si5|san6|lau4
 (海 市 蜃 楼)	hoi2|si5|san6|lau4
 (海 市 蜃 楼)	hoi2|si5|san6|lau4
 (海 底 撈 月)	hoi2|dai2|laau4|jyut6
-(海 底 撈 ㊊)	hoi2|dai2|laau4|jyut6
 (海 底 撈 月)	hoi2|dai2|laau4|jyut6
-(海 底 撈 ㊊)	hoi2|dai2|laau4|jyut6
 (海 底 捞 月)	hoi2|dai2|laau4|jyut6
-(海 底 捞 ㊊)	hoi2|dai2|laau4|jyut6
 (海 底 捞 月)	hoi2|dai2|laau4|jyut6
-(海 底 捞 ㊊)	hoi2|dai2|laau4|jyut6
 (海 底 撈 針)	hoi2|dai2|laau4|zam1
 (海 底 撈 針)	hoi2|dai2|laau4|zam1
 (海 底 捞 针)	hoi2|dai2|laau4|zam1
@@ -20663,9 +18399,7 @@ _9      gau2||
 (海 鸥 飞 处)	hoi2|au1|fei1|cyu2
 (海 鸥 飞 处)	hoi2|au1|fei1|cyu2
 (海 上)	hoi2|soeng6
-(海 ㊤)	hoi2|soeng6
 (海 上)	hoi2|soeng6
-(海 ㊤)	hoi2|soeng6
 (海 里)	hoi2|leoi5
 (海 里)	hoi2|leoi5
 (海 里)	hoi2|leoi5
@@ -20858,7 +18592,6 @@ _9      gau2||
 渴	hot3
 游	jau4
 (游 山 玩 水)	jau4|saan1|wun6|seoi2
-(游 山 玩 ㊌)	jau4|saan1|wun6|seoi2
 (游 泳 衣)	jau4|wing6|ji3
 (游 說 團)	jau4|seoi3|tyun4
 (游 說 團)	jau4|seoi3|tyun4
@@ -20891,7 +18624,6 @@ _9      gau2||
 (湖 里)	wu4|leoi5
 (湖 里)	wu4|leoi5
 (湖 上)	wu4|soeng6
-(湖 ㊤)	wu4|soeng6
 湗	fung6
 湘	soeng1
 湙	jik6
@@ -21335,21 +19067,12 @@ _9      gau2||
 火	fo2
 ㊋	fo2
 (火 冒 三 丈)	fo2|mou6|saam1|zoeng6
-(㊋ 冒 三 丈)	fo2|mou6|saam1|zoeng6
-(火 冒 ㊂ 丈)	fo2|mou6|saam1|zoeng6
 (火 花 塞)	fo2|faa1|sak1
-(㊋ 花 塞)	fo2|faa1|sak1
 (火 花 塞)	fo2|faa1|sak1
-(㊋ 花 塞)	fo2|faa1|sak1
 (火 並)	fo2|bing3
-(㊋ 並)	fo2|bing3
 (火 並)	fo2|bing3
-(㊋ 並)	fo2|bing3
 (火 并)	fo2|bing3
-(㊋ 并)	fo2|bing3
 (火 上)	fo2|soeng6
-(火 ㊤)	fo2|soeng6
-(㊋ 上)	fo2|soeng6
 灬	biu1
 灭	mit6
 灮	gwong1
@@ -21421,8 +19144,6 @@ _9      gau2||
 (炸 彈)	zaa3|daan2
 (炸 弹)	zaa3|daan2
 (炸 中)	zaa3|zung3
-(炸 🀄)	zaa3|zung3
-(炸 ㊥)	zaa3|zung3
 点	dim2
 🉄	dim2
 為	wai4
@@ -21747,7 +19468,6 @@ _9      gau2||
 爫	zaau2
 爬	paa4
 (爬 上 床 上)	paa4|soeng5|cong4|soeng3
-(爬 ㊤ 床 ㊤)	paa4|soeng5|cong4|soeng3
 (爬 著)	paa4|zoek6
 (爬 著)	paa4|zoek6
 (爬 着)	paa4|zoek6
@@ -21793,7 +19513,6 @@ _9      gau2||
 (片 言 只 語)	pin3|jin4|zek3|jyu5
 (片 言 只 语)	pin3|jin4|zek3|jyu5
 (片 假 名)	pin3|gaa2|ming4
-(片 假 ㊔)	pin3|gaa2|ming4
 (片 斷)	pin3|dyun6
 (片 断)	pin3|dyun6
 版	baan2
@@ -21843,15 +19562,10 @@ _9      gau2||
 特	dak6
 ㊕	dak6
 (特 內 里 費)	dak6|noi6|leoi5|fai3
-(㊕ 內 里 費)	dak6|noi6|leoi5|fai3
 (特 內 里 費)	dak6|noi6|leoi5|fai3
-(㊕ 內 里 費)	dak6|noi6|leoi5|fai3
 (特 内 里 费)	dak6|noi6|leoi5|fai3
-(㊕ 内 里 费)	dak6|noi6|leoi5|fai3
 (特 内 里 费)	dak6|noi6|leoi5|fai3
-(㊕ 内 里 费)	dak6|noi6|leoi5|fai3
 (特 使)	dak6|si3
-(㊕ 使)	dak6|si3
 牺	hei1
 牻	mong4
 牼	hang1
@@ -21896,9 +19610,7 @@ _9      gau2||
 犯	faan6
 犯	faan6
 (犯 上)	faan6|soeng6
-(犯 ㊤)	faan6|soeng6
 (犯 上)	faan6|soeng6
-(犯 ㊤)	faan6|soeng6
 犰	kau4
 犲	caai4
 犴	hon4
@@ -21954,7 +19666,6 @@ _9      gau2||
 狠	han2
 狡	gaau2
 (狡 兔 三 窟)	gaau2|tou3|saam1|fat1
-(狡 兔 ㊂ 窟)	gaau2|tou3|saam1|fat1
 (狡 黠)	gaau2|kit3
 狢	hok6
 狥	seon1
@@ -22014,8 +19725,6 @@ _9      gau2||
 (猛 干)	maang5|gon3
 猜	caai1
 (猜 中)	caai1|zung3
-(猜 🀄)	caai1|zung3
-(猜 ㊥)	caai1|zung3
 猝	cyut3
 猞	se3
 猟	lip6
@@ -22267,7 +19976,6 @@ _9      gau2||
 珫	cung1
 班	baan1
 (班 上)	baan1|soeng6
-(班 ㊤)	baan1|soeng6
 (班 禪)	baan1|sim4
 (班 長)	baan1|zoeng2
 (班 长)	baan1|zoeng2
@@ -22293,19 +20001,12 @@ _9      gau2||
 理	lei5
 理	lei5
 (理 智 上)	lei5|zi3|soeng6
-(理 智 ㊤)	lei5|zi3|soeng6
 (理 智 上)	lei5|zi3|soeng6
-(理 智 ㊤)	lei5|zi3|soeng6
 (理 論 上)	lei5|leon6|soeng6
-(理 論 ㊤)	lei5|leon6|soeng6
 (理 論 上)	lei5|leon6|soeng6
-(理 論 ㊤)	lei5|leon6|soeng6
 (理 論 上)	lei5|leon6|soeng6
-(理 論 ㊤)	lei5|leon6|soeng6
 (理 论 上)	lei5|leon6|soeng6
-(理 论 ㊤)	lei5|leon6|soeng6
 (理 论 上)	lei5|leon6|soeng6
-(理 论 ㊤)	lei5|leon6|soeng6
 (理 應)	lei5|jing1
 (理 應)	lei5|jing1
 (理 应)	lei5|jing1
@@ -22497,9 +20198,7 @@ _9      gau2||
 (瓦 尔 基 里)	ngaa5|ji5|gei1|leoi5
 (瓦 尔 基 里)	ngaa5|ji5|gei1|leoi5
 (瓦 西 里)	ngaa5|sai1|leoi5
-(瓦 🀂 里)	ngaa5|sai1|leoi5
 (瓦 西 里)	ngaa5|sai1|leoi5
-(瓦 🀂 里)	ngaa5|sai1|leoi5
 (瓦 里 斯)	ngaa5|leoi5|si1
 (瓦 里 斯)	ngaa5|leoi5|si1
 瓧	sap6 ngaa5
@@ -22548,9 +20247,7 @@ _9      gau2||
 甙	doi6
 甚	sam6
 (甚 囂 塵 上)	sam6|hiu1|can4|soeng6
-(甚 囂 塵 ㊤)	sam6|hiu1|can4|soeng6
 (甚 嚣 尘 上)	sam6|hiu1|can4|soeng6
-(甚 嚣 尘 ㊤)	sam6|hiu1|can4|soeng6
 甜	tim4
 甝	hon4
 甞	soeng4
@@ -22565,17 +20262,14 @@ _9      gau2||
 (生 產 反 應 堆)	saang7|caan2|faan2|jing3|deoi1
 (生 产 反 应 堆)	saang7|caan2|faan2|jing3|deoi1
 (生 兒 育 女)	saang1|ji4|juk6|neoi5
-(生 兒 育 ㊛)	saang1|ji4|juk6|neoi5
 (生 兒 育 女)	saang1|ji4|juk6|neoi5
 (生 儿 育 女)	saang1|ji4|juk6|neoi5
-(生 儿 育 ㊛)	saang1|ji4|juk6|neoi5
 (生 儿 育 女)	saang1|ji4|juk6|neoi5
 (生 命 吠 陀)	saang7|ming6|fai6|to4
 (生 命 徵 象)	saang7|ming6|zing1|zoeng6
 (生 命 征 象)	saang7|ming6|zing1|zoeng6
 (生 命 科 學)	saang7|ming6|fo1|hok6
 (生 命 科 学)	saang7|ming6|fo1|hok6
-(生 命 科 ㊫)	saang7|ming6|fo1|hok6
 (生 命 素 質)	saang7|ming6|sou3|zat1
 (生 命 素 质)	saang7|ming6|sou3|zat1
 (生 命 跡 象)	saang7|ming6|zik1|zoeng6
@@ -22583,13 +20277,10 @@ _9      gau2||
 (生 命 週 期)	saang7|ming6|zau1|kei4
 (生 命 周 期)	saang7|ming6|zau1|kei4
 (生 產 企 業)	saang7|caan2|kei5|jip6
-(生 產 ㊭ 業)	saang7|caan2|kei5|jip6
 (生 产 企 业)	saang7|caan2|kei5|jip6
-(生 产 ㊭ 业)	saang7|caan2|kei5|jip6
 (生 產 勞 動)	saang7|caan2|lou4|dung6
 (生 產 勞 動)	saang7|caan2|lou4|dung6
 (生 产 劳 动)	saang7|caan2|lou4|dung6
-(生 产 ㊘ 动)	saang7|caan2|lou4|dung6
 (生 產 單 位)	saang7|caan2|daan1|wai2
 (生 产 单 位)	saang7|caan2|daan1|wai2
 (生 產 成 本)	saang7|caan2|sing4|bun2
@@ -22609,9 +20300,7 @@ _9      gau2||
 (生 產 設 施)	saang7|caan2|cit3|si1
 (生 产 设 施)	saang7|caan2|cit3|si1
 (生 產 資 料)	saang7|caan2|zi1|liu2
-(生 產 ㊮ 料)	saang7|caan2|zi1|liu2
 (生 產 資 料)	saang7|caan2|zi1|liu2
-(生 產 ㊮ 料)	saang7|caan2|zi1|liu2
 (生 产 资 料)	saang7|caan2|zi1|liu2
 (生 产 资 料)	saang7|caan2|zi1|liu2
 (生 產 關 係)	saang7|caan2|gwaan1|hai6
@@ -22648,8 +20337,6 @@ _9      gau2||
 (生 利 息)	saang1|lei6|sik1
 (生 利 息)	saang1|lei6|sik1
 (生 命 中)	sang1|ming6|zung7
-(生 命 🀄)	sang1|ming6|zung7
-(生 命 ㊥)	sang1|ming6|zung7
 (生 人)	saang1|jan4
 (生 來)	saang1|loi4
 (生 來)	saang1|loi4
@@ -22661,9 +20348,7 @@ _9      gau2||
 (生 意)	saang1|ji3
 (生 抽)	saang1|cau1
 (生 日)	saang1|jat6
-(生 ㊐)	saang1|jat6
 (生 水)	saang1|seoi2
-(生 ㊌)	saang1|seoi2
 (生 猛)	saang1|maang5
 (生 產)	sang7|caan2
 (生 产)	sang7|caan2
@@ -22733,8 +20418,6 @@ _9      gau2||
 (田 种)	tin4|zung3
 由	jau4
 (由 上 而 下)	jau4|soeng6|ji4|haa6
-(由 上 而 ㊦)	jau4|soeng6|ji4|haa6
-(由 ㊤ 而 下)	jau4|soeng6|ji4|haa6
 (由 檐 而 繁)	jau4|sim4|ji4|faan4
 (由 檐 而 繁)	jau4|sim4|ji4|faan4
 (由 朝 到 晚)	jau4|ziu1|dou3|maan5
@@ -22743,8 +20426,6 @@ _9      gau2||
 (由 近 而 遠)	jau4|kan5|ji4|jyun5
 (由 近 而 远)	jau4|kan5|ji4|jyun5
 (由 下 到 上)	jau4|haa6|dou3|soeng6
-(由 ㊦ 到 上)	jau4|haa6|dou3|soeng6
-(由 下 到 ㊤)	jau4|haa6|dou3|soeng6
 甲	gaap3
 申	san1
 🈸	san1
@@ -22758,25 +20439,14 @@ _9      gau2||
 男	naam4
 ㊚	naam4
 (男 才 女 貌)	naam4|coi4|neoi5|maau6
-(㊚ 才 女 貌)	naam4|coi4|neoi5|maau6
-(男 才 ㊛ 貌)	naam4|coi4|neoi5|maau6
 (男 才 女 貌)	naam4|coi4|neoi5|maau6
-(㊚ 才 女 貌)	naam4|coi4|neoi5|maau6
 (男 人 婆)	naam4|jan4|po4
-(㊚ 人 婆)	naam4|jan4|po4
 (男 儐 相)	naam4|ban1|soeng3
-(㊚ 儐 相)	naam4|ban1|soeng3
 (男 傧 相)	naam4|ban1|soeng3
-(㊚ 傧 相)	naam4|ban1|soeng3
 (男 學 生)	naam4|hok6|saang1
-(㊚ 學 生)	naam4|hok6|saang1
 (男 学 生)	naam4|hok6|saang1
-(男 ㊫ 生)	naam4|hok6|saang1
-(㊚ 学 生)	naam4|hok6|saang1
 (男 用 表)	naam4|jung6|biu1
-(㊚ 用 表)	naam4|jung6|biu1
 (男 人)	naam4|jan2
-(㊚ 人)	naam4|jan2
 甸	din6
 甹	ping1
 町	ting2
@@ -22797,9 +20467,7 @@ _9      gau2||
 (画 着)	waak6|zoek6
 (画 着)	waak6|zoek6
 (画 上)	waak6|soeng5
-(画 ㊤)	waak6|soeng5
 (画 上)	waak6|soeng5
-(画 ㊤)	waak6|soeng5
 (画 画)	waak6|waa2
 (画 画)	waak6|waa2
 (画 龟)	waak6|gwai1
@@ -22829,9 +20497,7 @@ _9      gau2||
 (留 美 學 生)	lau4|mei5|hok6|saang1
 (留 美 學 生)	lau4|mei5|hok6|saang1
 (留 美 学 生)	lau4|mei5|hok6|saang1
-(留 美 ㊫ 生)	lau4|mei5|hok6|saang1
 (留 美 学 生)	lau4|mei5|hok6|saang1
-(留 美 ㊫ 生)	lau4|mei5|hok6|saang1
 (留 心 看 著)	lau4|sam1|hon1|zyu3
 (留 心 看 著)	lau4|sam1|hon1|zyu3
 (留 心 看 著)	lau4|sam1|hon1|zyu3
@@ -22841,9 +20507,7 @@ _9      gau2||
 (留 學 生)	lau4|hok6|saang1
 (留 學 生)	lau4|hok6|saang1
 (留 学 生)	lau4|hok6|saang1
-(留 ㊫ 生)	lau4|hok6|saang1
 (留 学 生)	lau4|hok6|saang1
-(留 ㊫ 生)	lau4|hok6|saang1
 畚	bun2
 畛	zan2
 畜	cuk1
@@ -22873,7 +20537,6 @@ _9      gau2||
 (畫 著)	waak6|zoek6
 (畫 著)	waak6|zoek6
 (畫 上)	waak6|soeng5
-(畫 ㊤)	waak6|soeng5
 (畫 畫)	waak6|waa2
 (畫 龜)	waak6|gwai1
 (畫 龜)	waak6|gwai1
@@ -23164,15 +20827,9 @@ _9      gau2||
 (白 相)	baak6|soeng3
 百	baak3
 (百 發 百 中)	baak3|faat3|baak3|zung3
-(百 發 百 🀄)	baak3|faat3|baak3|zung3
-(百 發 百 ㊥)	baak3|faat3|baak3|zung3
 (百 发 百 中)	baak3|faat3|baak3|zung3
-(百 发 百 🀄)	baak3|faat3|baak3|zung3
-(百 发 百 ㊥)	baak3|faat3|baak3|zung3
 (百 里 挑 一)	baak3|leoi5|tiu1|jat1
-(百 里 挑 ㊀)	baak3|leoi5|tiu1|jat1
 (百 里 挑 一)	baak3|leoi5|tiu1|jat1
-(百 里 挑 ㊀)	baak3|leoi5|tiu1|jat1
 (百 分 之)	baak3|fan6|zi1
 (百 分 數)	baak3|fan6|sou3
 (百 分 數)	baak3|fan6|sou3
@@ -23187,7 +20844,6 @@ _9      gau2||
 (百 行)	baak3|hong4
 (百 乘)	baak3|sing6
 (百 下)	baak3|haa5
-(百 ㊦)	baak3|haa5
 (百 载)	baak3|zoi2
 (百 載)	baak3|zoi2
 癿	gaa1
@@ -23200,7 +20856,6 @@ _9      gau2||
 (皆 使)	gaai1|si2
 皇	wong4
 (皇 上)	wong4|soeng6
-(皇 ㊤)	wong4|soeng6
 (皇 位)	wong4|wai6
 皈	gwai1
 皋	gou1
@@ -23285,7 +20940,6 @@ _9      gau2||
 監	gaam1
 ㊬	gaam1
 (監 生)	gaam3|saang1
-(㊬ 生)	gaam3|saang1
 盤	pun4
 盥	fun2
 盦	am1
@@ -23377,8 +21031,6 @@ _9      gau2||
 (相 衝)	soeng1|cung3
 (相 冲)	soeng1|cung3
 (相 中)	soeng3|zung3
-(相 🀄)	soeng3|zung3
-(相 ㊥)	soeng3|zung3
 (相 命)	soeng3|ming6
 (相 率)	soeng3|leot6
 (相 率)	soeng3|leot6
@@ -23404,11 +21056,7 @@ _9      gau2||
 (省 长)	saang2|zoeng2
 (省 长)	saang2|zoeng2
 (省 中)	saang2|zung3
-(省 🀄)	saang2|zung3
-(省 ㊥)	saang2|zung3
 (省 中)	saang2|zung3
-(省 🀄)	saang2|zung3
-(省 ㊥)	saang2|zung3
 (省 分)	saang2|fan6
 (省 分)	saang2|fan6
 眄	min5
@@ -23419,8 +21067,6 @@ _9      gau2||
 眊	mou6
 看	hon3
 (看 中)	hon3|zung3
-(看 🀄)	hon3|zung3
-(看 ㊥)	hon3|zung3
 (看 守)	hon1|sau2
 (看 相)	hon3|soeng3
 (看 管)	hon1|gun2
@@ -23571,9 +21217,7 @@ _9      gau2||
 (睡 着 觉)	seoi6|zoek6|gaau3
 (睡 着 觉)	seoi6|zoek6|gaau3
 (睡 一 覺)	seoi6|jat1|gaau3
-(睡 ㊀ 覺)	seoi6|jat1|gaau3
 (睡 一 觉)	seoi6|jat1|gaau3
-(睡 ㊀ 觉)	seoi6|jat1|gaau3
 (睡 不 著)	seoi6|bat1|zoek6
 (睡 不 著)	seoi6|bat1|zoek6
 (睡 不 著)	seoi6|bat1|zoek6
@@ -24009,20 +21653,12 @@ _9      gau2||
 ㊓	se5
 社	se5
 (社 會 上)	se5|wui5|soeng6
-(社 會 ㊤)	se5|wui5|soeng6
-(㊓ 會 上)	se5|wui5|soeng6
 (社 會 上)	se5|wui5|soeng6
-(社 會 ㊤)	se5|wui5|soeng6
 (社 会 上)	se5|wui5|soeng6
-(社 会 ㊤)	se5|wui5|soeng6
-(㊓ 会 上)	se5|wui5|soeng6
 (社 会 上)	se5|wui5|soeng6
-(社 会 ㊤)	se5|wui5|soeng6
 (社 長)	se5|zoeng2
-(㊓ 長)	se5|zoeng2
 (社 長)	se5|zoeng2
 (社 长)	se5|zoeng2
-(㊓ 长)	se5|zoeng2
 (社 长)	se5|zoeng2
 礿	joek6
 祀	zi6
@@ -24103,13 +21739,10 @@ _9      gau2||
 禄	luk6
 禅	sim4
 (禅 门 五 宗)	sim3|mun4|ng5|zung1
-(禅 门 五 ㊪)	sim3|mun4|ng5|zung1
-(禅 门 ㊄ 宗)	sim3|mun4|ng5|zung1
 (禅 位)	sim3|wai2
 (禅 城)	sim3|sing4
 (禅 堂)	sim3|tong4
 (禅 宗)	sim3|zung1
-(禅 ㊪)	sim3|zung1
 (禅 师)	sim3|si1
 (禅 房)	sim3|fong4
 (禅 杖)	sim3|zoeng6
@@ -24213,7 +21846,6 @@ _9      gau2||
 (种 了)	zung3|liu5
 (种 豆)	zung3|dau6
 (种 下)	zung3|haa6
-(种 ㊦)	zung3|haa6
 (种 痘)	zung3|dau6
 (种 些)	zung3|se1
 (种 瓜)	zung3|gwaa1
@@ -24225,7 +21857,6 @@ _9      gau2||
 科	fo1
 (科 學 研 究)	fo1|hok6|jin6|gau3
 (科 学 研 究)	fo1|hok6|jin6|gau3
-(科 ㊫ 研 究)	fo1|hok6|jin6|gau3
 (科 頭 跣 足)	fo1|tau4|sin2|zuk1
 (科 头 跣 足)	fo1|tau4|sin2|zuk1
 (科 長)	fo1|zoeng2
@@ -24238,9 +21869,7 @@ _9      gau2||
 秘	bei3
 ㊙	bei3
 (秘 撈)	bei3|lou7
-(㊙ 撈)	bei3|lou7
 (秘 捞)	bei3|lou7
-(㊙ 捞)	bei3|lou7
 秝	lang3
 租	zou1
 秠	pei1
@@ -24320,7 +21949,6 @@ _9      gau2||
 (種 了)	zung3|liu5
 (種 豆)	zung3|dau6
 (種 下)	zung3|haa6
-(種 ㊦)	zung3|haa6
 (種 痘)	zung3|dau6
 (種 些)	zung3|se1
 (種 瓜)	zung3|gwaa1
@@ -24487,9 +22115,7 @@ _9      gau2||
 立	lap6
 立	lap6
 (立 上)	lap6|soeng6
-(立 ㊤)	lap6|soeng6
 (立 上)	lap6|soeng6
-(立 ㊤)	lap6|soeng6
 竏	cin1 sing1
 竑	wang4
 竒	kei4
@@ -24594,7 +22220,6 @@ _9      gau2||
 筈	kut3
 等	dang2
 (等 下)	dang2|haa5
-(等 ㊦)	dang2|haa5
 筊	gaau2
 筋	gan1
 筌	cyun4
@@ -24639,7 +22264,6 @@ _9      gau2||
 筼	wan4
 签	cim1
 (签 名)	cim7|meng2
-(签 ㊔)	cim7|meng2
 简	gaan2
 箄	bei6
 箅	bai3
@@ -24777,7 +22401,6 @@ _9      gau2||
 簼	gau1
 簽	cim1
 (簽 名)	cim7|meng2
-(簽 ㊔)	cim7|meng2
 簾	lim4
 簾	lim4
 簿	bou6
@@ -24999,7 +22622,6 @@ _9      gau2||
 (紙 帶)	zi2|daai2
 (紙 錢)	zi2|cin4
 (紙 上)	zi2|soeng6
-(紙 ㊤)	zi2|soeng6
 級	kap1
 (級 長)	kap1|zoeng2
 紛	fan1
@@ -25164,7 +22786,6 @@ _9      gau2||
 綱	gong1
 網	mong5
 (網 上)	mong5|soeng6
-(網 ㊤)	mong5|soeng6
 綳	bang1
 綴	zeoi3
 綵	coi2
@@ -25204,7 +22825,6 @@ _9      gau2||
 緙	kaak1
 線	sin3
 (線 上 查 詢)	sin3|soeng6|caa4|seon7
-(線 ㊤ 查 詢)	sin3|soeng6|caa4|seon7
 緜	min4
 緝	cap1
 緞	dyun6
@@ -25445,7 +23065,6 @@ _9      gau2||
 (纸 带)	zi2|daai2
 (纸 钱)	zi2|cin4
 (纸 上)	zi2|soeng6
-(纸 ㊤)	zi2|soeng6
 纹	man4
 纺	fong2
 纻	cyu5
@@ -25454,7 +23073,6 @@ _9      gau2||
 纾	syu1
 线	sin3
 (线 上 查 询)	sin3|soeng6|caa4|seon7
-(线 ㊤ 查 询)	sin3|soeng6|caa4|seon7
 绀	gam3
 绁	sit3
 绂	fat1
@@ -25609,7 +23227,6 @@ _9      gau2||
 罐	gun3
 网	mong5
 (网 上)	mong5|soeng6
-(网 ㊤)	mong5|soeng6
 罒	muk6
 罔	mong5
 罕	hon2
@@ -25796,15 +23413,11 @@ _9      gau2||
 (老 太 婆)	lou5|taai3|po2
 (老 太 婆)	lou5|taai3|po2
 (老 處 女)	lou5|cyu2|neoi5
-(老 處 ㊛)	lou5|cyu2|neoi5
 (老 處 女)	lou5|cyu2|neoi5
 (老 處 女)	lou5|cyu2|neoi5
-(老 處 ㊛)	lou5|cyu2|neoi5
 (老 处 女)	lou5|cyu2|neoi5
-(老 处 ㊛)	lou5|cyu2|neoi5
 (老 处 女)	lou5|cyu2|neoi5
 (老 处 女)	lou5|cyu2|neoi5
-(老 处 ㊛)	lou5|cyu2|neoi5
 (老 背 少)	lou5|bui6|siu3
 (老 背 少)	lou5|bui6|siu3
 (老 伯)	lou5|baa3
@@ -25828,8 +23441,6 @@ _9      gau2||
 耂	lou5
 考	haau2
 (考 中)	haau2|zung3
-(考 🀄)	haau2|zung3
-(考 ㊥)	haau2|zung3
 (考 訂)	haau2|ding6
 (考 订)	haau2|ding6
 (考 量)	haau2|loeng4
@@ -25961,15 +23572,11 @@ _9      gau2||
 肈	siu6
 肉	juk6
 (肉 麻 當 有 趣)	juk6|maa4|dong3|jau5|ceoi3
-(肉 麻 當 ㊒ 趣)	juk6|maa4|dong3|jau5|ceoi3
 (肉 麻 当 有 趣)	juk6|maa4|dong3|jau5|ceoi3
-(肉 麻 当 ㊒ 趣)	juk6|maa4|dong3|jau5|ceoi3
 (肉 長 的)	juk6|zoeng2|dik1
 (肉 长 的)	juk6|zoeng2|dik1
 (肉 體 上)	juk6|tai2|soeng6
-(肉 體 ㊤)	juk6|tai2|soeng6
 (肉 体 上)	juk6|tai2|soeng6
-(肉 体 ㊤)	juk6|tai2|soeng6
 (肉 冠)	juk6|gun3
 (肉 松)	juk6|sung7
 肊	jik1
@@ -26004,7 +23611,6 @@ _9      gau2||
 肨	pong3
 肩	gin1
 (肩 上)	gin1|soeng6
-(肩 ㊤)	gin1|soeng6
 肪	fong1
 肫	zeon1
 肭	nat6
@@ -26117,11 +23723,9 @@ _9      gau2||
 (脏 兮 兮)	zong1|hai4|hai4
 (脏 乱)	zong1|lyun6
 (脏 土)	zong1|tou2
-(脏 ㊏)	zong1|tou2
 (脏 字)	zong1|zi6
 (脏 弹)	zong1|daan6
 (脏 水)	zong1|seoi2
-(脏 ㊌)	zong1|seoi2
 (脏 污)	zong1|wu1
 (脏 煤)	zong1|mui4
 (脏 病)	zong1|beng6
@@ -26164,7 +23768,6 @@ _9      gau2||
 (脷 苔)	lei6|toi1
 脸	lim5
 (脸 上)	lim5|soeng6
-(脸 ㊤)	lim5|soeng6
 脹	zoeng3
 脺	ceoi3
 脽	seoi4
@@ -26288,7 +23891,6 @@ _9      gau2||
 臈	laap6
 臉	lim5
 (臉 上)	lim5|soeng6
-(臉 ㊤)	lim5|soeng6
 臊	sou1
 臌	gu2
 臍	ci4
@@ -26322,18 +23924,12 @@ _9      gau2||
 自	zi6
 (自 助 洗 衣 店)	zi6|zo6|sai2|ji3|dim3
 (自 上 而 下)	zi6|soeng6|ji4|haa6
-(自 上 而 ㊦)	zi6|soeng6|ji4|haa6
-(自 ㊤ 而 下)	zi6|soeng6|ji4|haa6
 (自 下 而 上)	zi6|haa6|ji4|soeng6
-(自 ㊦ 而 上)	zi6|haa6|ji4|soeng6
-(自 下 而 ㊤)	zi6|haa6|ji4|soeng6
 (自 蹈 法 網)	zi6|tou1|faat3|mong5
 (自 蹈 法 网)	zi6|tou1|faat3|mong5
 (自 動 電 話)	zi6|dung6|din6|waa2
 (自 动 电 话)	zi6|dung6|din6|waa2
 (自 下 到 上)	zi6|haa6|dou3|soeng6
-(自 ㊦ 到 上)	zi6|haa6|dou3|soeng6
-(自 下 到 ㊤)	zi6|haa6|dou3|soeng6
 (自 畫 像)	zi6|waa6|zoeng6
 (自 画 像)	zi6|waa6|zoeng6
 (自 画 像)	zi6|waa6|zoeng6
@@ -26365,13 +23961,9 @@ _9      gau2||
 臲	jit6
 至	zi3
 (至 高 無 上)	zi3|gou1|mou4|soeng6
-(至 高 無 ㊤)	zi3|gou1|mou4|soeng6
 (至 高 无 上)	zi3|gou1|mou4|soeng6
-(至 高 无 ㊤)	zi3|gou1|mou4|soeng6
 (至 上)	zi3|soeng6
-(至 ㊤)	zi3|soeng6
 (至 正)	zi3|zeng3
-(至 ㊣)	zi3|zeng3
 致	zi3
 臶	zin6
 臷	dit6
@@ -26429,9 +24021,7 @@ _9      gau2||
 舝	hat6
 舞	mou5
 (舞 水 端 里)	mou5|seoi2|dyun1|leoi5
-(舞 ㊌ 端 里)	mou5|seoi2|dyun1|leoi5
 (舞 水 端 里)	mou5|seoi2|dyun1|leoi5
-(舞 ㊌ 端 里)	mou5|seoi2|dyun1|leoi5
 舟	zau1
 (舟 車)	zau1|geoi1
 (舟 車)	zau1|geoi1
@@ -26471,7 +24061,6 @@ _9      gau2||
 舸	go2
 船	syun4
 (船 上)	syun4|soeng6
-(船 ㊤)	syun4|soeng6
 (船 只)	syun4|zek3
 舺	gaap3
 舻	lou4
@@ -26594,7 +24183,6 @@ _9      gau2||
 (花 被)	faa1|pei5
 (花 弗)	faa1|fit1
 (花 名)	faa1|meng2
-(花 ㊔)	faa1|meng2
 (花 麽)	faa1|jiu1
 (花 么)	faa1|jiu1
 芳	fong1
@@ -26624,9 +24212,7 @@ _9      gau2||
 苏	sou1
 (苏 格 兰 折 耳 猫)	sou1|gaak3|laan4|zip3|ji5|maau1
 (苏 里 南)	sou1|leoi5|naam4
-(苏 里 🀁)	sou1|leoi5|naam4
 (苏 里 南)	sou1|leoi5|naam4
-(苏 里 🀁)	sou1|leoi5|naam4
 苐	dai6
 苑	jyun2
 (苑 里)	jyun2|leoi5
@@ -26656,7 +24242,6 @@ _9      gau2||
 (苦 過 弟 弟)	fu2|gwo3|di4|di2
 (苦 过 弟 弟)	fu2|gwo3|di4|di2
 (苦 上 加 苦)	fu2|soeng6|gaa1|fu2
-(苦 ㊤ 加 苦)	fu2|soeng6|gaa1|fu2
 (苦 差)	fu2|caai1
 (苦 干)	fu2|gon3
 (苦 澀)	fu2|sap1
@@ -26673,13 +24258,9 @@ _9      gau2||
 苯	bun2
 英	jing1
 (英 倫 三 島)	jing1|leon4|saam1|dou2
-(英 倫 ㊂ 島)	jing1|leon4|saam1|dou2
 (英 倫 三 島)	jing1|leon4|saam1|dou2
-(英 倫 ㊂ 島)	jing1|leon4|saam1|dou2
 (英 伦 三 岛)	jing1|leon4|saam1|dou2
-(英 伦 ㊂ 岛)	jing1|leon4|saam1|dou2
 (英 文 名)	jing1|man4|meng2
-(英 文 ㊔)	jing1|man4|meng2
 (英 哩)	jing1|lei5
 苲	zaa3
 苴	zeoi1
@@ -27387,9 +24968,7 @@ _9      gau2||
 蘆	lou4
 蘇	sou1
 (蘇 里 南)	sou1|leoi5|naam4
-(蘇 里 🀁)	sou1|leoi5|naam4
 (蘇 里 南)	sou1|leoi5|naam4
-(蘇 里 🀁)	sou1|leoi5|naam4
 蘉	mong4
 蘊	wan5
 蘋	ping4
@@ -27458,7 +25037,6 @@ _9      gau2||
 (處 分)	cyu5|fan7
 (處 境)	cyu5|ging2
 (處 女)	cyu5|neoi5
-(處 ㊛)	cyu5|neoi5
 (處 女)	cyu5|neoi5
 (處 方)	cyu5|fong1
 (處 於)	cyu5|jyu7
@@ -27843,11 +25421,8 @@ _9      gau2||
 (行 萬 里 路 勝 讀 萬 捲 書)	haang4|maan6|lei5|lou6|sing3|duk6|maan6|gyun2|syu1
 (行 萬 里 路 勝 讀 萬 捲 書)	haang4|maan6|lei5|lou6|sing3|duk6|maan6|gyun2|syu1
 (行 不 改 姓 坐 不 改 名)	hang4|bat1|goi2|sing3|zo6|bat1|goi2|ming4
-(行 不 改 姓 坐 不 改 ㊔)	hang4|bat1|goi2|sing3|zo6|bat1|goi2|ming4
 (行 不 改 姓 坐 不 改 名)	hang4|bat1|goi2|sing3|zo6|bat1|goi2|ming4
-(行 不 改 姓 坐 不 改 ㊔)	hang4|bat1|goi2|sing3|zo6|bat1|goi2|ming4
 (行 不 改 姓 坐 不 改 名)	hang4|bat1|goi2|sing3|zo6|bat1|goi2|ming4
-(行 不 改 姓 坐 不 改 ㊔)	hang4|bat1|goi2|sing3|zo6|bat1|goi2|ming4
 (行 行 出 狀 元)	hong4|hong4|ceot1|zong6|jyun4
 (行 行 出 狀 元)	hong4|hong4|ceot1|zong6|jyun4
 (行 行 出 狀 元)	hong4|hong4|ceot1|zong6|jyun4
@@ -27866,13 +25441,9 @@ _9      gau2||
 (行 住 坐 卧)	haang4|zyu6|co5|ngo6
 (行 住 坐 卧)	haang4|zyu6|co5|ngo6
 (行 有 行 規)	hong4|jau5|hong4|kwai1
-(行 ㊒ 行 規)	hong4|jau5|hong4|kwai1
 (行 有 行 規)	hong4|jau5|hong4|kwai1
-(行 ㊒ 行 規)	hong4|jau5|hong4|kwai1
 (行 有 行 规)	hong4|jau5|hong4|kwai1
-(行 ㊒ 行 规)	hong4|jau5|hong4|kwai1
 (行 有 行 规)	hong4|jau5|hong4|kwai1
-(行 ㊒ 行 规)	hong4|jau5|hong4|kwai1
 (行 差 踏 錯)	haang4|caa1|daap6|co3
 (行 差 踏 錯)	haang4|caa1|daap6|co3
 (行 差 踏 错)	haang4|caa1|daap6|co3
@@ -27982,9 +25553,7 @@ _9      gau2||
 (行 東)	hong4|dung1
 (行 東)	hong4|dung1
 (行 东)	hong4|dung1
-(行 🀀)	hong4|dung1
 (行 东)	hong4|dung1
-(行 🀀)	hong4|dung1
 (行 寬)	hong4|fun1
 (行 寬)	hong4|fun1
 (行 宽)	hong4|fun1
@@ -28024,7 +25593,6 @@ _9      gau2||
 衖	hong6
 街	gaai1
 (街 上)	gaai1|soeng6
-(街 ㊤)	gaai1|soeng6
 衙	ngaa4
 衚	wu4
 衛	wai6
@@ -28280,21 +25848,13 @@ _9      gau2||
 西	sai1
 🀂	sai1
 (西 班 牙 話)	sai1|baan1|ngaa4|waa2
-(🀂 班 牙 話)	sai1|baan1|ngaa4|waa2
 (西 班 牙 话)	sai1|baan1|ngaa4|waa2
-(🀂 班 牙 话)	sai1|baan1|ngaa4|waa2
 (西 西 里)	sai1|sai1|leoi5
-(🀂 🀂 里)	sai1|sai1|leoi5
 (西 西 里)	sai1|sai1|leoi5
-(🀂 🀂 里)	sai1|sai1|leoi5
 (西 崑 體)	sai1|kwan1|tai2
-(🀂 崑 體)	sai1|kwan1|tai2
 (西 崑 体)	sai1|kwan1|tai2
-(🀂 崑 体)	sai1|kwan1|tai2
 (西 藏)	sai1|zong6
-(🀂 藏)	sai1|zong6
 (西 伯)	sai1|baa3
-(🀂 伯)	sai1|baa3
 要	jiu3
 (要 生 要 死)	jiu3|saang1|jiu3|sei2
 (要 挾)	jiu1|hip6
@@ -28426,7 +25986,6 @@ _9      gau2||
 (訂 條 約)	ding6|tiu4|joek3
 (訂 婚)	ding6|fan1
 (訂 正)	ding6|zing3
-(訂 ㊣)	ding6|zing3
 (訂 立)	ding6|lap6
 (訂 立)	ding6|lap6
 (訂 製)	ding6|zai3
@@ -28519,7 +26078,6 @@ _9      gau2||
 試	si3
 (試 嚇)	si3|haa5
 (試 下)	si3|haa5
-(試 ㊦)	si3|haa5
 詧	caat3
 詩	si1
 (詩 既 亡)	si1|gei3|mou4
@@ -28536,8 +26094,6 @@ _9      gau2||
 詰	gat1
 話	waa6
 (話 中)	waa6|zung3
-(話 🀄)	waa6|zung3
-(話 ㊥)	waa6|zung3
 該	goi1
 詳	coeng4
 詵	san1
@@ -28659,8 +26215,6 @@ _9      gau2||
 諁	zyut3
 諂	cim2
 (諂 上 欺 下)	cim2|soeng6|hei1|haa6
-(諂 上 欺 ㊦)	cim2|soeng6|hei1|haa6
-(諂 ㊤ 欺 下)	cim2|soeng6|hei1|haa6
 諃	cam1
 諄	deon1
 諆	hei1
@@ -28861,7 +26415,6 @@ _9      gau2||
 (订 条 约)	ding6|tiu4|joek3
 (订 婚)	ding6|fan1
 (订 正)	ding6|zing3
-(订 ㊣)	ding6|zing3
 (订 立)	ding6|lap6
 (订 立)	ding6|lap6
 (订 制)	ding6|zai3
@@ -28930,7 +26483,6 @@ _9      gau2||
 试	si3
 (试 吓)	si3|haa5
 (试 下)	si3|haa5
-(试 ㊦)	si3|haa5
 诖	gwaa3
 诗	si1
 (诗 既 亡)	si1|gei3|mou4
@@ -28949,12 +26501,8 @@ _9      gau2||
 (话 里 套 话)	waa6|leoi5|tou3|waa6
 (话 里 套 话)	waa6|leoi5|tou3|waa6
 (话 里 有 话)	waa6|leoi5|jau5|waa6
-(话 里 ㊒ 话)	waa6|leoi5|jau5|waa6
 (话 里 有 话)	waa6|leoi5|jau5|waa6
-(话 里 ㊒ 话)	waa6|leoi5|jau5|waa6
 (话 中)	waa6|zung3
-(话 🀄)	waa6|zung3
-(话 ㊥)	waa6|zung3
 诞	daan3
 诟	gau3
 诠	cyun4
@@ -29028,8 +26576,6 @@ _9      gau2||
 (调 治)	tiu4|zi6
 谄	cim2
 (谄 上 欺 下)	cim2|soeng6|hei1|haa6
-(谄 上 欺 ㊦)	cim2|soeng6|hei1|haa6
-(谄 ㊤ 欺 下)	cim2|soeng6|hei1|haa6
 谅	loeng6
 谆	deon1
 谇	seoi6
@@ -29265,9 +26811,7 @@ _9      gau2||
 購	kau3
 賽	coi3
 (賽 里 木 湖)	coi3|leoi5|muk6|wu4
-(賽 里 ㊍ 湖)	coi3|leoi5|muk6|wu4
 (賽 里 木 湖)	coi3|leoi5|muk6|wu4
-(賽 里 ㊍ 湖)	coi3|leoi5|muk6|wu4
 賾	zaak3
 贃	taan3
 贄	zi3
@@ -29372,9 +26916,7 @@ _9      gau2||
 赚	zaan6
 赛	coi3
 (赛 里 木 湖)	coi3|leoi5|muk6|wu4
-(赛 里 ㊍ 湖)	coi3|leoi5|muk6|wu4
 (赛 里 木 湖)	coi3|leoi5|muk6|wu4
-(赛 里 ㊍ 湖)	coi3|leoi5|muk6|wu4
 赜	zaak3
 赝	ngaan6
 赞	zaan3
@@ -29399,9 +26941,7 @@ _9      gau2||
 走	zau2
 🈰	zau2
 (走 馬 上 任)	zau2|maa5|soeng5|jam6
-(走 馬 ㊤ 任)	zau2|maa5|soeng5|jam6
 (走 马 上 任)	zau2|maa5|soeng5|jam6
-(走 马 ㊤ 任)	zau2|maa5|soeng5|jam6
 (走 散)	zau2|saan2
 赱	zau2
 赳	dau2
@@ -29500,7 +27040,6 @@ _9      gau2||
 跡	zik1
 跣	sin3
 (跣 咗 一 跤)	sin3|zo2|jat1|gaau7
-(跣 咗 ㊀ 跤)	sin3|zo2|jat1|gaau7
 (跣 親)	sin3|can7
 (跣 亲)	sin3|can7
 (跣 低)	sin3|dai7
@@ -29516,17 +27055,11 @@ _9      gau2||
 路	lou6
 路	lou6
 (路 線 上)	lou6|sin3|soeng6
-(路 線 ㊤)	lou6|sin3|soeng6
 (路 線 上)	lou6|sin3|soeng6
-(路 線 ㊤)	lou6|sin3|soeng6
 (路 线 上)	lou6|sin3|soeng6
-(路 线 ㊤)	lou6|sin3|soeng6
 (路 线 上)	lou6|sin3|soeng6
-(路 线 ㊤)	lou6|sin3|soeng6
 (路 上)	lou6|soeng6
-(路 ㊤)	lou6|soeng6
 (路 上)	lou6|soeng6
-(路 ㊤)	lou6|soeng6
 跰	pin4
 跱	si6
 跲	gaap3
@@ -29574,8 +27107,6 @@ _9      gau2||
 (踢 达 舞)	tek3|taat3|mou5
 (踢 躂 舞)	tek3|taat3|mou5
 (踢 中)	tek3|zung3
-(踢 🀄)	tek3|zung3
-(踢 ㊥)	tek3|zung3
 踣	baak6
 踤	cyut3
 踥	cip3
@@ -29710,29 +27241,16 @@ _9      gau2||
 (身 輕 言 微)	san1|heng1|jin4|mei4
 (身 轻 言 微)	san1|heng1|jin4|mei4
 (身 中 數 槍)	san1|zung3|sou3|coeng1
-(身 🀄 數 槍)	san1|zung3|sou3|coeng1
-(身 ㊥ 數 槍)	san1|zung3|sou3|coeng1
 (身 中 數 槍)	san1|zung3|sou3|coeng1
-(身 🀄 數 槍)	san1|zung3|sou3|coeng1
-(身 ㊥ 數 槍)	san1|zung3|sou3|coeng1
 (身 中 数 枪)	san1|zung3|sou3|coeng1
-(身 🀄 数 枪)	san1|zung3|sou3|coeng1
-(身 ㊥ 数 枪)	san1|zung3|sou3|coeng1
 (身 中 數 彈)	san1|zung3|sou3|daan6
-(身 🀄 數 彈)	san1|zung3|sou3|daan6
-(身 ㊥ 數 彈)	san1|zung3|sou3|daan6
 (身 中 數 彈)	san1|zung3|sou3|daan6
-(身 🀄 數 彈)	san1|zung3|sou3|daan6
-(身 ㊥ 數 彈)	san1|zung3|sou3|daan6
 (身 中 数 弹)	san1|zung3|sou3|daan6
-(身 🀄 数 弹)	san1|zung3|sou3|daan6
-(身 ㊥ 数 弹)	san1|zung3|sou3|daan6
 (身 微 言 輕)	san1|mei4|jin4|heng1
 (身 微 言 轻)	san1|mei4|jin4|heng1
 (身 份 證)	san1|fan6|zing3
 (身 份 证)	san1|fan6|zing3
 (身 上)	san1|soeng6
-(身 ㊤)	san1|soeng6
 (身 份)	san1|fan2
 (身 分)	san1|fan6
 躬	gung1
@@ -29760,11 +27278,8 @@ _9      gau2||
 (車 里 雅 賓 斯 克)	ce1|leoi5|ngaa5|ban1|si1|hak1
 (車 里 雅 賓 斯 克)	ce1|leoi5|ngaa5|ban1|si1|hak1
 (車 水 馬 龍)	geoi1|seoi2|maa5|lung4
-(車 ㊌ 馬 龍)	geoi1|seoi2|maa5|lung4
 (車 水 馬 龍)	geoi1|seoi2|maa5|lung4
-(車 ㊌ 馬 龍)	geoi1|seoi2|maa5|lung4
 (車 水 馬 龍)	geoi1|seoi2|maa5|lung4
-(車 ㊌ 馬 龍)	geoi1|seoi2|maa5|lung4
 (車 載 斗 量)	ce1|zoi3|dau2|loeng4
 (車 載 斗 量)	ce1|zoi3|dau2|loeng4
 (車 載 斗 量)	ce1|zoi3|dau2|loeng4
@@ -29917,10 +27432,8 @@ _9      gau2||
 (轉 軸)	zyun3|zuk6
 (轉 頭)	zyun3|tau4
 (轉 右)	zyun3|jau6
-(轉 ㊨)	zyun3|jau6
 (轉 臺)	zyun3|toi4
 (轉 左)	zyun3|zo2
-(轉 ㊧)	zyun3|zo2
 轊	wai6
 轍	cit3
 轎	giu2
@@ -29951,7 +27464,6 @@ _9      gau2||
 (车 里 雅 宾 斯 克)	ce1|leoi5|ngaa5|ban1|si1|hak1
 (车 里 雅 宾 斯 克)	ce1|leoi5|ngaa5|ban1|si1|hak1
 (车 水 马 龙)	geoi1|seoi2|maa5|lung4
-(车 ㊌ 马 龙)	geoi1|seoi2|maa5|lung4
 (车 载 斗 量)	ce1|zoi3|dau2|loeng4
 (车 载 斗 量)	ce1|zoi3|dau2|loeng4
 (车 马 费)	ce1|maa5|fai3
@@ -29969,7 +27481,6 @@ _9      gau2||
 轫	jan6
 转	zyun2
 (转 学 生)	zyun2|hok6|saang7
-(转 ㊫ 生)	zyun2|hok6|saang7
 (转 捩 点)	zyun2|lit6|dim2
 (转 速 表)	zyun2|cuk1|biu1
 (转 动)	zyun3|dung6
@@ -29982,9 +27493,7 @@ _9      gau2||
 (转 轴)	zyun3|zuk6
 (转 头)	zyun3|tau4
 (转 右)	zyun3|jau6
-(转 ㊨)	zyun3|jau6
 (转 左)	zyun3|zo2
-(转 ㊧)	zyun3|zo2
 轭	aak1
 轮	leon4
 软	jyun5
@@ -30001,7 +27510,6 @@ _9      gau2||
 轺	jiu4
 轻	hing1
 (轻 描 淡 写)	hing1|miu4|daam6|se2
-(轻 描 淡 ㊢)	hing1|miu4|daam6|se2
 (轻 轻 松 松)	hing1|hing1|sung7|sung7
 (轻 飘 飘)	heng1|piu1|piu1
 (轻 口 供)	hing7|hau2|gung7
@@ -30069,7 +27577,6 @@ _9      gau2||
 辱	juk6
 農	nung4
 (農 業 生 產 合 作 社)	nung4|jip6|saang7|caan2|hap6|zok3|se5
-(農 業 生 產 合 作 ㊓)	nung4|jip6|saang7|caan2|hap6|zok3|se5
 (農 業 生 產 合 作 社)	nung4|jip6|saang7|caan2|hap6|zok3|se5
 (農 舍)	nung4|se3
 辳	nung4
@@ -30128,7 +27635,6 @@ _9      gau2||
 (返 頭 嫁)	faan1|tau4|gaa3
 (返 头 嫁)	faan1|tau4|gaa3
 (返 上 嚟)	faan1|soeng5|lai4
-(返 ㊤ 嚟)	faan1|soeng5|lai4
 (返 埋 去)	faan1|maai4|heoi3
 (返 落 嚟)	faan1|lok6|lai4
 (返 落 嚟)	faan1|lok6|lai4
@@ -30138,15 +27644,12 @@ _9      gau2||
 (返 生)	faan1|saang1
 (返 學)	faan1|hok6
 (返 学)	faan1|hok6
-(返 ㊫)	faan1|hok6
 (返 夜)	faan1|je2
-(返 ㊰)	faan1|je2
 迕	ng6
 还	waan4
 (还 返)	waan4|faan1
 这	ze5
 (这 下)	ze5|haa5
-(这 ㊦)	ze5|haa5
 (这 里)	ze5|leoi5
 (这 里)	ze5|leoi5
 (这 只)	ze5|zek3
@@ -30158,18 +27661,11 @@ _9      gau2||
 违	wai4
 连	lin4
 (连 三 并 四)	lin4|saam7|bing3|sei3
-(连 ㊂ 并 四)	lin4|saam7|bing3|sei3
-(连 三 并 ㊃)	lin4|saam7|bing3|sei3
 (连 中 三 元)	lin4|zung3|saam1|jyun4
-(连 🀄 三 元)	lin4|zung3|saam1|jyun4
-(连 ㊥ 三 元)	lin4|zung3|saam1|jyun4
-(连 中 ㊂ 元)	lin4|zung3|saam1|jyun4
-(连 🀄 ㊂ 元)	lin4|zung3|saam1|jyun4
 (连 衣 裙)	lin4|ji3|kwan4
 (连 长)	lin4|zoeng2
 迟	ci4
 (迟 下)	ci4|haa5
-(迟 ㊦)	ci4|haa5
 迢	tiu4
 迣	lai6
 迤	ji4
@@ -30214,8 +27710,6 @@ _9      gau2||
 逈	gwing2
 选	syun2
 (选 中)	syun2|zung3
-(选 🀄)	syun2|zung3
-(选 ㊥)	syun2|zung3
 逊	seon3
 逋	bou1
 逌	jau4
@@ -30234,7 +27728,6 @@ _9      gau2||
 逗	dau6
 這	ze5
 (這 下)	ze5|haa5
-(這 ㊦)	ze5|haa5
 (這 只)	ze5|zek3
 (這 行)	ze5|hong4
 (這 行)	ze5|hong4
@@ -30253,15 +27746,7 @@ _9      gau2||
 連	lin4
 連	lin4
 (連 中 三 元)	lin4|zung3|saam1|jyun4
-(連 🀄 三 元)	lin4|zung3|saam1|jyun4
-(連 ㊥ 三 元)	lin4|zung3|saam1|jyun4
-(連 中 ㊂ 元)	lin4|zung3|saam1|jyun4
-(連 🀄 ㊂ 元)	lin4|zung3|saam1|jyun4
 (連 中 三 元)	lin4|zung3|saam1|jyun4
-(連 🀄 三 元)	lin4|zung3|saam1|jyun4
-(連 ㊥ 三 元)	lin4|zung3|saam1|jyun4
-(連 中 ㊂ 元)	lin4|zung3|saam1|jyun4
-(連 🀄 ㊂ 元)	lin4|zung3|saam1|jyun4
 (連 衣 裙)	lin4|ji3|kwan4
 (連 衣 裙)	lin4|ji3|kwan4
 (連 長)	lin4|zoeng2
@@ -30296,7 +27781,6 @@ _9      gau2||
 遊	jau4
 🈫	jau4
 (遊 山 玩 水)	jau4|saan1|wun6|seoi2
-(遊 山 玩 ㊌)	jau4|saan1|wun6|seoi2
 (遊 說)	jau4|seoi3
 (遊 說)	jau4|seoi3
 (遊 說)	jau4|seoi3
@@ -30341,7 +27825,6 @@ _9      gau2||
 適	sik1
 ㊜	sik1
 (適 當)	sik1|dong3
-(㊜ 當)	sik1|dong3
 遫	cuk1
 遬	cuk1
 遭	zou1
@@ -30351,17 +27834,13 @@ _9      gau2||
 遲	ci4
 遲	ci4
 (遲 下)	ci4|haa5
-(遲 ㊦)	ci4|haa5
 (遲 下)	ci4|haa5
-(遲 ㊦)	ci4|haa5
 遴	leon4
 遵	zeon1
 遶	jiu5
 遷	cin1
 選	syun2
 (選 中)	syun2|zung3
-(選 🀄)	syun2|zung3
-(選 ㊥)	syun2|zung3
 遹	leot6
 遺	wai4
 遻	ng6
@@ -30440,9 +27919,7 @@ _9      gau2||
 邿	si1
 郁	wat1
 (郁 不 得 其 正)	juk1|bat1|dak1|kei4|zing3
-(郁 不 得 其 ㊣)	juk1|bat1|dak1|kei4|zing3
 (郁 不 得 其 正)	juk1|bat1|dak1|kei4|zing3
-(郁 不 得 其 ㊣)	juk1|bat1|dak1|kei4|zing3
 (郁 親)	juk1|can1
 (郁 亲)	juk1|can1
 (郁 秀)	juk1|sau3
@@ -30456,10 +27933,8 @@ _9      gau2||
 郎	long4
 郎	long4
 (郎 才 女 貌)	long4|coi4|neoi5|maau6
-(郎 才 ㊛ 貌)	long4|coi4|neoi5|maau6
 (郎 才 女 貌)	long4|coi4|neoi5|maau6
 (郎 才 女 貌)	long4|coi4|neoi5|maau6
-(郎 才 ㊛ 貌)	long4|coi4|neoi5|maau6
 郏	gaap3
 郐	kui2
 郑	zeng6
@@ -30727,9 +28202,7 @@ _9      gau2||
 (里 奥 格 兰 德)	leoi5|ou3|gaak3|laan4|dak1
 (里 奥 格 兰 德)	leoi5|ou3|gaak3|laan4|dak1
 (里 希 特 霍 芬)	leoi5|hei1|dak6|fok3|fan1
-(里 希 ㊕ 霍 芬)	leoi5|hei1|dak6|fok3|fan1
 (里 希 特 霍 芬)	leoi5|hei1|dak6|fok3|fan1
-(里 希 ㊕ 霍 芬)	leoi5|hei1|dak6|fok3|fan1
 (里 約 熱 內 盧)	lei5|joek3|jit6|noi6|lou4
 (里 約 熱 內 盧)	lei5|joek3|jit6|noi6|lou4
 (里 約 熱 內 盧)	lei5|joek3|jit6|noi6|lou4
@@ -30754,9 +28227,7 @@ _9      gau2||
 (里 外 里)	lei5|ngoi6|lei5
 (里 外 里)	lei5|ngoi6|lei5
 (里 克 特)	leoi5|hak1|dak6
-(里 克 ㊕)	leoi5|hak1|dak6
 (里 克 特)	leoi5|hak1|dak6
-(里 克 ㊕)	leoi5|hak1|dak6
 (里 士 滿)	leoi5|si6|mun5
 (里 士 滿)	leoi5|si6|mun5
 (里 士 满)	leoi5|si6|mun5
@@ -30824,19 +28295,11 @@ _9      gau2||
 (重 文 輕 武)	zung6|man4|hing1|mou5
 (重 文 轻 武)	zung6|man4|hing1|mou5
 (重 水 生 產)	cung5|seoi2|saang7|caan2
-(重 ㊌ 生 產)	cung5|seoi2|saang7|caan2
 (重 水 生 产)	cung5|seoi2|saang7|caan2
-(重 ㊌ 生 产)	cung5|seoi2|saang7|caan2
 (重 男 輕 女)	zung6|naam4|hing1|neoi5
-(重 ㊚ 輕 女)	zung6|naam4|hing1|neoi5
-(重 男 輕 ㊛)	zung6|naam4|hing1|neoi5
 (重 男 輕 女)	zung6|naam4|hing1|neoi5
-(重 ㊚ 輕 女)	zung6|naam4|hing1|neoi5
 (重 男 轻 女)	zung6|naam4|hing1|neoi5
-(重 ㊚ 轻 女)	zung6|naam4|hing1|neoi5
-(重 男 轻 ㊛)	zung6|naam4|hing1|neoi5
 (重 男 轻 女)	zung6|naam4|hing1|neoi5
-(重 ㊚ 轻 女)	zung6|naam4|hing1|neoi5
 (重 色 輕 友)	zung6|sik1|hing1|jau5
 (重 色 轻 友)	zung6|sik1|hing1|jau5
 (重 義 輕 利)	zung6|ji6|hing1|lei6
@@ -30844,9 +28307,7 @@ _9      gau2||
 (重 义 轻 利)	zung6|ji6|hing1|lei6
 (重 义 轻 利)	zung6|ji6|hing1|lei6
 (重 賞 之 下)	cung5|soeng2|zi1|haa6
-(重 賞 之 ㊦)	cung5|soeng2|zi1|haa6
 (重 赏 之 下)	cung5|soeng2|zi1|haa6
-(重 赏 之 ㊦)	cung5|soeng2|zi1|haa6
 (重 彈 老 調)	cung4|taan4|lou5|diu6
 (重 彈 老 調)	cung4|taan4|lou5|diu6
 (重 彈 老 調)	cung4|taan4|lou5|diu6
@@ -30857,7 +28318,6 @@ _9      gau2||
 (重 農 主 義)	zung6|nung4|zyu2|ji6
 (重 农 主 义)	zung6|nung4|zyu2|ji6
 (重 重 一 拍)	cung2|cung2|jat1|paak3
-(重 重 ㊀ 拍)	cung2|cung2|jat1|paak3
 (重 轟 炸 機)	cung5|gwang1|zaa3|gei1
 (重 轰 炸 机)	cung5|gwang1|zaa3|gei1
 (重 元 素)	cung5|jyun4|sou3
@@ -30908,7 +28368,6 @@ _9      gau2||
 (重 氫)	cung5|hing1
 (重 氢)	cung5|hing1
 (重 水)	cung5|seoi2
-(重 ㊌)	cung5|seoi2
 (重 油)	cung5|jau4
 (重 炮)	cung5|paau3
 (重 病)	cung5|beng6
@@ -30935,7 +28394,6 @@ _9      gau2||
 (重 量)	cung5|loeng6
 (重 量)	cung5|loeng6
 (重 金)	cung5|gam1
-(重 ㊎)	cung5|gam1
 (重 金)	cung5|gam1
 (重 鎮)	zung6|zan3
 (重 镇)	zung6|zan3
@@ -30978,82 +28436,51 @@ _9      gau2||
 ㊎	gam1
 金	gam1
 (金 生 丽 水)	gam1|sang7|lai6|seoi2
-(㊎ 生 丽 水)	gam1|sang7|lai6|seoi2
-(金 生 丽 ㊌)	gam1|sang7|lai6|seoi2
 (金 生 丽 水)	gam1|sang7|lai6|seoi2
-(金 生 丽 ㊌)	gam1|sang7|lai6|seoi2
 (金 生 麗 水)	gam1|sang7|lai6|seoi2
-(㊎ 生 麗 水)	gam1|sang7|lai6|seoi2
-(金 生 麗 ㊌)	gam1|sang7|lai6|seoi2
 (金 生 麗 水)	gam1|sang7|lai6|seoi2
-(㊎ 生 麗 水)	gam1|sang7|lai6|seoi2
-(金 生 麗 ㊌)	gam1|sang7|lai6|seoi2
 (金 生 麗 水)	gam1|sang7|lai6|seoi2
-(金 生 麗 ㊌)	gam1|sang7|lai6|seoi2
 (金 里 奇)	gam1|leoi5|kei4
-(㊎ 里 奇)	gam1|leoi5|kei4
 (金 里 奇)	gam1|leoi5|kei4
 (金 里 奇)	gam1|leoi5|kei4
-(㊎ 里 奇)	gam1|leoi5|kei4
 (金 創 藥)	gam1|cong1|joek6
-(㊎ 創 藥)	gam1|cong1|joek6
 (金 創 藥)	gam1|cong1|joek6
 (金 创 药)	gam1|cong1|joek6
-(㊎ 创 药)	gam1|cong1|joek6
 (金 创 药)	gam1|cong1|joek6
 (金 叵 羅)	gam1|bo1|lo4
-(㊎ 叵 羅)	gam1|bo1|lo4
 (金 叵 羅)	gam1|bo1|lo4
 (金 叵 羅)	gam1|bo1|lo4
-(㊎ 叵 羅)	gam1|bo1|lo4
 (金 叵 罗)	gam1|bo1|lo4
-(㊎ 叵 罗)	gam1|bo1|lo4
 (金 叵 罗)	gam1|bo1|lo4
 (金 縷 衣)	gam1|leoi5|ji1
-(㊎ 縷 衣)	gam1|leoi5|ji1
 (金 縷 衣)	gam1|leoi5|ji1
-(㊎ 縷 衣)	gam1|leoi5|ji1
 (金 縷 衣)	gam1|leoi5|ji1
 (金 缕 衣)	gam1|leoi5|ji1
-(㊎ 缕 衣)	gam1|leoi5|ji1
 (金 缕 衣)	gam1|leoi5|ji1
 (金 錢)	gam1|cin4
-(㊎ 錢)	gam1|cin4
 (金 錢)	gam1|cin4
 (金 钱)	gam1|cin4
-(㊎ 钱)	gam1|cin4
 (金 钱)	gam1|cin4
 (金 行)	gam1|hong2
-(㊎ 行)	gam1|hong2
 (金 行)	gam1|hong2
-(㊎ 行)	gam1|hong2
 (金 行)	gam1|hong2
 (金 鋼)	gam1|gong1
-(㊎ 鋼)	gam1|gong1
 (金 鋼)	gam1|gong1
 (金 钢)	gam1|gong1
-(㊎ 钢)	gam1|gong1
 (金 钢)	gam1|gong1
 (金 鋪)	gam1|pou2
-(㊎ 鋪)	gam1|pou2
 (金 鋪)	gam1|pou2
 (金 铺)	gam1|pou2
-(㊎ 铺)	gam1|pou2
 (金 铺)	gam1|pou2
 (金 條)	gam1|tiu5
-(㊎ 條)	gam1|tiu5
 (金 條)	gam1|tiu5
 (金 条)	gam1|tiu5
-(㊎ 条)	gam1|tiu5
 (金 条)	gam1|tiu5
 (金 表)	gam1|biu1
-(㊎ 表)	gam1|biu1
 (金 表)	gam1|biu1
 (金 釵)	gam1|caai1
-(㊎ 釵)	gam1|caai1
 (金 釵)	gam1|caai1
 (金 钗)	gam1|caai1
-(㊎ 钗)	gam1|caai1
 (金 钗)	gam1|caai1
 釓	gaat3
 釔	jyut3
@@ -31841,7 +29268,6 @@ _9      gau2||
 (長 相 廝 守)	coeng4|soeng1|si1|sau2
 (長 嫂 如 母)	zoeng2|sou2|jyu4|mou5
 (長 此 下 去)	coeng4|ci2|haa5|heoi3
-(長 此 ㊦ 去)	coeng4|ci2|haa5|heoi3
 (長 相 斯 守)	coeng4|soeng1|si1|sau2
 (長 沙 灣)	coeng4|saa1|waan4
 (長 癤 子)	zoeng2|zit3|zi5
@@ -31852,7 +29278,6 @@ _9      gau2||
 (長 出)	zoeng2|ceot1
 (長 大)	zoeng2|daai6
 (長 女)	zoeng2|neoi5
-(長 ㊛)	zoeng2|neoi5
 (長 女)	zoeng2|neoi5
 (長 子)	zoeng2|zi2
 (長 孫)	zoeng2|syun1
@@ -31863,7 +29288,6 @@ _9      gau2||
 (長 成)	zoeng2|sing4
 (長 滿)	zoeng2|mun5
 (長 男)	zoeng2|naam4
-(長 ㊚)	zoeng2|naam4
 (長 相)	zoeng2|soeng3
 (長 老)	zoeng2|lou5
 (長 老)	zoeng2|lou5
@@ -31892,7 +29316,6 @@ _9      gau2||
 (长 相 厮 守)	coeng4|soeng1|si1|sau2
 (长 嫂 如 母)	zoeng2|sou2|jyu4|mou5
 (长 此 下 去)	coeng4|ci2|haa5|heoi3
-(长 此 ㊦ 去)	coeng4|ci2|haa5|heoi3
 (长 相 斯 守)	coeng4|soeng1|si1|sau2
 (长 沙 湾)	coeng4|saa1|waan4
 (长 疖 子)	zoeng2|zit3|zi5
@@ -31903,7 +29326,6 @@ _9      gau2||
 (长 出)	zoeng2|ceot1
 (长 大)	zoeng2|daai6
 (长 女)	zoeng2|neoi5
-(长 ㊛)	zoeng2|neoi5
 (长 女)	zoeng2|neoi5
 (长 子)	zoeng2|zi2
 (长 孙)	zoeng2|syun1
@@ -31914,7 +29336,6 @@ _9      gau2||
 (长 成)	zoeng2|sing4
 (长 满)	zoeng2|mun5
 (长 男)	zoeng2|naam4
-(长 ㊚)	zoeng2|naam4
 (长 相)	zoeng2|soeng3
 (长 老)	zoeng2|lou5
 (长 老)	zoeng2|lou5
@@ -31952,8 +29373,6 @@ _9      gau2||
 (間 諜)	gaan3|dip6
 (間 開)	gaan3|hoi1
 (間 中)	gaan3|zung1
-(間 🀄)	gaan3|zung1
-(間 ㊥)	gaan3|zung1
 (間 條)	gaan3|tiu4
 (間 尺)	gaan3|cek3
 閔	man5
@@ -32041,8 +29460,6 @@ _9      gau2||
 (间 谍)	gaan3|dip6
 (间 开)	gaan3|hoi1
 (间 中)	gaan3|zung1
-(间 🀄)	gaan3|zung1
-(间 ㊥)	gaan3|zung1
 (间 条)	gaan3|tiu4
 (间 尺)	gaan3|cek3
 闵	man5
@@ -32158,7 +29575,6 @@ _9      gau2||
 际	zai3
 陆	luk6
 (陆 上)	luk6|soeng6
-(陆 ㊤)	luk6|soeng6
 陇	lung5
 陈	can4
 陉	zing4
@@ -32167,9 +29583,7 @@ _9      gau2||
 陋	lau6
 陌	mak6
 (陌 上 隴 間)	mak6|soeng6|lung5|gaan1
-(陌 ㊤ 隴 間)	mak6|soeng6|lung5|gaan1
 (陌 上 陇 间)	mak6|soeng6|lung5|gaan1
-(陌 ㊤ 陇 间)	mak6|soeng6|lung5|gaan1
 降	gong3
 降	gong3
 (降 伏)	hong4|fuk6
@@ -32213,7 +29627,6 @@ _9      gau2||
 陛	bai6
 陜	gip6
 (陜 西)	sim2|sai1
-(陜 🀂)	sim2|sai1
 陝	sim2
 陞	sing1
 陟	zik1
@@ -32224,9 +29637,7 @@ _9      gau2||
 陣	zan6
 除	ceoi4
 (除 笨 有 精)	ceoi4|ban6|jau5|zeng1
-(除 笨 ㊒ 精)	ceoi4|ban6|jau5|zeng1
 (除 笨 有 精)	ceoi4|ban6|jau5|zeng1
-(除 笨 ㊒ 精)	ceoi4|ban6|jau5|zeng1
 陥	ham6
 陧	nip6
 陨	wan5
@@ -32246,9 +29657,7 @@ _9      gau2||
 陸	luk6
 陸	luk6
 (陸 上)	luk6|soeng6
-(陸 ㊤)	luk6|soeng6
 (陸 上)	luk6|soeng6
-(陸 ㊤)	luk6|soeng6
 険	him2
 陻	jan1
 陼	zyu2
@@ -32501,7 +29910,6 @@ _9      gau2||
 靝	tin1
 非	fei1
 (非 婚 生 子 女)	fei1|fan1|sang1|zi2|neoi5
-(非 婚 生 子 ㊛)	fei1|fan1|sang1|zi2|neoi5
 (非 婚 生 子 女)	fei1|fan1|sang1|zi2|neoi5
 (非 始 料 所 及)	fei1|ci2|liu6|so2|kap6
 (非 始 料 所 及)	fei1|ci2|liu6|so2|kap6
@@ -32522,7 +29930,6 @@ _9      gau2||
 (面 嚮)	min6|hoeng3
 (面 相)	min6|soeng3
 (面 上)	min6|soeng6
-(面 ㊤)	min6|soeng6
 靥	jip3
 靦	min5
 靧	fui3
@@ -32708,7 +30115,6 @@ _9      gau2||
 頬	haap3
 頭	tau4
 (頭 上)	tau4|soeng6
-(頭 ㊤)	tau4|soeng6
 (頭 里)	tau4|leoi5
 (頭 里)	tau4|leoi5
 頮	fui3
@@ -32954,7 +30360,6 @@ _9      gau2||
 餎	lok3
 餐	caan1
 (餐 名)	caan1|meng2
-(餐 ㊔)	caan1|meng2
 餑	but6
 餒	neoi5
 餓	ngo6
@@ -32997,7 +30402,6 @@ _9      gau2||
 餾	lau4
 餿	sau1
 (餿 水)	saau3|seoi2
-(餿 ㊌)	saau3|seoi2
 (餿 味)	suk1|mei6
 饀	tou4
 饁	jip3
@@ -33065,7 +30469,6 @@ _9      gau2||
 (馈 送)	gwai3|sung3
 馊	sau1
 (馊 水)	saau3|seoi2
-(馊 ㊌)	saau3|seoi2
 (馊 味)	suk1|mei6
 馋	caam4
 馌	jip3
@@ -33101,15 +30504,12 @@ _9      gau2||
 馪	pan1
 馬	maa5
 (馬 斯 特 里 赫 特)	maa5|si1|dak6|leoi5|hak1|dak6
-(馬 斯 ㊕ 里 赫 ㊕)	maa5|si1|dak6|leoi5|hak1|dak6
 (馬 斯 特 里 赫 特)	maa5|si1|dak6|leoi5|hak1|dak6
-(馬 斯 ㊕ 里 赫 ㊕)	maa5|si1|dak6|leoi5|hak1|dak6
 (馬 里 蘭 州)	maa5|lei5|laan4|zau1
 (馬 里 蘭 州)	maa5|lei5|laan4|zau1
 (馬 里 蘭 州)	maa5|lei5|laan4|zau1
 (馬 馬 虎 虎)	maa1|maa1|fu1|fu1
 (馬 上 將 要)	maa5|soeng6|zoeng7|jiu3
-(馬 ㊤ 將 要)	maa5|soeng6|zoeng7|jiu3
 (馬 德 里)	maa5|dak1|lei5
 (馬 德 里)	maa5|dak1|lei5
 (馬 里 蘭)	maa5|lei5|laan4
@@ -33119,7 +30519,6 @@ _9      gau2||
 (馬 裡 蘭)	maa5|lei5|laan4
 (馬 裡 蘭)	maa5|lei5|laan4
 (馬 上)	maa5|soeng6
-(馬 ㊤)	maa5|soeng6
 (馬 虎)	maa1|fu1
 (馬 里)	maa5|leoi5
 (馬 里)	maa5|leoi5
@@ -33275,14 +30674,11 @@ _9      gau2||
 驫	biu1
 马	maa5
 (马 斯 特 里 赫 特)	maa5|si1|dak6|leoi5|hak1|dak6
-(马 斯 ㊕ 里 赫 ㊕)	maa5|si1|dak6|leoi5|hak1|dak6
 (马 斯 特 里 赫 特)	maa5|si1|dak6|leoi5|hak1|dak6
-(马 斯 ㊕ 里 赫 ㊕)	maa5|si1|dak6|leoi5|hak1|dak6
 (马 里 兰 州)	maa5|lei5|laan4|zau1
 (马 里 兰 州)	maa5|lei5|laan4|zau1
 (马 马 虎 虎)	maa1|maa1|fu1|fu1
 (马 上 将 要)	maa5|soeng6|zoeng7|jiu3
-(马 ㊤ 将 要)	maa5|soeng6|zoeng7|jiu3
 (马 德 里)	maa5|dak1|lei5
 (马 德 里)	maa5|dak1|lei5
 (马 里 兰)	maa5|lei5|laan4
@@ -33290,7 +30686,6 @@ _9      gau2||
 (马 裡 兰)	maa5|lei5|laan4
 (马 裡 兰)	maa5|lei5|laan4
 (马 上)	maa5|soeng6
-(马 ㊤)	maa5|soeng6
 (马 虎)	maa1|fu1
 (马 里)	maa5|leoi5
 (马 里)	maa5|leoi5
@@ -33573,7 +30968,6 @@ _9      gau2||
 (鮮 為)	sin2|wai4
 (鮮 少)	sin2|siu2
 (鮮 有)	sin2|jau5
-(鮮 ㊒)	sin2|jau5
 (鮮 見)	sin2|gin3
 (鮮 見)	sin2|gin3
 鮰	wui4
@@ -33723,7 +31117,6 @@ _9      gau2||
 (鲜 为)	sin2|wai4
 (鲜 少)	sin2|siu2
 (鲜 有)	sin2|jau5
-(鲜 ㊒)	sin2|jau5
 (鲜 见)	sin2|gin3
 鲞	soeng2
 鲟	cam4
@@ -34136,7 +31529,6 @@ _9      gau2||
 麼	mo1
 麽	mo1
 (麽 九)	jiu1|gau2
-(麽 ㊈)	jiu1|gau2
 麾	fai1
 麿	leoi5
 黀	zau1


### PR DESCRIPTION
Second thoughts: only need SINGLE-character readings for the circled ones. Making exceptions work across a circled character is so unlikely to be needed as not worth the cost in space and complicating future dictionary edits. Most circled-character greetings add variant selectors that can mess up multi-character entries anyway.